### PR TITLE
P2 (B5): Redis-backed rate limiter (cluster-wide enforcement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,29 @@ the available commands for a quick lookup (INCOMPLETE, use help for full list).
         HTTP client maximum retries (default 3)
   -http-client-timeout duration
         HTTP client timeout (default 10s)
+  -limiter-burst int
+        Rate limiter maximum burst (default 10)
+  -limiter-enabled
+        Enable rate limiter (default true)
+  -limiter-rps float
+        Rate limiter maximum requests per second (default 5)
 ```
+
+> **Rate limiter note:** As of P2, the limiter is backed by Redis using
+> [`go-redis/redis_rate/v10`](https://github.com/go-redis/redis_rate) so the
+> configured `-limiter-rps` and `-limiter-burst` apply **across the cluster**,
+> not per-instance. The previous in-memory implementation under-counted by a
+> factor of N when running N pods behind a load balancer.
+>
+> If Redis is unreachable the limiter **fails open** (allows the request
+> through, increments `rate_limiter_redis_errors_total` and
+> `rate_limiter_fail_open_total` on `/debug/vars`, and logs a WARN).
+> Operators should alert on a non-zero `rate_limiter_redis_errors_total`
+> rate. Successful and denied requests are counted separately as
+> `rate_limiter_allowed_total` and `rate_limiter_denied_total`.
+>
+> Sub-1-rps configurations are not supported by the underlying GCRA bucket
+> type; values <1 are rounded up to 1 and a warning is logged at startup.
 
 Using `make run`, will run the API with a default connection string located 
 in `cmd\api\.env`. If you're using `powershell`, you need to load the values otherwise you will get

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,6 +62,43 @@ If a key is leaked in a commit, build artifact, log file, or chat:
 5. **Tail logs for unauthorized use** of the old key for at least 24 hours
    (most upstreams record the last-used IP).
 
+## Rate limiter operations
+
+The HTTP rate limiter is backed by Redis (P2). Each request consults a
+GCRA bucket via `go-redis/redis_rate/v10` keyed on the client's real IP
+(`X-Forwarded-For`-aware via `tomasen/realip`). The configured
+`-limiter-rps` and `-limiter-burst` are now **cluster-wide**, not
+per-pod. Replicas no longer multiply the effective rate.
+
+### Behaviour during a Redis outage
+
+The middleware **fails open**: if Redis is unreachable or the limiter
+call errors, the request is allowed through. The cost of fail-open is
+bounded (upstream LB, downstream connection pools, etc. still apply).
+The cost of fail-closed during a Redis blip would be a total API
+outage — unacceptable for a non-critical-path dependency.
+
+### Required alerting
+
+Operators should configure alerts on these `/debug/vars` counters:
+
+| Metric                                  | Alert when                                         |
+| --------------------------------------- | -------------------------------------------------- |
+| `rate_limiter_redis_errors_total`       | Rate > 0 sustained for > 1m → Redis health issue   |
+| `rate_limiter_fail_open_total`          | Rate > 0 sustained for > 1m → limiter is bypassed  |
+| `rate_limiter_denied_total`             | Sudden spike → potential abuse                     |
+| `rate_limiter_disabled_total`           | Should be 0 in production; nonzero → misconfig     |
+
+`rate_limiter_configured` (string) reports the active settings on each
+boot for sanity-checking config rollouts.
+
+### Latency budget
+
+The Redis call is wrapped in a 200ms `context.WithTimeout`. Hitting that
+ceiling counts as a Redis error and triggers fail-open. The expected p99
+is well below 5ms on a same-AZ Redis; if you see higher, suspect Redis
+saturation rather than the limiter middleware.
+
 ## CI security scanning
 
 Every push and PR to `main` runs:

--- a/cmd/api/middleware.go
+++ b/cmd/api/middleware.go
@@ -1,18 +1,20 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"expvar"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/Blue-Davinci/OptiVest/internal/data"
 	"github.com/felixge/httpsnoop"
+	"github.com/go-redis/redis_rate/v10"
 	"github.com/tomasen/realip"
-	"golang.org/x/time/rate"
+	"go.uber.org/zap"
 )
 
 func (app *application) recoverPanic(next http.Handler) http.Handler {
@@ -105,72 +107,137 @@ func (app *application) requireActivatedUser(next http.Handler) http.Handler {
 	})
 }
 
-// The rateLimit() middleware will be used to rate limit the number of requests that a
-// client can make to certain routes within a given time window.
-func (app *application) rateLimit(next http.Handler) http.Handler {
-	// Define a client struct to hold the rate limiter and last seen time for each
-	// client.
-	type client struct {
-		limiter  *rate.Limiter
-		lastSeen time.Time
-	}
+// rateLimitRedisKeyPrefix namespaces every rate-limit key in Redis so we
+// don't collide with other Redis users (cache, MFA sessions, notifications).
+const rateLimitRedisKeyPrefix = "optivest:ratelimit:ip:"
 
-	// Declare a mutex and a map to hold the clients' IP addresses and rate limiters.
-	var (
-		mu      sync.Mutex
-		clients = make(map[string]*client)
-	)
-	// Launch a background goroutine which removes old entries from the clients map once
-	// every minute.
-	go func() {
-		for {
-			time.Sleep(time.Minute)
-			// Lock the mutex to prevent any rate limiter checks from happening while
-			// the cleanup is taking place.
-			mu.Lock()
-			// Loop through all clients. If they haven't been seen within the last three
-			// minutes, delete the corresponding entry from the map.
-			for ip, client := range clients {
-				if time.Since(client.lastSeen) > 3*time.Minute {
-					delete(clients, ip)
-				}
-			}
-			// Importantly, unlock the mutex when the cleanup is complete.
-			mu.Unlock()
-		}
-	}()
+// rateLimitRedisTimeout caps how long we'll wait on Redis for a single
+// limiter check. Keep it tight: every request blocks on this. If Redis is
+// unhealthy we want to fail-open quickly rather than degrade tail latency.
+const rateLimitRedisTimeout = 200 * time.Millisecond
+
+// Rate-limiter expvar metrics, exposed on /debug/vars. Counters use Float
+// because expvar.Int.Add takes int64 and we want fractional Δ atomically;
+// in practice we only Add(1), but Float is the standard pattern for "this
+// is a counter that ops will graph as a rate".
+var (
+	rateLimitAllows     = expvar.NewInt("rate_limiter_allowed_total")
+	rateLimitDenies     = expvar.NewInt("rate_limiter_denied_total")
+	rateLimitRedisErrs  = expvar.NewInt("rate_limiter_redis_errors_total")
+	rateLimitFailOpens  = expvar.NewInt("rate_limiter_fail_open_total")
+	rateLimitDisabled   = expvar.NewInt("rate_limiter_disabled_total")
+	rateLimitConfigured = expvar.NewString("rate_limiter_configured")
+)
+
+// rateLimit returns a middleware that enforces a per-IP request rate using a
+// Redis-backed GCRA bucket (github.com/go-redis/redis_rate/v10). Replaces the
+// previous in-memory token-bucket implementation, which under-counted by a
+// factor of N when running N application instances behind a load balancer:
+// each instance had its own clients map, so the configured limit was the
+// per-pod limit, not the per-cluster limit.
+//
+// Behaviour
+//
+//   - Keying is per real-IP (via tomasen/realip, same as before). User-keying
+//     is intentionally out of scope for this PR because rateLimit runs before
+//     authenticate in the global middleware chain — see routes.go.
+//   - On allow, sets standard rate-limit response headers so well-behaved
+//     clients can self-throttle:
+//       X-RateLimit-Limit       <burst>
+//       X-RateLimit-Remaining   <tokens left in window>
+//   - On deny, also sets Retry-After (seconds, integer per RFC 7231) and
+//     X-RateLimit-Reset (seconds until the bucket refills) so clients have
+//     two equivalent ways to read the back-off.
+//   - On Redis error, FAILS OPEN: the request is allowed through and a
+//     warning is logged + a metric incremented. Rationale: the cost of
+//     letting traffic through during a Redis outage is bounded (we still
+//     have upstream LB, downstream DB pool limits, etc.), but the cost of
+//     fail-closed is total API outage every time Redis blips. Ops should
+//     alert on rate_limiter_redis_errors_total > 0 so this never goes
+//     unnoticed.
+//   - Honours app.config.limiter.enabled: when false, every request is
+//     allowed without touching Redis (counted via rate_limiter_disabled_total).
+func (app *application) rateLimit(next http.Handler) http.Handler {
+	// Build the Limit once at middleware-construction time. redis_rate.Limit
+	// requires an integer Rate per Period; the pre-existing config flag is a
+	// float64. We round up to the nearest integer to err on the side of
+	// being slightly more permissive than the operator asked for, and warn
+	// loudly if precision was lost so the misconfiguration is visible.
+	rate := int(math.Ceil(app.config.limiter.rps))
+	if rate < 1 {
+		rate = 1
+	}
+	if float64(rate) != app.config.limiter.rps {
+		app.logger.Warn("limiter-rps was rounded up to the nearest integer; sub-1-rps configurations are not supported by the redis_rate v10 limit type",
+			zap.Float64("configured_rps", app.config.limiter.rps),
+			zap.Int("effective_rps", rate),
+		)
+	}
+	limit := redis_rate.Limit{
+		Rate:   rate,
+		Burst:  app.config.limiter.burst,
+		Period: time.Second,
+	}
+	rateLimitConfigured.Set(fmt.Sprintf("rps=%d burst=%d enabled=%t", rate, limit.Burst, app.config.limiter.enabled))
+
+	limiter := redis_rate.NewLimiter(app.RedisDB)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Only carry out the check if rate limiting is enabled.
-		if app.config.limiter.enabled {
-			// Extract the client's IP address from the request.
-			ip := realip.FromRequest(r)
-			// Lock the mutex to prevent this code from being executed concurrently.
-			mu.Lock()
-			// Check to see if the IP address already exists in the map. If it doesn't, then
-			// initialize a new rate limiter and add the IP address and limiter to the map.
-			if _, found := clients[ip]; !found {
-				clients[ip] = &client{
-					// Use the requests-per-second and burst values from the config struct.
-					limiter: rate.NewLimiter(rate.Limit(app.config.limiter.rps), app.config.limiter.burst),
-				}
-			}
-			// Update the last seen time for the client.
-			clients[ip].lastSeen = time.Now()
-
-			// Call the Allow() method on the rate limiter for the current IP address. If
-			// the request isn't allowed, unlock the mutex and send a 429 Too Many Requests
-			// response, just like before.
-			if !clients[ip].limiter.Allow() {
-				mu.Unlock()
-				app.rateLimitExceededResponse(w, r)
-				return
-			}
-			// unlock the mutex before calling the next handler in the
-			// chain
-			mu.Unlock()
+		if !app.config.limiter.enabled {
+			rateLimitDisabled.Add(1)
+			next.ServeHTTP(w, r)
+			return
 		}
-		next.ServeHTTP(w, r)
+
+		ip := realip.FromRequest(r)
+		key := rateLimitRedisKeyPrefix + ip
+
+		// Bound the Redis call independently of the request's context so a
+		// slow Redis can't push a request's tail latency past
+		// rateLimitRedisTimeout. Still inherits cancellation from the
+		// request — if the client disconnects, we abort the limiter check
+		// too.
+		ctx, cancel := context.WithTimeout(r.Context(), rateLimitRedisTimeout)
+		defer cancel()
+
+		res, err := limiter.Allow(ctx, key, limit)
+		if err != nil {
+			// Fail-open. Log loudly so this is observable; ops should alert
+			// on rate_limiter_redis_errors_total > 0. Log at WARN, not
+			// ERROR, because a single transient Redis error shouldn't page —
+			// sustained errors should.
+			rateLimitRedisErrs.Add(1)
+			rateLimitFailOpens.Add(1)
+			app.logger.Warn("rate limiter Redis error; failing open",
+				zap.String("ip", ip),
+				zap.Error(err),
+			)
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Inform clients about their budget on every response so well-behaved
+		// callers can self-throttle without ever hitting 429.
+		w.Header().Set("X-RateLimit-Limit", strconv.Itoa(limit.Burst))
+		w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(res.Remaining))
+
+		if res.Allowed > 0 {
+			rateLimitAllows.Add(1)
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		rateLimitDenies.Add(1)
+		// Retry-After per RFC 7231 §7.1.3 is "delta-seconds" (integer); round
+		// up so we never tell the client to retry sooner than the bucket
+		// actually refills.
+		retry := int(math.Ceil(res.RetryAfter.Seconds()))
+		if retry < 1 {
+			retry = 1
+		}
+		w.Header().Set("Retry-After", strconv.Itoa(retry))
+		w.Header().Set("X-RateLimit-Reset", strconv.Itoa(int(math.Ceil(res.ResetAfter.Seconds()))))
+		app.rateLimitExceededResponse(w, r)
 	})
 }
 func (app *application) metrics(next http.Handler) http.Handler {

--- a/cmd/api/middleware_test.go
+++ b/cmd/api/middleware_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+)
+
+// rateLimitTestApp returns a minimal *application wired to either a real
+// in-memory miniredis-backed client (mr != nil) or a misconfigured client
+// pointing at a closed listener (mr == nil) so the limiter Allow() call
+// fails. The rate limiter middleware is the System Under Test; we don't
+// route through any real handler.
+func rateLimitTestApp(t *testing.T, mr *miniredis.Miniredis, rps float64, burst int, enabled bool) (*application, *redis.Client) {
+	t.Helper()
+
+	var rdb *redis.Client
+	if mr != nil {
+		rdb = redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	} else {
+		// 127.0.0.1:1 is a guaranteed-closed port; any Allow() against this
+		// client returns an immediate error, exercising the fail-open path.
+		rdb = redis.NewClient(&redis.Options{
+			Addr:        "127.0.0.1:1",
+			DialTimeout: 50 * time.Millisecond,
+			MaxRetries:  -1,
+		})
+	}
+
+	app := &application{
+		logger:  zap.NewNop(),
+		ctx:     context.Background(),
+		RedisDB: rdb,
+		config: config{
+			limiter: struct {
+				rps     float64
+				burst   int
+				enabled bool
+			}{
+				rps:     rps,
+				burst:   burst,
+				enabled: enabled,
+			},
+		},
+	}
+	return app, rdb
+}
+
+// drive issues a GET to the rate-limit middleware wrapped around a handler
+// that just returns 200 OK with a known body. Returns the response so tests
+// can inspect status, headers, and counters in the middleware-recorded path.
+func drive(t *testing.T, app *application) *http.Response {
+	t.Helper()
+	mw := app.rateLimit(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "203.0.113.7:9999" // a fixed, RFC5737-documentation IP
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+	return rec.Result()
+}
+
+// TestRateLimit_AllowsUnderThreshold verifies that requests issued within the
+// configured burst budget are all allowed and carry the documentation
+// headers (X-RateLimit-Limit / -Remaining) so well-behaved clients can
+// self-throttle.
+func TestRateLimit_AllowsUnderThreshold(t *testing.T) {
+	mr := miniredis.RunT(t)
+	app, _ := rateLimitTestApp(t, mr, 10, 5, true)
+
+	for i := 0; i < 5; i++ {
+		resp := drive(t, app)
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("request %d: status = %d, want 200 (under burst)", i+1, resp.StatusCode)
+		}
+		if got := resp.Header.Get("X-RateLimit-Limit"); got != "5" {
+			t.Errorf("request %d: X-RateLimit-Limit = %q, want %q", i+1, got, "5")
+		}
+		if resp.Header.Get("X-RateLimit-Remaining") == "" {
+			t.Errorf("request %d: missing X-RateLimit-Remaining header", i+1)
+		}
+	}
+}
+
+// TestRateLimit_DeniesOverThreshold verifies that once the burst is
+// exhausted, the next request gets a 429 and a populated Retry-After.
+func TestRateLimit_DeniesOverThreshold(t *testing.T) {
+	mr := miniredis.RunT(t)
+	app, _ := rateLimitTestApp(t, mr, 1, 2, true) // 1rps, burst 2
+
+	// Burn through the burst.
+	for i := 0; i < 2; i++ {
+		resp := drive(t, app)
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("priming request %d: status = %d, want 200", i+1, resp.StatusCode)
+		}
+	}
+
+	// The next request must be 429.
+	resp := drive(t, app)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("over-burst request: status = %d, want %d", resp.StatusCode, http.StatusTooManyRequests)
+	}
+	if ra := resp.Header.Get("Retry-After"); ra == "" {
+		t.Error("Retry-After header missing on 429")
+	} else if n, err := strconv.Atoi(ra); err != nil || n < 1 {
+		t.Errorf("Retry-After = %q, want a positive integer (RFC 7231 delta-seconds)", ra)
+	}
+	if reset := resp.Header.Get("X-RateLimit-Reset"); reset == "" {
+		t.Error("X-RateLimit-Reset header missing on 429")
+	}
+}
+
+// TestRateLimit_DisabledShortCircuits asserts that enabled=false skips Redis
+// entirely. We confirm by passing a client wired to a closed port — if the
+// disable check were missing, that would surface as fail-open + warning, but
+// here we expect a clean pass with no Redis touched at all.
+func TestRateLimit_DisabledShortCircuits(t *testing.T) {
+	app, _ := rateLimitTestApp(t, nil, 1, 1, false)
+
+	resp := drive(t, app)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("disabled limiter: status = %d, want 200", resp.StatusCode)
+	}
+	if resp.Header.Get("X-RateLimit-Limit") != "" {
+		t.Error("disabled limiter must not emit X-RateLimit-Limit headers")
+	}
+}
+
+// TestRateLimit_FailOpenOnRedisError is the most important test in this file:
+// when Redis is unreachable, the middleware must allow the request through
+// (fail-open) rather than 503-ing the entire API. Wiring the client to a
+// guaranteed-dead port causes Allow() to return an error.
+func TestRateLimit_FailOpenOnRedisError(t *testing.T) {
+	app, _ := rateLimitTestApp(t, nil, 100, 100, true)
+
+	// First, prove Redis really is unreachable so the test is testing what
+	// it thinks it's testing. If 127.0.0.1:1 ever becomes reachable in some
+	// future CI environment the test must still pass, but the assertion
+	// below would no longer be exercising the fail-open path — surface it.
+	probeCtx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	if err := app.RedisDB.Ping(probeCtx).Err(); err == nil {
+		t.Fatal("test setup invariant broken: 127.0.0.1:1 is reachable, fail-open path not exercised")
+	}
+
+	resp := drive(t, app)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Redis-down request: status = %d, want 200 (fail-open)", resp.StatusCode)
+	}
+}
+
+// TestRateLimit_PerIPIsolation confirms two distinct IPs maintain
+// independent buckets — exhausting one IP's budget must not affect another.
+// This is the property that prevents a noisy neighbour from rate-limiting
+// every other client behind the same load balancer.
+func TestRateLimit_PerIPIsolation(t *testing.T) {
+	mr := miniredis.RunT(t)
+	app, _ := rateLimitTestApp(t, mr, 1, 1, true)
+
+	driveAs := func(ip string) *http.Response {
+		mw := app.rateLimit(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.RemoteAddr = ip + ":50000"
+		rec := httptest.NewRecorder()
+		mw.ServeHTTP(rec, req)
+		return rec.Result()
+	}
+
+	// Exhaust IP A's bucket (rps=1, burst=1 → second request hits 429).
+	r1 := driveAs("198.51.100.1")
+	if r1.StatusCode != http.StatusOK {
+		t.Fatalf("A first: %d", r1.StatusCode)
+	}
+	r1.Body.Close()
+
+	r2 := driveAs("198.51.100.1")
+	if r2.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("A second: %d, want 429", r2.StatusCode)
+	}
+	r2.Body.Close()
+
+	// IP B starts fresh and should be allowed.
+	r3 := driveAs("198.51.100.2")
+	if r3.StatusCode != http.StatusOK {
+		t.Fatalf("B first: %d (IP isolation broken — A's exhausted bucket affected B)", r3.StatusCode)
+	}
+	r3.Body.Close()
+}

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,13 @@ module github.com/Blue-Davinci/OptiVest
 go 1.25.0
 
 require (
+	github.com/alicebob/miniredis/v2 v2.37.0
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
 	github.com/felixge/httpsnoop v1.0.4
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/cors v1.2.1
 	github.com/go-mail/mail/v2 v2.3.0
+	github.com/go-redis/redis_rate/v10 v10.0.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/joho/godotenv v1.5.1
@@ -24,7 +26,6 @@ require (
 	github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.50.0
-	golang.org/x/time v0.6.0
 )
 
 require (
@@ -39,6 +40,7 @@ require (
 	github.com/mmcdole/goxpp v1.1.1-0.20240225020742-a0c311522b23 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/net v0.53.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/PuerkitoBio/goquery v1.8.0 h1:PJTF7AmFCFKk1N6V6jmKfrNH9tV5pNE6lZMkG0gta/U=
 github.com/PuerkitoBio/goquery v1.8.0/go.mod h1:ypIiRMtY7COPGk+I/YbZLbxsxn9g5ejnI2HSMtkjZvI=
+github.com/alicebob/miniredis/v2 v2.37.0 h1:RheObYW32G1aiJIj81XVt78ZHJpHonHLHW7OLIshq68=
+github.com/alicebob/miniredis/v2 v2.37.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/andybalholm/cascadia v1.3.1 h1:nhxRkql1kdYCc8Snf7D5/D3spOX+dBgjA6u8x004T2c=
 github.com/andybalholm/cascadia v1.3.1/go.mod h1:R4bJ1UQfqADjvDa4P6HZHLh/3OxWWEqc0Sk8XGwHqvA=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de h1:FxWPpzIjnTlhPwqqXc4/vE0f7GvRjuAsbW+HOIe8KnA=
@@ -27,6 +29,8 @@ github.com/go-chi/cors v1.2.1 h1:xEC8UT3Rlp2QuWNEr4Fs/c2EAGVKBwy/1vHx3bppil4=
 github.com/go-chi/cors v1.2.1/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/go-mail/mail/v2 v2.3.0 h1:wha99yf2v3cpUzD1V9ujP404Jbw2uEvs+rBJybkdYcw=
 github.com/go-mail/mail/v2 v2.3.0/go.mod h1:oE2UK8qebZAjjV1ZYUpY7FPnbi/kIU53l1dmqPRb4go=
+github.com/go-redis/redis_rate/v10 v10.0.1 h1:calPxi7tVlxojKunJwQ72kwfozdy25RjA0bCj1h0MUo=
+github.com/go-redis/redis_rate/v10 v10.0.1/go.mod h1:EMiuO9+cjRkR7UvdvwMO7vbgqJkltQHtwbdIQvaBKIU=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -89,6 +93,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce h1:fb190+cK2Xz/dvi9Hv8eCYJYvIGUTN2/KLq1pT6CjEc=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
 github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
@@ -112,8 +118,6 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
 golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
-golang.org/x/time v0.6.0 h1:eTDhh4ZXt5Qf0augr54TN6suAUudPcawVZeIAPU7D4U=
-golang.org/x/time v0.6.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
## Summary

Replaces the in-memory token-bucket rate limiter with a Redis-backed GCRA limiter (`go-redis/redis_rate/v10`) so the configured limits actually mean what they say in a multi-instance deployment.

## The bug this fixes

The previous implementation kept a per-IP `*rate.Limiter` in a process-local `map[string]*client`. With N pods behind a load balancer, the configured `-limiter-rps` was the per-pod limit, not the per-cluster limit. A determined client could sustain `rps * N` requests per second, and the limit was effectively unenforceable once we scaled out. State was also lost on every restart, meaning a noisy client's "throttling" only persisted until the next deploy.

This is a real production correctness gap, not a perf concern, hence promoting it from the deferred B5 slot in P1 to its own P2 PR.

## Behaviour comparison

| Property | Before | After |
|---|---|---|
| Source of truth | per-pod `map[ip]*rate.Limiter` | `redis_rate/v10` GCRA bucket in Redis |
| Multi-instance enforcement | broken (N times under-counted) | cluster-wide |
| Survives restart | no, resets every deploy | yes, TTL-d in Redis |
| `Retry-After` header | absent | RFC 7231 delta-seconds |
| `X-RateLimit-Limit` and `X-RateLimit-Remaining` headers | absent | on every limited response |
| `X-RateLimit-Reset` on 429 | absent | present |
| Redis outage handling | n/a | fail-open with WARN log plus metrics |
| Per-IP isolation | yes | yes |
| Per-IP keying | yes, via `tomasen/realip` | yes, via `tomasen/realip` |
| Per-user keying | no | no (deferred, see notes below) |

## Fail-open vs fail-closed

When Redis errors (network, timeout, restart, OOM), the middleware fails open: the request is allowed through, a WARN is logged, and `rate_limiter_redis_errors_total` plus `rate_limiter_fail_open_total` increment. Rationale: the cost of letting traffic through during a Redis outage is bounded (upstream LB, downstream connection pools, and OS-level limits all still apply). The cost of fail-closed would be a total API outage every time Redis blips for any reason. Operators alert on the metric.

The Redis call itself is wrapped in a 200ms `context.WithTimeout` so a slow Redis cannot push request tail latency past that ceiling.

## What is deliberately not in scope

- **Per-user keying.** `rateLimit` runs before `authenticate` in the global middleware chain, so the user is not yet in the context at limiter time. Adding per-user keying needs either reordering the chain (which lets unauth traffic skip rate limiting, bad for login brute-force) or doing lightweight token-only auth inside the limiter. Both are bigger design decisions; punted.
- **Hybrid L1+L2 (in-memory fast-path with Redis fallback).** Premature optimization without measurements showing the Redis round-trip is too slow. Add only if and when needed.
- **Per-route limits.** Same rationale.

## New observability surface

On `/debug/vars`:

```
rate_limiter_allowed_total
rate_limiter_denied_total
rate_limiter_redis_errors_total      (alert on rate > 0 sustained)
rate_limiter_fail_open_total         (alert on rate > 0 sustained)
rate_limiter_disabled_total          (should be 0 in prod)
rate_limiter_configured              (string snapshot of active config)
```

`SECURITY.md` now has a `Rate limiter operations` section covering all of this for the on-call runbook.

## Test plan

- [x] `go vet ./...` clean
- [x] `staticcheck ./...` clean
- [x] `govulncheck ./...` reports no vulnerabilities
- [x] `go test -race -count=1 -timeout=120s ./...` passes including 5 new unit tests using `miniredis/v2` (no live Redis required for CI):
  - `TestRateLimit_AllowsUnderThreshold`: under-burst requests pass and carry budget headers
  - `TestRateLimit_DeniesOverThreshold`: over-burst returns 429 plus `Retry-After` plus `X-RateLimit-Reset`
  - `TestRateLimit_DisabledShortCircuits`: `enabled=false` skips Redis entirely
  - `TestRateLimit_FailOpenOnRedisError`: wires client at a closed port, asserts fail-open allows the request
  - `TestRateLimit_PerIPIsolation`: exhausts IP A's bucket, asserts IP B is unaffected
- [x] `go mod tidy` produces no diff

### Manual smoke (suggested, requires deployed env)

```bash
# allowed responses include the budget headers
curl -i http://OPTIVEST/v1/healthcheck | grep -i 'X-RateLimit'

# burn through the burst, expect 429 plus Retry-After
for i in $(seq 1 20); do
  curl -s -o /dev/null -w '%{http_code}\n' http://OPTIVEST/v1/healthcheck
done
```

## Net diff

```
6 files changed, 405 insertions(+), 65 deletions(-)
```

Roughly two-thirds tests plus docs; production code is `cmd/api/middleware.go` only.

## Dependencies

- **Added**: `github.com/go-redis/redis_rate/v10` (v10.0.1), same maintainers as the `redis/go-redis/v9` we just upgraded to in P1
- **Added (test-only)**: `github.com/alicebob/miniredis/v2` (v2.37.0), standard in-memory Redis fake for Go tests
- **Removed**: `golang.org/x/time`, was the source of `rate.Limiter`, no longer used