### PR TITLE
P0 follow-up: bump go-chi/chi to v5.2.5 (host-header open redirect)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
 	github.com/felixge/httpsnoop v1.0.4
-	github.com/go-chi/chi/v5 v5.1.0
+	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/cors v1.2.1
 	github.com/go-mail/mail/v2 v2.3.0
 	github.com/go-redis/redis/v8 v8.11.5

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/go-chi/chi/v5 v5.1.0 h1:acVI1TYaD+hhedDJ3r54HyA6sExp3HfXq7QWEEY/xMw=
-github.com/go-chi/chi/v5 v5.1.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
+github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
 github.com/go-chi/cors v1.2.1 h1:xEC8UT3Rlp2QuWNEr4Fs/c2EAGVKBwy/1vHx3bppil4=
 github.com/go-chi/cors v1.2.1/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/go-mail/mail/v2 v2.3.0 h1:wha99yf2v3cpUzD1V9ujP404Jbw2uEvs+rBJybkdYcw=


### PR DESCRIPTION
## Summary

Single-commit follow-up to PR #31 — bumps `github.com/go-chi/chi/v5` from `v5.1.0` to `v5.2.5` to clear [GO-2026-4316 / GHSA host-header injection](https://pkg.go.dev/vuln/GO-2026-4316) (open redirect via `Host` header in `middleware.RedirectSlashes`).

This commit was originally part of #31 but landed on the branch after a GitHub PR-sync glitch caused by the repo casing change (\`optivest\` -> \`OptiVest\`) and didn't make it into the merge. Re-shipping it cleanly on a fresh branch.

## Reachability

The OptiVest API does **not** call \`middleware.RedirectSlashes\` anywhere in the codebase, so this is a "vulnerable module present, not reachable from the call graph" finding:

- \`govulncheck\` reports **No vulnerabilities found** (it traces actual call graphs).
- Dependabot still flags it (it walks the module graph), so this bump silences the alert.
- A future feature wiring up \`RedirectSlashes\` would inherit the vulnerability — bumping now removes that latent risk.

Patched in chi \`v5.2.4\`; we go to \`v5.2.5\` (current latest).

## Test plan

- [x] \`make audit\` passes locally (build, vet, staticcheck, govulncheck, \`go test -race\`)
- [x] \`govulncheck ./...\` reports **No vulnerabilities found**
- [ ] CI workflow green on first run (the new \`.github/workflows/ci.yml\` from #31 will run this automatically)

## After merge

Dependabot's open redirect alert (#6 on the security tab) should clear immediately, dropping the count to **0**.