### PR TITLE
refactor(data): propagate request context through every DB-touching method

### DIFF
--- a/cmd/api/ai_operations.go
+++ b/cmd/api/ai_operations.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -39,9 +40,11 @@ type Delta struct {
 	Content string `json:"content"`
 }
 
-// buildLLMRequest sends a request to the LLM API with the user's profile and investment analysis data
-// and returns the analyzed portfolio data.
-func (app *application) buildInvestmentPortfolioLLMRequest(user *data.User, goals *data.InvestmentGoal, investmentAnalysis *data.InvestmentAnalysis) (*data.LLMAnalyzedPortfolio, error) {
+// buildLLMRequest sends a request to the LLM API with the user's profile and
+// investment analysis data and returns the analyzed portfolio data. ctx flows
+// from the originating HTTP request so the downstream INSERT into
+// CreateLLMAnalysisResponse aborts when the client disconnects.
+func (app *application) buildInvestmentPortfolioLLMRequest(ctx context.Context, user *data.User, goals *data.InvestmentGoal, investmentAnalysis *data.InvestmentAnalysis) (*data.LLMAnalyzedPortfolio, error) {
 	// Create a profile
 	profile := UserPortfolioProfile{
 		UserTimeHorizon:    user.TimeHorizon,
@@ -80,7 +83,7 @@ func (app *application) buildInvestmentPortfolioLLMRequest(user *data.User, goal
 	}
 	app.logger.Info("Done building LLM request for investment portfolio")
 	// save the analyzed portfolio to the database using CreateLLMAnalysisResponse
-	err = app.models.InvestmentPortfolioManager.CreateLLMAnalysisResponse(user.ID, analyzedPortfolio)
+	err = app.models.InvestmentPortfolioManager.CreateLLMAnalysisResponse(ctx, user.ID, analyzedPortfolio)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/api/authentication.go
+++ b/cmd/api/authentication.go
@@ -39,7 +39,7 @@ func (app *application) createAuthenticationApiKeyHandler(w http.ResponseWriter,
 		return
 	}
 	// get the user from the database
-	user, err := app.models.Users.GetByEmail(input.Email, app.config.encryption.key)
+	user, err := app.models.Users.GetByEmail(r.Context(), input.Email, app.config.encryption.key)
 	if err != nil {
 		switch {
 		// if the user is not found, we return an invalid credentials response
@@ -115,7 +115,7 @@ func (app *application) performMFAOnLogin(w http.ResponseWriter, r *http.Request
 	// Generate a token with Scope mfa-login which will be used as a validation token
 	// and stored in redis as the value to our key. We will also send it to the user and
 	// require the user to send it back to us to validate their login
-	mfaToken, err := app.models.Tokens.New(user.ID, 5*time.Minute, data.ScopeMFALogin)
+	mfaToken, err := app.models.Tokens.New(r.Context(), user.ID, 5*time.Minute, data.ScopeMFALogin)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -158,7 +158,7 @@ func (app *application) performMFAOnLogin(w http.ResponseWriter, r *http.Request
 // time to whatever you want from the caller.
 func (app *application) generateAuthenticationTokenAndLogin(user *data.User, timeToLeave time.Duration, scope string, w http.ResponseWriter, r *http.Request) {
 	// Generate a new authentication token with a 72-hour expiry time and the scope 'authentication'.
-	bearer_token, err := app.models.Tokens.New(user.ID, timeToLeave, scope)
+	bearer_token, err := app.models.Tokens.New(r.Context(), user.ID, timeToLeave, scope)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -217,7 +217,7 @@ func (app *application) validateMFALoginAttemptHandler(w http.ResponseWriter, r 
 		return
 	}
 	// get the user from the database
-	user, err := app.models.Users.GetByEmail(input.Email, app.config.encryption.key)
+	user, err := app.models.Users.GetByEmail(r.Context(), input.Email, app.config.encryption.key)
 	if err != nil {
 		switch {
 		// if the user is not found, we return an invalid credentials response
@@ -279,7 +279,7 @@ func (app *application) validateMFALoginAttemptHandler(w http.ResponseWriter, r 
 	now := time.Now()
 	user.MFALastChecked = &now
 	// Save the user to the DB
-	err = app.models.Users.UpdateUser(user, app.config.encryption.key)
+	err = app.models.Users.UpdateUser(r.Context(), user, app.config.encryption.key)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -312,7 +312,7 @@ func (app *application) createPasswordResetTokenHandler(w http.ResponseWriter, r
 	}
 	// Try to retrieve the corresponding user record for the email address. If it can't
 	// be found, return an error message to the client.
-	user, err := app.models.Users.GetByEmail(input.Email, app.config.encryption.key)
+	user, err := app.models.Users.GetByEmail(r.Context(), input.Email, app.config.encryption.key)
 	if err != nil {
 		switch {
 		// We willl use a generic error message to avoid leaking information about which
@@ -350,7 +350,7 @@ func (app *application) createPasswordResetTokenHandler(w http.ResponseWriter, r
 	}
 
 	// Otherwise, create a new password reset token with a 45-minute expiry time.
-	token, err := app.models.Tokens.New(user.ID, 45*time.Minute, data.ScopePasswordReset)
+	token, err := app.models.Tokens.New(r.Context(), user.ID, 45*time.Minute, data.ScopePasswordReset)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -450,7 +450,7 @@ func (app *application) createManualActivationTokenHandler(w http.ResponseWriter
 	}
 	// Try to retrieve the corresponding user record for the email address. If it can't
 	// be found, return an error message to the client.
-	user, err := app.models.Users.GetByEmail(input.Email, app.config.encryption.key)
+	user, err := app.models.Users.GetByEmail(r.Context(), input.Email, app.config.encryption.key)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -468,7 +468,7 @@ func (app *application) createManualActivationTokenHandler(w http.ResponseWriter
 		return
 	}
 	// Otherwise, create a new activation token.
-	token, err := app.models.Tokens.New(user.ID, 3*24*time.Hour, data.ScopeActivation)
+	token, err := app.models.Tokens.New(r.Context(), user.ID, 3*24*time.Hour, data.ScopeActivation)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -521,7 +521,7 @@ func (app *application) initializeRecoveryByRecoveryCodes(w http.ResponseWriter,
 	}
 	// Try to retrieve the corresponding user record for the email address. If it can't
 	// be found, return an error message to the client.
-	user, err := app.models.Users.GetByEmail(input.Email, app.config.encryption.key)
+	user, err := app.models.Users.GetByEmail(r.Context(), input.Email, app.config.encryption.key)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -545,7 +545,7 @@ func (app *application) initializeRecoveryByRecoveryCodes(w http.ResponseWriter,
 		return
 	}
 	// Otherwise, create a new recovery token with 15-minute expiry time.
-	token, err := app.models.Tokens.New(user.ID, 15*time.Minute, data.ScopeRecovery)
+	token, err := app.models.Tokens.New(r.Context(), user.ID, 15*time.Minute, data.ScopeRecovery)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -601,7 +601,7 @@ func (app *application) validateRecoveryCodeHandler(w http.ResponseWriter, r *ht
 		return
 	}
 	// get the user from the database
-	user, err := app.models.Users.GetForToken(data.ScopeRecovery, input.TokenPlaintext, app.config.encryption.key)
+	user, err := app.models.Users.GetForToken(r.Context(), data.ScopeRecovery, input.TokenPlaintext, app.config.encryption.key)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -613,7 +613,7 @@ func (app *application) validateRecoveryCodeHandler(w http.ResponseWriter, r *ht
 		return
 	}
 	// get the recovery code from the database
-	recoveryCode, err := app.models.MFAManager.GetRecoveryCodesByUserID(user.ID)
+	recoveryCode, err := app.models.MFAManager.GetRecoveryCodesByUserID(r.Context(), user.ID)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -638,13 +638,13 @@ func (app *application) validateRecoveryCodeHandler(w http.ResponseWriter, r *ht
 	user.MFAEnabled = false
 	user.MFASecret = ""
 	// Save the user to the DB
-	err = app.models.Users.UpdateUser(user, app.config.encryption.key)
+	err = app.models.Users.UpdateUser(r.Context(), user, app.config.encryption.key)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
 	}
 	// set the recovery code to used in the database
-	err = app.models.MFAManager.MarkRecoveryCodeAsUsed(recoveryCode.ID, user.ID)
+	err = app.models.MFAManager.MarkRecoveryCodeAsUsed(r.Context(), recoveryCode.ID, user.ID)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return

--- a/cmd/api/awards.go
+++ b/cmd/api/awards.go
@@ -8,7 +8,7 @@ func (app *application) getAllAwardsForUserByIDHandler(w http.ResponseWriter, r 
 	// retrieve the user id from the context
 	userID := app.contextGetUser(r).ID
 	// get all the awards for a user by ID
-	awards, err := app.models.AwardManager.GetAllAwardsForUserByID(userID)
+	awards, err := app.models.AwardManager.GetAllAwardsForUserByID(r.Context(), userID)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return

--- a/cmd/api/comments.go
+++ b/cmd/api/comments.go
@@ -40,7 +40,7 @@ func (app *application) getCommentsWithReactionsByAssociatedIdHandler(w http.Res
 		return
 	}
 	// get the comments
-	comments, metadata, err := app.models.CommentManagerModel.GetCommentsWithReactionsByAssociatedId(app.contextGetUser(r).ID, commentType, int64(input.AssociatedID), input.Filters)
+	comments, metadata, err := app.models.CommentManagerModel.GetCommentsWithReactionsByAssociatedId(r.Context(), app.contextGetUser(r).ID, commentType, int64(input.AssociatedID), input.Filters)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -88,7 +88,7 @@ func (app *application) createNewCommentHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 	// create the comment
-	err = app.models.CommentManagerModel.CreateNewComment(app.contextGetUser(r).ID, comment)
+	err = app.models.CommentManagerModel.CreateNewComment(r.Context(), app.contextGetUser(r).ID, comment)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -126,7 +126,7 @@ func (app *application) updateCommentHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	// get the comment from the database
-	comment, err := app.models.CommentManagerModel.GetCommentById(app.contextGetUser(r).ID, commentID)
+	comment, err := app.models.CommentManagerModel.GetCommentById(r.Context(), app.contextGetUser(r).ID, commentID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -146,7 +146,7 @@ func (app *application) updateCommentHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	// update the comment
-	err = app.models.CommentManagerModel.UpdateComment(app.contextGetUser(r).ID, comment)
+	err = app.models.CommentManagerModel.UpdateComment(r.Context(), app.contextGetUser(r).ID, comment)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrEditConflict):
@@ -186,7 +186,7 @@ func (app *application) createNewReactionHandler(w http.ResponseWriter, r *http.
 		return
 	}
 	// check if the comment exists
-	_, err = app.models.CommentManagerModel.GetCommentById(app.contextGetUser(r).ID, reaction.CommentID)
+	_, err = app.models.CommentManagerModel.GetCommentById(r.Context(), app.contextGetUser(r).ID, reaction.CommentID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -197,7 +197,7 @@ func (app *application) createNewReactionHandler(w http.ResponseWriter, r *http.
 		return
 	}
 	// create the reaction
-	err = app.models.CommentManagerModel.CreateNewReaction(app.contextGetUser(r).ID, reaction)
+	err = app.models.CommentManagerModel.CreateNewReaction(r.Context(), app.contextGetUser(r).ID, reaction)
 	if err != nil {
 		switch {
 		// handle duplicate reaction errors
@@ -231,7 +231,7 @@ func (app *application) deleteCommentHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	// delete the comment
-	err = app.models.CommentManagerModel.DeleteComment(app.contextGetUser(r).ID, commentID)
+	err = app.models.CommentManagerModel.DeleteComment(r.Context(), app.contextGetUser(r).ID, commentID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -264,7 +264,7 @@ func (app *application) deleteReactionHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 	// delete the reaction
-	err = app.models.CommentManagerModel.DeleteReaction(app.contextGetUser(r).ID, commentID)
+	err = app.models.CommentManagerModel.DeleteReaction(r.Context(), app.contextGetUser(r).ID, commentID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):

--- a/cmd/api/feeds.go
+++ b/cmd/api/feeds.go
@@ -51,7 +51,7 @@ func (app *application) createNewFeedHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	// insert the feed
-	err = app.models.FeedManager.CreateNewFeed(app.contextGetUser(r).ID, feed)
+	err = app.models.FeedManager.CreateNewFeed(r.Context(), app.contextGetUser(r).ID, feed)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrDuplicateFeed):
@@ -101,7 +101,7 @@ func (app *application) updateFeedHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	// get the feed
-	feed, err := app.models.FeedManager.GetFeedByID(feedID)
+	feed, err := app.models.FeedManager.GetFeedByID(r.Context(), feedID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -144,7 +144,7 @@ func (app *application) updateFeedHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	// update the feed
-	err = app.models.FeedManager.UpdateFeed(app.contextGetUser(r).ID, feed)
+	err = app.models.FeedManager.UpdateFeed(r.Context(), app.contextGetUser(r).ID, feed)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrDuplicateFeed):
@@ -181,7 +181,7 @@ func (app *application) deleteFeedByIDHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 	// delete the feed
-	deletedID, err := app.models.FeedManager.DeleteFeedByID(app.contextGetUser(r).ID, feedID)
+	deletedID, err := app.models.FeedManager.DeleteFeedByID(r.Context(), app.contextGetUser(r).ID, feedID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -231,6 +231,7 @@ func (app *application) getAllRSSPostWithFavoriteTagsHandler(w http.ResponseWrit
 	}
 	// get all the posts
 	posts, metadata, err := app.models.FeedManager.GetAllRSSPostWithFavoriteTag(
+		r.Context(),
 		app.contextGetUser(r).ID,
 		int64(input.FeedID),
 		input.Name,
@@ -275,7 +276,7 @@ func (app *application) getRssFeedPostByIDHandler(w http.ResponseWriter, r *http
 		return
 	}
 	// get the post
-	post, err := app.models.FeedManager.GetRssFeedPostByID(postID)
+	post, err := app.models.FeedManager.GetRssFeedPostByID(r.Context(), postID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -317,7 +318,7 @@ func (app *application) createNewFavoriteOnPostHandler(w http.ResponseWriter, r 
 		return
 	}
 	// Insert the Favorite
-	err = app.models.FeedManager.CreateNewFavoriteOnPost(app.contextGetUser(r).ID, favorite)
+	err = app.models.FeedManager.CreateNewFavoriteOnPost(r.Context(), app.contextGetUser(r).ID, favorite)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrDuplicateFavorite):
@@ -352,7 +353,7 @@ func (app *application) deleteFavoriteOnPostHandler(w http.ResponseWriter, r *ht
 	}
 	//app.logger.Info("postID", zap.Int64("postID", postID))
 	// Delete the Favorite
-	deletedID, err := app.models.FeedManager.DeleteFavoriteOnPost(app.contextGetUser(r).ID, postID)
+	deletedID, err := app.models.FeedManager.DeleteFavoriteOnPost(r.Context(), app.contextGetUser(r).ID, postID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):

--- a/cmd/api/financial_groups.go
+++ b/cmd/api/financial_groups.go
@@ -42,7 +42,7 @@ func (app *application) createNewUserGroupHandler(w http.ResponseWriter, r *http
 		return
 	}
 	// create a new group
-	err = app.models.FinancialGroupManager.CreateNewUserGroup(app.contextGetUser(r).ID, group)
+	err = app.models.FinancialGroupManager.CreateNewUserGroup(r.Context(), app.contextGetUser(r).ID, group)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGroupNameExists):
@@ -81,7 +81,7 @@ func (app *application) updateUserGroupHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 	// get the group by the details
-	group, err := app.models.FinancialGroupManager.GetGroupById(groupID)
+	group, err := app.models.FinancialGroupManager.GetGroupById(r.Context(), groupID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -120,7 +120,7 @@ func (app *application) updateUserGroupHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 	// update the group
-	err = app.models.FinancialGroupManager.UpdateUserGroup(groupID, app.contextGetUser(r).ID, group)
+	err = app.models.FinancialGroupManager.UpdateUserGroup(r.Context(), groupID, app.contextGetUser(r).ID, group)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGroupNameExists):
@@ -153,7 +153,7 @@ func (app *application) updateGroupUserRoleHandler(w http.ResponseWriter, r *htt
 		return
 	}
 	// get the group by the details
-	_, err = app.models.FinancialGroupManager.GetGroupById(groupID)
+	_, err = app.models.FinancialGroupManager.GetGroupById(r.Context(), groupID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -186,7 +186,7 @@ func (app *application) updateGroupUserRoleHandler(w http.ResponseWriter, r *htt
 		return
 	}
 	// update the user role
-	updatedAt, err := app.models.FinancialGroupManager.UpdateGroupUserRole(groupID, input.UserID, app.contextGetUser(r).ID, mappedRole)
+	updatedAt, err := app.models.FinancialGroupManager.UpdateGroupUserRole(r.Context(), groupID, input.UserID, app.contextGetUser(r).ID, mappedRole)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrEditConflict):
@@ -232,7 +232,7 @@ func (app *application) createNewGroupInvitation(w http.ResponseWriter, r *http.
 	}
 
 	// get the group by the details
-	group, err := app.models.FinancialGroupManager.GetGroupById(input.GroupID)
+	group, err := app.models.FinancialGroupManager.GetGroupById(r.Context(), input.GroupID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -256,7 +256,7 @@ func (app *application) createNewGroupInvitation(w http.ResponseWriter, r *http.
 		return
 	}
 	// check if the group has reached its maximum member count
-	isMaxedOut, err := app.models.FinancialGroupManager.CheckIfGroupMembersAreMaxedOut(input.GroupID)
+	isMaxedOut, err := app.models.FinancialGroupManager.CheckIfGroupMembersAreMaxedOut(r.Context(), input.GroupID)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -302,13 +302,13 @@ func (app *application) createNewGroupInvitation(w http.ResponseWriter, r *http.
 		return
 	}
 	// delete any existing group invitation that is not pending
-	err = app.models.FinancialGroupManager.DeleteNonPendingGroupInvitationsForUser(input.GroupID, input.InviteeUserEmail)
+	err = app.models.FinancialGroupManager.DeleteNonPendingGroupInvitationsForUser(r.Context(), input.GroupID, input.InviteeUserEmail)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
 	}
 	// create a new group invitation
-	err = app.models.FinancialGroupManager.CreateNewGroupInvitation(app.contextGetUser(r).ID, groupInvitation)
+	err = app.models.FinancialGroupManager.CreateNewGroupInvitation(r.Context(), app.contextGetUser(r).ID, groupInvitation)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGroupInvitationExists):
@@ -355,7 +355,7 @@ func (app *application) createNewPublicMembershipHandler(w http.ResponseWriter, 
 	// make a validator
 	v := validator.New()
 	// get the group by the details
-	group, err := app.models.FinancialGroupManager.GetGroupById(input.GroupID)
+	group, err := app.models.FinancialGroupManager.GetGroupById(r.Context(), input.GroupID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -373,7 +373,7 @@ func (app *application) createNewPublicMembershipHandler(w http.ResponseWriter, 
 		return
 	}
 	// check if the group's members are already maxed out
-	isMaxedOut, err := app.models.FinancialGroupManager.CheckIfGroupMembersAreMaxedOut(input.GroupID)
+	isMaxedOut, err := app.models.FinancialGroupManager.CheckIfGroupMembersAreMaxedOut(r.Context(), input.GroupID)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -384,7 +384,7 @@ func (app *application) createNewPublicMembershipHandler(w http.ResponseWriter, 
 		return
 	}
 	// create a new public membership
-	membershipID, err := app.models.FinancialGroupManager.CreateNewPublicMembership(app.contextGetUser(r).ID, input.GroupID)
+	membershipID, err := app.models.FinancialGroupManager.CreateNewPublicMembership(r.Context(), app.contextGetUser(r).ID, input.GroupID)
 	// if we get a ErrUserGroupMembershipExists error, we will return a 409
 	if err != nil {
 		switch {
@@ -424,7 +424,7 @@ func (app *application) updateGroupInvitationStatusHandler(w http.ResponseWriter
 		return
 	}
 	// get the group invitation by the details
-	groupInvitation, err := app.models.FinancialGroupManager.GetGroupInvitationById(groupID, input.InviteeEmail)
+	groupInvitation, err := app.models.FinancialGroupManager.GetGroupInvitationById(r.Context(), groupID, input.InviteeEmail)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -452,7 +452,7 @@ func (app *application) updateGroupInvitationStatusHandler(w http.ResponseWriter
 		return
 	}
 	// update the group invitation status
-	err = app.models.FinancialGroupManager.UpdateGroupInvitationStatus(mappedStatus, groupInvitation)
+	err = app.models.FinancialGroupManager.UpdateGroupInvitationStatus(r.Context(), mappedStatus, groupInvitation)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrEditConflict):
@@ -509,7 +509,7 @@ func (app *application) createNewGroupGoalHandler(w http.ResponseWriter, r *http
 		return
 	}
 	// check if the group exists
-	_, err = app.models.FinancialGroupManager.GetGroupById(input.GroupID)
+	_, err = app.models.FinancialGroupManager.GetGroupById(r.Context(), input.GroupID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -536,7 +536,7 @@ func (app *application) createNewGroupGoalHandler(w http.ResponseWriter, r *http
 		return
 	}
 	// create a new group goal
-	err = app.models.FinancialGroupManager.CreateNewGroupGoal(app.contextGetUser(r).ID, groupGoal)
+	err = app.models.FinancialGroupManager.CreateNewGroupGoal(r.Context(), app.contextGetUser(r).ID, groupGoal)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGroupNameExists):
@@ -577,7 +577,7 @@ func (app *application) updateGroupGoalHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 	// get the group goal by the details
-	groupGoal, err := app.models.FinancialGroupManager.GetGroupGoalById(groupID)
+	groupGoal, err := app.models.FinancialGroupManager.GetGroupGoalById(r.Context(), groupID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -604,7 +604,7 @@ func (app *application) updateGroupGoalHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 	// update the group goal
-	err = app.models.FinancialGroupManager.UpdateGroupGoal(app.contextGetUser(r).ID, groupGoal)
+	err = app.models.FinancialGroupManager.UpdateGroupGoal(r.Context(), app.contextGetUser(r).ID, groupGoal)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGroupNameExists):
@@ -642,7 +642,7 @@ func (app *application) createNewGroupTransactionHandler(w http.ResponseWriter, 
 		return
 	}
 	// check if user is member and group exists
-	err = app.models.FinancialGroupManager.CheckIfGroupExistsAndUserIsMember(app.contextGetUser(r).ID, input.GroupID)
+	err = app.models.FinancialGroupManager.CheckIfGroupExistsAndUserIsMember(r.Context(), app.contextGetUser(r).ID, input.GroupID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -653,7 +653,7 @@ func (app *application) createNewGroupTransactionHandler(w http.ResponseWriter, 
 		return
 	}
 	// check if Goal exists
-	groupGoal, err := app.models.FinancialGroupManager.GetGroupGoalById(input.GoalID)
+	groupGoal, err := app.models.FinancialGroupManager.GetGroupGoalById(r.Context(), input.GoalID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -685,7 +685,7 @@ func (app *application) createNewGroupTransactionHandler(w http.ResponseWriter, 
 		return
 	}
 	// create a new group transaction
-	err = app.models.FinancialGroupManager.CreateNewGroupTransaction(app.contextGetUser(r).ID, groupTransaction)
+	err = app.models.FinancialGroupManager.CreateNewGroupTransaction(r.Context(), app.contextGetUser(r).ID, groupTransaction)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrOverFunding):
@@ -716,7 +716,7 @@ func (app *application) deleteGroupTransactionHandler(w http.ResponseWriter, r *
 		return
 	}
 	// delete the group transaction
-	_, err = app.models.FinancialGroupManager.DeleteGroupTransaction(app.contextGetUser(r).ID, groupTransactionID)
+	_, err = app.models.FinancialGroupManager.DeleteGroupTransaction(r.Context(), app.contextGetUser(r).ID, groupTransactionID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -751,7 +751,7 @@ func (app *application) createNewGroupExpenseHandler(w http.ResponseWriter, r *h
 		return
 	}
 	// check if user is member and group exists
-	err = app.models.FinancialGroupManager.CheckIfGroupExistsAndUserIsMember(app.contextGetUser(r).ID, input.GroupID)
+	err = app.models.FinancialGroupManager.CheckIfGroupExistsAndUserIsMember(r.Context(), app.contextGetUser(r).ID, input.GroupID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -776,7 +776,7 @@ func (app *application) createNewGroupExpenseHandler(w http.ResponseWriter, r *h
 		return
 	}
 	// create a new group expense
-	err = app.models.FinancialGroupManager.CreateNewGroupExpense(app.contextGetUser(r).ID, groupExpense)
+	err = app.models.FinancialGroupManager.CreateNewGroupExpense(r.Context(), app.contextGetUser(r).ID, groupExpense)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -799,7 +799,7 @@ func (app *application) deleteGroupExpenseHandler(w http.ResponseWriter, r *http
 		return
 	}
 	// delete the group expense
-	_, err = app.models.FinancialGroupManager.DeleteGroupExpense(app.contextGetUser(r).ID, groupExpenseID)
+	_, err = app.models.FinancialGroupManager.DeleteGroupExpense(r.Context(), app.contextGetUser(r).ID, groupExpenseID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -821,7 +821,7 @@ func (app *application) deleteGroupExpenseHandler(w http.ResponseWriter, r *http
 // we will return a list of groups created by the user
 func (app *application) getAllGroupsCreatedByUserHandler(w http.ResponseWriter, r *http.Request) {
 	// get all the groups created by the user
-	groups, err := app.models.FinancialGroupManager.GetAllGroupsCreatedByUser(app.contextGetUser(r).ID)
+	groups, err := app.models.FinancialGroupManager.GetAllGroupsCreatedByUser(r.Context(), app.contextGetUser(r).ID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -859,7 +859,7 @@ func (app *application) getAllPublicGroupsHandler(w http.ResponseWriter, r *http
 	// None of the sort values are supported for this endpoint
 	input.Filters.SortSafelist = []string{"", ""}
 	// get all the public groups
-	groups, metadata, err := app.models.FinancialGroupManager.GetAllPublicGroups(app.contextGetUser(r).ID, input.Name, input.Filters)
+	groups, metadata, err := app.models.FinancialGroupManager.GetAllPublicGroups(r.Context(), app.contextGetUser(r).ID, input.Name, input.Filters)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -882,7 +882,7 @@ func (app *application) getAllPublicGroupsHandler(w http.ResponseWriter, r *http
 func (app *application) getAllGroupsUserIsMemberOfHandler(w http.ResponseWriter, r *http.Request) {
 	app.logger.Info("getting all groups user is a member of")
 	// get all the groups the user is a member of
-	groups, err := app.models.FinancialGroupManager.GetAllGroupsUserIsMemberOf(app.contextGetUser(r).ID)
+	groups, err := app.models.FinancialGroupManager.GetAllGroupsUserIsMemberOf(r.Context(), app.contextGetUser(r).ID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -934,7 +934,7 @@ func (app *application) getGroupTransactionsByGroupIdHandler(w http.ResponseWrit
 		return
 	}
 	// get all the transactions for the group
-	transactions, metadata, err := app.models.FinancialGroupManager.GetGroupTransactionsByGroupId(app.contextGetUser(r).ID, groupID, input.GoalID, input.Filters)
+	transactions, metadata, err := app.models.FinancialGroupManager.GetGroupTransactionsByGroupId(r.Context(), app.contextGetUser(r).ID, groupID, input.GoalID, input.Filters)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -987,7 +987,7 @@ func (app *application) getGroupExpensesByGroupIdHandler(w http.ResponseWriter, 
 		return
 	}
 	// get all the expenses for the group
-	expenses, metadata, err := app.models.FinancialGroupManager.GetGroupExpensesByGroupId(app.contextGetUser(r).ID, groupID, input.Category, input.Filters)
+	expenses, metadata, err := app.models.FinancialGroupManager.GetGroupExpensesByGroupId(r.Context(), app.contextGetUser(r).ID, groupID, input.Category, input.Filters)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -1022,7 +1022,7 @@ func (app *application) getDetailedGroupByIdHandler(w http.ResponseWriter, r *ht
 		return
 	}
 	// get the group by the details
-	group, err := app.models.FinancialGroupManager.GetDetailedGroupById(app.contextGetUser(r).ID, groupID)
+	group, err := app.models.FinancialGroupManager.GetDetailedGroupById(r.Context(), app.contextGetUser(r).ID, groupID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -1069,7 +1069,7 @@ func (app *application) adminDeleteGroupMemberHandler(w http.ResponseWriter, r *
 		return
 	}
 	// perform the Delete Request
-	_, err = app.models.FinancialGroupManager.AdminDeleteGroupMember(app.contextGetUser(r).ID, groupID, memberID)
+	_, err = app.models.FinancialGroupManager.AdminDeleteGroupMember(r.Context(), app.contextGetUser(r).ID, groupID, memberID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -1103,7 +1103,7 @@ func (app *application) userLeaveGroupHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 	// delete the user from the group
-	_, err = app.models.FinancialGroupManager.UserLeaveGroup(app.contextGetUser(r).ID, groupID)
+	_, err = app.models.FinancialGroupManager.UserLeaveGroup(r.Context(), app.contextGetUser(r).ID, groupID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):

--- a/cmd/api/financial_groups.go
+++ b/cmd/api/financial_groups.go
@@ -267,7 +267,7 @@ func (app *application) createNewGroupInvitation(w http.ResponseWriter, r *http.
 		return
 	}
 	// check if invitee exists
-	inviteeUser, err := app.models.Users.GetByEmail(input.InviteeUserEmail, app.config.encryption.key)
+	inviteeUser, err := app.models.Users.GetByEmail(r.Context(), input.InviteeUserEmail, app.config.encryption.key)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):

--- a/cmd/api/financial_management.go
+++ b/cmd/api/financial_management.go
@@ -81,7 +81,7 @@ func (app *application) createNewBudgetdHandler(w http.ResponseWriter, r *http.R
 		newBudget.ConversionRate = decimal.NewFromInt(1)
 	}
 	// Save the budget to the database
-	err = app.models.FinancialManager.CreateNewBudget(newBudget)
+	err = app.models.FinancialManager.CreateNewBudget(r.Context(), newBudget)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -122,7 +122,7 @@ func (app *application) updateBudgetHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Get budget details from the database
-	budget, err := app.models.FinancialManager.GetBudgetByID(budgetID)
+	budget, err := app.models.FinancialManager.GetBudgetByID(r.Context(), budgetID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -144,7 +144,7 @@ func (app *application) updateBudgetHandler(w http.ResponseWriter, r *http.Reque
 	user := app.contextGetUser(r)
 
 	// Retrieve the budget summary and total monthly contribution
-	budgetTotal, err := app.models.FinancialManager.GetAllGoalSummaryBudgetID(budget.Id, user.ID)
+	budgetTotal, err := app.models.FinancialManager.GetAllGoalSummaryBudgetID(r.Context(), budget.Id, user.ID)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -225,7 +225,7 @@ func (app *application) updateBudgetHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Proceed with the budget update in the database
-	err = app.models.FinancialManager.UpdateUserBudget(user.ID, budget)
+	err = app.models.FinancialManager.UpdateUserBudget(r.Context(), user.ID, budget)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrEditConflict):
@@ -270,7 +270,7 @@ func (app *application) deleteBudgetByIDHandler(w http.ResponseWriter, r *http.R
 	user := app.contextGetUser(r)
 
 	// Delete the budget from the database
-	_, err = app.models.FinancialManager.DeleteBudgetByID(user.ID, budgetID)
+	_, err = app.models.FinancialManager.DeleteBudgetByID(r.Context(), user.ID, budgetID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -317,7 +317,7 @@ func (app *application) getBudgetsForUserHandler(w http.ResponseWriter, r *http.
 		return
 	}
 	// Get the budgets for the user
-	enrichedBudgets, metadata, err := app.models.FinancialManager.GetBudgetsForUser(app.contextGetUser(r).ID, input.Name, input.Filters)
+	enrichedBudgets, metadata, err := app.models.FinancialManager.GetBudgetsForUser(r.Context(), app.contextGetUser(r).ID, input.Name, input.Filters)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -366,7 +366,7 @@ func (app *application) createNewGoalHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	// check if budget exists
-	budget, err := app.models.FinancialManager.GetBudgetByID(input.BudgetID)
+	budget, err := app.models.FinancialManager.GetBudgetByID(r.Context(), input.BudgetID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -405,7 +405,7 @@ func (app *application) createNewGoalHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	// check if the goal is still within the budget
-	goalSummaryTotals, err := app.models.FinancialManager.GetAllGoalSummaryBudgetID(newGoal.BudgetID, newGoal.UserID)
+	goalSummaryTotals, err := app.models.FinancialManager.GetAllGoalSummaryBudgetID(r.Context(), newGoal.BudgetID, newGoal.UserID)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -424,7 +424,7 @@ func (app *application) createNewGoalHandler(w http.ResponseWriter, r *http.Requ
 	}
 
 	// just directly write to the database
-	err = app.models.FinancialManager.CreateNewGoal(newGoal)
+	err = app.models.FinancialManager.CreateNewGoal(r.Context(), newGoal)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrDuplicateGoal):
@@ -481,7 +481,7 @@ func (app *application) updatedGoalHandler(w http.ResponseWriter, r *http.Reques
 	// get user
 	user := app.contextGetUser(r)
 	// Get the goal details from the database
-	goal, err := app.models.FinancialManager.GetGoalByID(user.ID, goalID)
+	goal, err := app.models.FinancialManager.GetGoalByID(r.Context(), user.ID, goalID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -492,7 +492,7 @@ func (app *application) updatedGoalHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	// check if budget exists
-	budget, err := app.models.FinancialManager.GetBudgetByID(goal.BudgetID)
+	budget, err := app.models.FinancialManager.GetBudgetByID(r.Context(), goal.BudgetID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -509,7 +509,7 @@ func (app *application) updatedGoalHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	// Get the budget summary and total monthly contribution
-	budgetTotal, err := app.models.FinancialManager.GetAllGoalSummaryBudgetID(goal.BudgetID, user.ID)
+	budgetTotal, err := app.models.FinancialManager.GetAllGoalSummaryBudgetID(r.Context(), goal.BudgetID, user.ID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -579,7 +579,7 @@ func (app *application) updatedGoalHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	// Proceed with the goal update in the database
-	err = app.models.FinancialManager.UpdateGoalByID(user.ID, goal)
+	err = app.models.FinancialManager.UpdateGoalByID(r.Context(), user.ID, goal)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrEditConflict):
@@ -641,7 +641,7 @@ func (app *application) getGoalTrackingHistoryHandler(w http.ResponseWriter, r *
 		return
 	}
 	// Get the goal tracking history for the user
-	goalTrackingHistory, metadata, err := app.models.FinancialManager.GetGoalTrackingHistory(user.ID, mappedTrackingType, input.Filters)
+	goalTrackingHistory, metadata, err := app.models.FinancialManager.GetGoalTrackingHistory(r.Context(), user.ID, mappedTrackingType, input.Filters)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -693,7 +693,7 @@ func (app *application) createNewGoalPlanHandler(w http.ResponseWriter, r *http.
 		return
 	}
 	// Save the goal plan to the database
-	err = app.models.FinancialManager.CreateNewGoalPlan(app.contextGetUser(r).ID, newGoalPlan)
+	err = app.models.FinancialManager.CreateNewGoalPlan(r.Context(), app.contextGetUser(r).ID, newGoalPlan)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrDuplicateGoalPlan):
@@ -728,7 +728,7 @@ func (app *application) updatedGoalPlanHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 	// Get the goal plan details from the database
-	goalPlan, err := app.models.FinancialManager.GetGoalPlanByID(app.contextGetUser(r).ID, goalPlanID)
+	goalPlan, err := app.models.FinancialManager.GetGoalPlanByID(r.Context(), app.contextGetUser(r).ID, goalPlanID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -770,7 +770,7 @@ func (app *application) updatedGoalPlanHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 	// Proceed with the goal plan update in the database
-	err = app.models.FinancialManager.UpdateGoalPlanByID(app.contextGetUser(r).ID, goalPlan)
+	err = app.models.FinancialManager.UpdateGoalPlanByID(r.Context(), app.contextGetUser(r).ID, goalPlan)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrEditConflict):
@@ -846,7 +846,7 @@ func (app *application) getGoalPlansForUserHandler(w http.ResponseWriter, r *htt
 	}
 
 	// Get the goal plans for the user
-	goalPlans, metadata, err := app.models.FinancialManager.GetGoalPlansForUser(user.ID, input.Filters)
+	goalPlans, metadata, err := app.models.FinancialManager.GetGoalPlansForUser(r.Context(), user.ID, input.Filters)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -880,7 +880,7 @@ func (app *application) getBudgetGoalExpenseSummaryHandler(w http.ResponseWriter
 	user := app.contextGetUser(r)
 
 	// Get the goals and expenses for the user
-	enrichedBudgets, err := app.models.FinancialManager.GetBudgetGoalExpenseSummary(user.ID)
+	enrichedBudgets, err := app.models.FinancialManager.GetBudgetGoalExpenseSummary(r.Context(), user.ID)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -924,7 +924,7 @@ func (app *application) getAllGoalsWithProgressionByUserIDHandler(w http.Respons
 	user := app.contextGetUser(r)
 
 	// Get the goals with progression for the user
-	goals, metadata, err := app.models.FinancialManager.GetAllGoalsWithProgressionByUserID(user.ID, input.Name, input.Filters)
+	goals, metadata, err := app.models.FinancialManager.GetAllGoalsWithProgressionByUserID(r.Context(), user.ID, input.Name, input.Filters)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):

--- a/cmd/api/financial_tracker.go
+++ b/cmd/api/financial_tracker.go
@@ -37,7 +37,7 @@ func (app *application) createNewExpenseHandler(w http.ResponseWriter, r *http.R
 	// get the user
 	user := app.contextGetUser(r)
 	// get the budget
-	budget, err := app.models.FinancialManager.GetBudgetByID(input.BudgetID)
+	budget, err := app.models.FinancialManager.GetBudgetByID(r.Context(), input.BudgetID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -66,7 +66,7 @@ func (app *application) createNewExpenseHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 	// get the available surplus
-	goalTotals, err := app.models.FinancialManager.GetAllGoalSummaryBudgetID(expense.BudgetID, user.ID)
+	goalTotals, err := app.models.FinancialManager.GetAllGoalSummaryBudgetID(r.Context(), expense.BudgetID, user.ID)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -83,7 +83,7 @@ func (app *application) createNewExpenseHandler(w http.ResponseWriter, r *http.R
 		}
 	}
 	// save the expense
-	err = app.models.FinancialTrackingManager.CreateNewExpense(user.ID, expense)
+	err = app.models.FinancialTrackingManager.CreateNewExpense(r.Context(), user.ID, expense)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -132,7 +132,7 @@ func (app *application) updateExpenseByIDHandler(w http.ResponseWriter, r *http.
 	user := app.contextGetUser(r)
 
 	// get the expense
-	expense, err := app.models.FinancialTrackingManager.GetExpenseByID(user.ID, expenseID)
+	expense, err := app.models.FinancialTrackingManager.GetExpenseByID(r.Context(), user.ID, expenseID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -144,7 +144,7 @@ func (app *application) updateExpenseByIDHandler(w http.ResponseWriter, r *http.
 	}
 
 	// get the budget
-	budget, err := app.models.FinancialManager.GetBudgetByID(expense.BudgetID)
+	budget, err := app.models.FinancialManager.GetBudgetByID(r.Context(), expense.BudgetID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -156,7 +156,7 @@ func (app *application) updateExpenseByIDHandler(w http.ResponseWriter, r *http.
 	}
 
 	// get the available surplus (this includes the current expense)
-	goalTotals, err := app.models.FinancialManager.GetAllGoalSummaryBudgetID(expense.BudgetID, user.ID)
+	goalTotals, err := app.models.FinancialManager.GetAllGoalSummaryBudgetID(r.Context(), expense.BudgetID, user.ID)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -208,7 +208,7 @@ func (app *application) updateExpenseByIDHandler(w http.ResponseWriter, r *http.
 	}
 
 	// 5. Save the updated expense to the database
-	err = app.models.FinancialTrackingManager.UpdateExpenseByID(user.ID, expense)
+	err = app.models.FinancialTrackingManager.UpdateExpenseByID(r.Context(), user.ID, expense)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -258,7 +258,7 @@ func (app *application) createNewRecurringExpenseHandler(w http.ResponseWriter, 
 
 	// Next Recurrence we will need to calculate
 	// Get budget details from the database
-	budget, err := app.models.FinancialManager.GetBudgetByID(input.BudgetID)
+	budget, err := app.models.FinancialManager.GetBudgetByID(r.Context(), input.BudgetID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -287,7 +287,7 @@ func (app *application) createNewRecurringExpenseHandler(w http.ResponseWriter, 
 	// calculate amount of the expense per month based on the recurrence interval
 	recurringExpense.ProjectedAmount = recurringExpense.CalculateTotalAmountPerMonth()
 	// Get our totals
-	goalTotals, err := app.models.FinancialManager.GetAllGoalSummaryBudgetID(recurringExpense.BudgetID, user.ID)
+	goalTotals, err := app.models.FinancialManager.GetAllGoalSummaryBudgetID(r.Context(), recurringExpense.BudgetID, user.ID)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -307,7 +307,7 @@ func (app *application) createNewRecurringExpenseHandler(w http.ResponseWriter, 
 	recurringExpense.CalculateNextOccurrence()
 	app.logger.Info("next occurrence", zap.String("next_occurrence", recurringExpense.NextOccurrence.String()))
 	// Create the recurring expense
-	err = app.models.FinancialTrackingManager.CreateNewRecurringExpense(user.ID, recurringExpense)
+	err = app.models.FinancialTrackingManager.CreateNewRecurringExpense(r.Context(), user.ID, recurringExpense)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrDuplicateRecurringExpense):
@@ -358,7 +358,7 @@ func (app *application) updateRecurringExpenseByIDHandler(w http.ResponseWriter,
 	}
 
 	user := app.contextGetUser(r)
-	recurringExpense, err := app.models.FinancialTrackingManager.GetRecurringExpenseByID(user.ID, expenseID)
+	recurringExpense, err := app.models.FinancialTrackingManager.GetRecurringExpenseByID(r.Context(), user.ID, expenseID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -371,7 +371,7 @@ func (app *application) updateRecurringExpenseByIDHandler(w http.ResponseWriter,
 	// print created at
 	app.logger.Info("created at", zap.String("created_at", recurringExpense.CreatedAt.String()))
 
-	budget, err := app.models.FinancialManager.GetBudgetByID(recurringExpense.BudgetID)
+	budget, err := app.models.FinancialManager.GetBudgetByID(r.Context(), recurringExpense.BudgetID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -421,7 +421,7 @@ func (app *application) updateRecurringExpenseByIDHandler(w http.ResponseWriter,
 	app.logger.Info("new projected amount", zap.String("new_projected_amount", newProjectedAmount.String()))
 
 	// Get available surplus
-	goalTotals, err := app.models.FinancialManager.GetAllGoalSummaryBudgetID(recurringExpense.BudgetID, user.ID)
+	goalTotals, err := app.models.FinancialManager.GetAllGoalSummaryBudgetID(r.Context(), recurringExpense.BudgetID, user.ID)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -452,7 +452,7 @@ func (app *application) updateRecurringExpenseByIDHandler(w http.ResponseWriter,
 		return
 	}
 	// Save the updated recurring expense
-	err = app.models.FinancialTrackingManager.UpdateRecurringExpenseByID(user.ID, recurringExpense)
+	err = app.models.FinancialTrackingManager.UpdateRecurringExpenseByID(r.Context(), user.ID, recurringExpense)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -493,7 +493,7 @@ func (app *application) getAllExpensesByUserIDHandler(w http.ResponseWriter, r *
 		return
 	}
 	// get our expenses
-	expenses, metadata, err := app.models.FinancialTrackingManager.GetAllExpensesByUserID(app.contextGetUser(r).ID, input.Name, input.Filters)
+	expenses, metadata, err := app.models.FinancialTrackingManager.GetAllExpensesByUserID(r.Context(), app.contextGetUser(r).ID, input.Name, input.Filters)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -536,7 +536,7 @@ func (app *application) getAllRecurringExpensesByUserIDHandler(w http.ResponseWr
 		return
 	}
 	// get our expenses
-	recurringExpenses, metadata, err := app.models.FinancialTrackingManager.GetAllRecurringExpensesByUserID(app.contextGetUser(r).ID, input.Name, input.Filters)
+	recurringExpenses, metadata, err := app.models.FinancialTrackingManager.GetAllRecurringExpensesByUserID(r.Context(), app.contextGetUser(r).ID, input.Name, input.Filters)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -616,7 +616,7 @@ func (app *application) createNewIncomeHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 	// save the income
-	err = app.models.FinancialTrackingManager.CreateNewIncome(user.ID, income)
+	err = app.models.FinancialTrackingManager.CreateNewIncome(r.Context(), user.ID, income)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -654,7 +654,7 @@ func (app *application) getAllIncomesByUserIDHandler(w http.ResponseWriter, r *h
 		return
 	}
 	// get our incomes
-	incomes, metadata, err := app.models.FinancialTrackingManager.GetAllIncomesByUserID(app.contextGetUser(r).ID, input.Name, input.Filters)
+	incomes, metadata, err := app.models.FinancialTrackingManager.GetAllIncomesByUserID(r.Context(), app.contextGetUser(r).ID, input.Name, input.Filters)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -707,7 +707,7 @@ func (app *application) updateIncomeHandler(w http.ResponseWriter, r *http.Reque
 	user := app.contextGetUser(r)
 
 	// Fetch the existing income entry from the database.
-	income, err := app.models.FinancialTrackingManager.GetIncomeByID(user.ID, incomeID)
+	income, err := app.models.FinancialTrackingManager.GetIncomeByID(r.Context(), user.ID, incomeID)
 	if err != nil {
 		if errors.Is(err, data.ErrGeneralRecordNotFound) {
 			app.notFoundResponse(w, r)
@@ -776,7 +776,7 @@ func (app *application) updateIncomeHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Save the updated income to the database.
-	err = app.models.FinancialTrackingManager.UpdateIncomeByID(user.ID, income)
+	err = app.models.FinancialTrackingManager.UpdateIncomeByID(r.Context(), user.ID, income)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -849,7 +849,7 @@ func (app *application) createNewDebtHandler(w http.ResponseWriter, r *http.Requ
 	debt.EstimatedPayoffDate = estimatedPayoffDate
 
 	// Insert the new debt into the database
-	err = app.models.FinancialTrackingManager.CreateNewDebt(app.contextGetUser(r).ID, debt)
+	err = app.models.FinancialTrackingManager.CreateNewDebt(r.Context(), app.contextGetUser(r).ID, debt)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrDuplicateDebt):
@@ -897,7 +897,7 @@ func (app *application) updateDebtHandler(w http.ResponseWriter, r *http.Request
 	}
 
 	// Fetch the existing debt from the DB
-	debt, err := app.models.FinancialTrackingManager.GetDebtByID(app.contextGetUser(r).ID, debtID)
+	debt, err := app.models.FinancialTrackingManager.GetDebtByID(r.Context(), app.contextGetUser(r).ID, debtID)
 	if err != nil {
 		if errors.Is(err, data.ErrGeneralRecordNotFound) {
 			app.notFoundResponse(w, r)
@@ -978,7 +978,7 @@ func (app *application) updateDebtHandler(w http.ResponseWriter, r *http.Request
 			PrincipalPayment: principalPayment,
 		}
 
-		err = app.models.FinancialTrackingManager.CreateNewDebtPayment(app.contextGetUser(r).ID, payment)
+		err = app.models.FinancialTrackingManager.CreateNewDebtPayment(r.Context(), app.contextGetUser(r).ID, payment)
 		if err != nil {
 			app.serverErrorResponse(w, r, err)
 			return
@@ -989,7 +989,7 @@ func (app *application) updateDebtHandler(w http.ResponseWriter, r *http.Request
 	}
 
 	// Save the updated debt back to the database
-	err = app.models.FinancialTrackingManager.UpdateDebtByID(app.contextGetUser(r).ID, debt)
+	err = app.models.FinancialTrackingManager.UpdateDebtByID(r.Context(), app.contextGetUser(r).ID, debt)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -1052,7 +1052,7 @@ func (app *application) getAllDebtsByUserIDHandler(w http.ResponseWriter, r *htt
 	}
 
 	// Get all debts for the user
-	debts, metadata, err := app.models.FinancialTrackingManager.GetAllDebtsByUserID(app.contextGetUser(r).ID, input.Name, input.Filters)
+	debts, metadata, err := app.models.FinancialTrackingManager.GetAllDebtsByUserID(r.Context(), app.contextGetUser(r).ID, input.Name, input.Filters)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -1136,7 +1136,7 @@ func (app *application) getDebtPaymentsByDebtUserIDHandler(w http.ResponseWriter
 		return
 	}
 	// Get the debt payments from the database
-	payments, metadata, err := app.models.FinancialTrackingManager.GetDebtPaymentsByDebtUserID(app.contextGetUser(r).ID, debtID, input.StartDate, input.EndDate, input.Filters)
+	payments, metadata, err := app.models.FinancialTrackingManager.GetDebtPaymentsByDebtUserID(r.Context(), app.contextGetUser(r).ID, debtID, input.StartDate, input.EndDate, input.Filters)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -1192,7 +1192,7 @@ func (app *application) makeDebtPaymentHandler(w http.ResponseWriter, r *http.Re
 	v := validator.New()
 
 	// Step 3: Retrieve the debt record for the user by debt ID
-	debt, err := app.models.FinancialTrackingManager.GetDebtByID(app.contextGetUser(r).ID, debtID)
+	debt, err := app.models.FinancialTrackingManager.GetDebtByID(r.Context(), app.contextGetUser(r).ID, debtID)
 	if err != nil {
 		app.notFoundResponse(w, r)
 		return
@@ -1241,7 +1241,7 @@ func (app *application) makeDebtPaymentHandler(w http.ResponseWriter, r *http.Re
 	}
 
 	// Step 8: Save the new debt repayment record in the database
-	err = app.models.FinancialTrackingManager.CreateNewDebtPayment(debt.UserID, payment)
+	err = app.models.FinancialTrackingManager.CreateNewDebtPayment(r.Context(), debt.UserID, payment)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -1269,7 +1269,7 @@ func (app *application) makeDebtPaymentHandler(w http.ResponseWriter, r *http.Re
 	debt.TotalInterestPaid = debt.TotalInterestPaid.Add(interestPayment)
 
 	// Step 14: Update the debt record in the database with the new balance and dates
-	err = app.models.FinancialTrackingManager.UpdateDebtByID(debt.UserID, debt)
+	err = app.models.FinancialTrackingManager.UpdateDebtByID(r.Context(), debt.UserID, debt)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):

--- a/cmd/api/general.go
+++ b/cmd/api/general.go
@@ -54,7 +54,7 @@ func (app *application) createContactUsHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 	// save the contact us request in the database
-	err = app.models.GeneralManagerModel.CreateContactUs(user.ID, contactUs)
+	err = app.models.GeneralManagerModel.CreateContactUs(r.Context(), user.ID, contactUs)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return

--- a/cmd/api/helpers.go
+++ b/cmd/api/helpers.go
@@ -452,7 +452,7 @@ func (app *application) aunthenticatorHelper(r *http.Request) (*data.User, error
 	// again calling the invalidAuthenticationTokenResponse() helper if no
 	// matching record was found. IMPORTANT: Notice that we are using
 	// ScopeAuthentication as the first parameter here.
-	user, err := app.models.Users.GetForToken(data.ScopeAuthentication, token, app.config.encryption.key)
+	user, err := app.models.Users.GetForToken(r.Context(), data.ScopeAuthentication, token, app.config.encryption.key)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):

--- a/cmd/api/helpers.go
+++ b/cmd/api/helpers.go
@@ -469,24 +469,24 @@ func (app *application) aunthenticatorHelper(r *http.Request) (*data.User, error
 // Depending on that investment type i.e (stock,bond,alternative), we check if that ID exists for that user
 // in the respective table
 // If it does not exist, we add an error to the validator
-func (app *application) investmentTransactionValidatorHelper(v *validator.Validator, transaction *data.InvestmentTransaction) interface{} {
+func (app *application) investmentTransactionValidatorHelper(ctx context.Context, v *validator.Validator, transaction *data.InvestmentTransaction) interface{} {
 	var investment interface{}
 	// check if the investment exists
 	switch transaction.InvestmentType {
 	case data.InvPortInvestmentTypeStock:
-		stock, err := app.models.InvestmentPortfolioManager.GetStockByStockID(transaction.InvestmentID)
+		stock, err := app.models.InvestmentPortfolioManager.GetStockByStockID(ctx, transaction.InvestmentID)
 		if err != nil {
 			v.AddError("investment_id", "stock investment does not exist")
 		}
 		investment = stock
 	case data.InvPortInvestmentTypeBond:
-		bond, err := app.models.InvestmentPortfolioManager.GetBondByBondID(transaction.InvestmentID)
+		bond, err := app.models.InvestmentPortfolioManager.GetBondByBondID(ctx, transaction.InvestmentID)
 		if err != nil {
 			v.AddError("investment_id", "bond investment does not exist")
 		}
 		investment = bond
 	case data.InvPortInvestmentTypeAlternative:
-		alternative, err := app.models.InvestmentPortfolioManager.GetAlternativeInvestmentByAlternativeID(transaction.InvestmentID)
+		alternative, err := app.models.InvestmentPortfolioManager.GetAlternativeInvestmentByAlternativeID(ctx, transaction.InvestmentID)
 		if err != nil {
 			v.AddError("investment_id", "alternative investment does not exist")
 		}
@@ -504,28 +504,28 @@ func (app *application) investmentTransactionValidatorHelper(v *validator.Valida
 // Then all we update is the quantity, if transaction type is sell, we substract the quantity
 // if transaction type is buy, we add the quantity. Each unique investment type will have its own
 // case for this function in terms of updates i.e stock, bond and alternative
-func (app *application) updateInvestmentTransactionHelper(userID int64, transactionType string, transactionQuantity decimal.Decimal, investment interface{}) error {
+func (app *application) updateInvestmentTransactionHelper(ctx context.Context, userID int64, transactionType string, transactionQuantity decimal.Decimal, investment interface{}) error {
 	switch transactionType {
 	case "buy":
 		switch t := investment.(type) {
 		case *data.StockInvestment:
 			t.Quantity = t.Quantity.Add(transactionQuantity)
 			// update passing the fully updated struct
-			err := app.models.InvestmentPortfolioManager.UpdateStockInvestment(userID, t)
+			err := app.models.InvestmentPortfolioManager.UpdateStockInvestment(ctx, userID, t)
 			if err != nil {
 				return err
 			}
 		case *data.BondInvestment:
 			t.Quantity = t.Quantity.Add(transactionQuantity)
 			// update passing the fully updated struct
-			err := app.models.InvestmentPortfolioManager.UpdateBondInvestment(userID, t)
+			err := app.models.InvestmentPortfolioManager.UpdateBondInvestment(ctx, userID, t)
 			if err != nil {
 				return err
 			}
 		case *data.AlternativeInvestment:
 			t.Quantity = t.Quantity.Add(transactionQuantity)
 			// update passing the fully updated struct
-			err := app.models.InvestmentPortfolioManager.UpdateAlternativeInvestment(userID, t)
+			err := app.models.InvestmentPortfolioManager.UpdateAlternativeInvestment(ctx, userID, t)
 			if err != nil {
 				return err
 			}
@@ -535,21 +535,21 @@ func (app *application) updateInvestmentTransactionHelper(userID int64, transact
 		case *data.StockInvestment:
 			t.Quantity = t.Quantity.Sub(transactionQuantity)
 			// update passing the fully updated struct
-			err := app.models.InvestmentPortfolioManager.UpdateStockInvestment(userID, t)
+			err := app.models.InvestmentPortfolioManager.UpdateStockInvestment(ctx, userID, t)
 			if err != nil {
 				return err
 			}
 		case *data.BondInvestment:
 			t.Quantity = t.Quantity.Sub(transactionQuantity)
 			// update passing the fully updated struct
-			err := app.models.InvestmentPortfolioManager.UpdateBondInvestment(userID, t)
+			err := app.models.InvestmentPortfolioManager.UpdateBondInvestment(ctx, userID, t)
 			if err != nil {
 				return err
 			}
 		case *data.AlternativeInvestment:
 			t.Quantity = t.Quantity.Sub(transactionQuantity)
 			// update passing the fully updated struct
-			err := app.models.InvestmentPortfolioManager.UpdateAlternativeInvestment(userID, t)
+			err := app.models.InvestmentPortfolioManager.UpdateAlternativeInvestment(ctx, userID, t)
 			if err != nil {
 				return err
 			}

--- a/cmd/api/investment_operations.go
+++ b/cmd/api/investment_operations.go
@@ -45,7 +45,7 @@ func (app *application) updateBondAnalysis(ctx context.Context, userID int64, bo
 	bond.SortinoRatio = bondAnalysisStatistics.SortinoRatio
 
 	// save the bond analysis
-	err = app.models.InvestmentPortfolioManager.CreateBondAnalysis(userID, bond.BondSymbol, bond)
+	err = app.models.InvestmentPortfolioManager.CreateBondAnalysis(ctx, userID, bond.BondSymbol, bond)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (app *application) updateStockAnalysis(ctx context.Context, userID int64, s
 	stock.SectorPerformance = sectorPerformance
 	stock.SentimentLabel = stockAnalysisStatistics.MostFrequentLabel
 	// save the stock analysis using CreateStockAnalysis passing userID, riskFreeRate, stockSymbol, stockAnalysis
-	err = app.models.InvestmentPortfolioManager.CreateStockAnalysis(userID, riskFreeRate, stock.StockSymbol, stock)
+	err = app.models.InvestmentPortfolioManager.CreateStockAnalysis(ctx, userID, riskFreeRate, stock.StockSymbol, stock)
 	if err != nil {
 		return err
 	}

--- a/cmd/api/investment_portfolio.go
+++ b/cmd/api/investment_portfolio.go
@@ -833,7 +833,7 @@ func (app *application) investmentPrtfolioAnalysisHandler(w http.ResponseWriter,
 	//  retrieve user ID from context
 	user := app.contextGetUser(r)
 	// start by getting our goals
-	goals, err := app.models.FinancialManager.GetGoalsForUserInvestmentHelper(user.ID)
+	goals, err := app.models.FinancialManager.GetGoalsForUserInvestmentHelper(r.Context(), user.ID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):

--- a/cmd/api/investment_portfolio.go
+++ b/cmd/api/investment_portfolio.go
@@ -69,7 +69,7 @@ func (app *application) createNewStockInvestmentHandler(w http.ResponseWriter, r
 		return
 	}
 	// create a new stock
-	err = app.models.InvestmentPortfolioManager.CreateNewStockInvestment(user.ID, stock)
+	err = app.models.InvestmentPortfolioManager.CreateNewStockInvestment(r.Context(), user.ID, stock)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -100,7 +100,7 @@ func (app *application) updateStockInvestmentHandler(w http.ResponseWriter, r *h
 		return
 	}
 	// check if stock
-	stock, err := app.models.InvestmentPortfolioManager.GetStockByStockID(stockID)
+	stock, err := app.models.InvestmentPortfolioManager.GetStockByStockID(r.Context(), stockID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -139,7 +139,7 @@ func (app *application) updateStockInvestmentHandler(w http.ResponseWriter, r *h
 		return
 	}
 	// update the stock
-	err = app.models.InvestmentPortfolioManager.UpdateStockInvestment(app.contextGetUser(r).ID, stock)
+	err = app.models.InvestmentPortfolioManager.UpdateStockInvestment(r.Context(), app.contextGetUser(r).ID, stock)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralEditConflict):
@@ -173,7 +173,7 @@ func (app *application) deleteStockInvestmentByIDHandler(w http.ResponseWriter, 
 		return
 	}
 	// delete the stock
-	deletedStockID, err := app.models.InvestmentPortfolioManager.DeleteStockInvestmentByID(app.contextGetUser(r).ID, stockID)
+	deletedStockID, err := app.models.InvestmentPortfolioManager.DeleteStockInvestmentByID(r.Context(), app.contextGetUser(r).ID, stockID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -218,7 +218,7 @@ func (app *application) getAllStockInvestmentByUserIDHandler(w http.ResponseWrit
 	}
 	// make a redis key with data.RedisInvestmentPortfolioStockPrefix, user.ID, input.Name, input.Filters.Page and input.Filters.PageSize
 	redisKey := fmt.Sprintf("%s:%d:%s:%d:%d", data.RedisInvestmentPortfolioStockPrefix, app.contextGetUser(r).ID, input.Name, input.Filters.Page, input.Filters.PageSize)
-	ctx := context.Background()
+	ctx := r.Context()
 	// set the struct we will need which will include the stock ([]*data.EnrichedStockInvestment) and metadata (*data.Metadata)
 	type stockData struct {
 		Stock    []*data.EnrichedStockInvestment
@@ -245,7 +245,7 @@ func (app *application) getAllStockInvestmentByUserIDHandler(w http.ResponseWrit
 	}
 
 	// get our stock information
-	stock, metadata, err := app.models.InvestmentPortfolioManager.GetAllStockInvestmentByUserID(app.contextGetUser(r).ID, input.Name, input.Filters)
+	stock, metadata, err := app.models.InvestmentPortfolioManager.GetAllStockInvestmentByUserID(ctx, app.contextGetUser(r).ID, input.Name, input.Filters)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -308,7 +308,7 @@ func (app *application) createNewBondInvestmentHandler(w http.ResponseWriter, r 
 		return
 	}
 	// create a new bond
-	err = app.models.InvestmentPortfolioManager.CreateNewBondInvestment(user.ID, bond)
+	err = app.models.InvestmentPortfolioManager.CreateNewBondInvestment(r.Context(), user.ID, bond)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -339,7 +339,7 @@ func (app *application) updateBondInvestmentHandler(w http.ResponseWriter, r *ht
 		return
 	}
 	// get the bond
-	bond, err := app.models.InvestmentPortfolioManager.GetBondByBondID(bondID)
+	bond, err := app.models.InvestmentPortfolioManager.GetBondByBondID(r.Context(), bondID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -375,7 +375,7 @@ func (app *application) updateBondInvestmentHandler(w http.ResponseWriter, r *ht
 		return
 	}
 	// update the bond
-	err = app.models.InvestmentPortfolioManager.UpdateBondInvestment(app.contextGetUser(r).ID, bond)
+	err = app.models.InvestmentPortfolioManager.UpdateBondInvestment(r.Context(), app.contextGetUser(r).ID, bond)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralEditConflict):
@@ -408,7 +408,7 @@ func (app *application) deleteBondInvestmentByIDHandler(w http.ResponseWriter, r
 		return
 	}
 	// delete the bond
-	deletedBondID, err := app.models.InvestmentPortfolioManager.DeleteBondInvestmentByID(app.contextGetUser(r).ID, bondID)
+	deletedBondID, err := app.models.InvestmentPortfolioManager.DeleteBondInvestmentByID(r.Context(), app.contextGetUser(r).ID, bondID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -453,7 +453,7 @@ func (app *application) getAllBondInvestmentByUserIDHandler(w http.ResponseWrite
 	}
 	// make redis key with data.RedisInvestmentPortfolioBondPrefix, user.ID, input.Name, input.Filters.Page and input.Filters.PageSize
 	redisKey := fmt.Sprintf("%s:%d:%s:%d:%d", data.RedisInvestmentPortfolioBondPrefix, app.contextGetUser(r).ID, input.Name, input.Filters.Page, input.Filters.PageSize)
-	ctx := context.Background()
+	ctx := r.Context()
 	// set the struct we will need which will include the bond ([]*data.EnrichedBondInvestment) and metadata (*data.Metadata)
 	type bondData struct {
 		Bond     []*data.EnrichedBondInvestment
@@ -479,7 +479,7 @@ func (app *application) getAllBondInvestmentByUserIDHandler(w http.ResponseWrite
 		return
 	}
 	// get our bond information
-	bond, metadata, err := app.models.InvestmentPortfolioManager.GetAllBondInvestmentByUserID(app.contextGetUser(r).ID, input.Name, input.Filters)
+	bond, metadata, err := app.models.InvestmentPortfolioManager.GetAllBondInvestmentByUserID(ctx, app.contextGetUser(r).ID, input.Name, input.Filters)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -555,7 +555,7 @@ func (app *application) createNewAlternativeInvestmentHandler(w http.ResponseWri
 		}
 	}
 	// create a new alternative
-	err = app.models.InvestmentPortfolioManager.CreateNewAlternativeInvestment(user.ID, alternative)
+	err = app.models.InvestmentPortfolioManager.CreateNewAlternativeInvestment(r.Context(), user.ID, alternative)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -592,7 +592,7 @@ func (app *application) updateAlternativeInvestmentHandler(w http.ResponseWriter
 		return
 	}
 	// get the alternative
-	alternative, err := app.models.InvestmentPortfolioManager.GetAlternativeInvestmentByAlternativeID(alternativeID)
+	alternative, err := app.models.InvestmentPortfolioManager.GetAlternativeInvestmentByAlternativeID(r.Context(), alternativeID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -651,7 +651,7 @@ func (app *application) updateAlternativeInvestmentHandler(w http.ResponseWriter
 	}
 
 	// update the alternative
-	err = app.models.InvestmentPortfolioManager.UpdateAlternativeInvestment(app.contextGetUser(r).ID, alternative)
+	err = app.models.InvestmentPortfolioManager.UpdateAlternativeInvestment(r.Context(), app.contextGetUser(r).ID, alternative)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralEditConflict):
@@ -684,7 +684,7 @@ func (app *application) deleteAlternativeInvestmentByIDHandler(w http.ResponseWr
 		return
 	}
 	// delete the alternative
-	deletedAlternativeID, err := app.models.InvestmentPortfolioManager.DeleteAlternativeInvestmentByID(app.contextGetUser(r).ID, alternativeID)
+	deletedAlternativeID, err := app.models.InvestmentPortfolioManager.DeleteAlternativeInvestmentByID(r.Context(), app.contextGetUser(r).ID, alternativeID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -764,19 +764,19 @@ func (app *application) createNewInvestmentTransactionHandler(w http.ResponseWri
 		return
 	}
 	// validate the investment
-	resultValue := app.investmentTransactionValidatorHelper(v, transaction)
+	resultValue := app.investmentTransactionValidatorHelper(r.Context(), v, transaction)
 	if !v.Valid() {
 		app.failedValidationResponse(w, r, v.Errors)
 		return
 	}
 	// create a new transaction
-	err = app.models.InvestmentPortfolioManager.CreateNewInvestmentTransaction(user.ID, transaction)
+	err = app.models.InvestmentPortfolioManager.CreateNewInvestmentTransaction(r.Context(), user.ID, transaction)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
 	}
 	// if transaction was successful, let us update the investment
-	err = app.updateInvestmentTransactionHelper(user.ID, input.TransactionType, input.Quantity, resultValue)
+	err = app.updateInvestmentTransactionHelper(r.Context(), user.ID, input.TransactionType, input.Quantity, resultValue)
 	if err != nil {
 		app.logger.Info("error updating investment", zap.Error(err))
 	}
@@ -803,7 +803,7 @@ func (app *application) deleteInvestmentTransactionByIDHandler(w http.ResponseWr
 		return
 	}
 	// delete the transaction
-	deletedTransactionID, err := app.models.InvestmentPortfolioManager.DeleteInvestmentTransactionByID(app.contextGetUser(r).ID, transactionID)
+	deletedTransactionID, err := app.models.InvestmentPortfolioManager.DeleteInvestmentTransactionByID(r.Context(), app.contextGetUser(r).ID, transactionID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -849,7 +849,7 @@ func (app *application) investmentPrtfolioAnalysisHandler(w http.ResponseWriter,
 		return
 	}
 	// check all investments
-	investmentAnalysis, err := app.models.InvestmentPortfolioManager.GetAllInvestmentsByUserID(user.ID)
+	investmentAnalysis, err := app.models.InvestmentPortfolioManager.GetAllInvestmentsByUserID(r.Context(), user.ID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -877,7 +877,7 @@ func (app *application) investmentPrtfolioAnalysisHandler(w http.ResponseWriter,
 		return
 	}
 
-	analyzedLLMResponse, err := app.buildInvestmentPortfolioLLMRequest(user, goals, investmentAnalysis)
+	analyzedLLMResponse, err := app.buildInvestmentPortfolioLLMRequest(r.Context(), user, goals, investmentAnalysis)
 	if err != nil {
 		//app.serverErrorResponse(w, r, err)
 		app.logger.Info("Error building LLM request:", zap.Error(err))
@@ -898,7 +898,7 @@ func (app *application) getLatestLLMAnalysisResponseByUserIDHandler(w http.Respo
 	//  retrieve user ID from context
 	user := app.contextGetUser(r)
 	// get the latest LLM analysis response
-	latestLLMAnalysisResponse, err := app.models.InvestmentPortfolioManager.GetLatestLLMAnalysisResponseByUserID(user.ID)
+	latestLLMAnalysisResponse, err := app.models.InvestmentPortfolioManager.GetLatestLLMAnalysisResponseByUserID(r.Context(), user.ID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -921,7 +921,7 @@ func (app *application) getAllInvestmentInfoByUserIDHandler(w http.ResponseWrite
 	//  retrieve user ID from context
 	user := app.contextGetUser(r)
 	redisKey := fmt.Sprintf("%s%d", data.RedisInvestmentPortfolioSummaryPrefix, user.ID)
-	ctx := context.Background()
+	ctx := r.Context()
 	// check if result was already cached in the cache
 	cachedResponse, err := getFromCache[[]*data.InvestmentSummary](ctx, app.RedisDB, redisKey)
 	if err != nil {
@@ -941,7 +941,7 @@ func (app *application) getAllInvestmentInfoByUserIDHandler(w http.ResponseWrite
 		return
 	}
 	// check all investments
-	investmentAnalysis, err := app.models.InvestmentPortfolioManager.GetAllInvestmentInfoByUserID(user.ID)
+	investmentAnalysis, err := app.models.InvestmentPortfolioManager.GetAllInvestmentInfoByUserID(ctx, user.ID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -1035,7 +1035,7 @@ func (app *application) getAllAlternativeInvestmentByUserIDHandler(w http.Respon
 	// make redis key with data.RedisInvestmentPortfolioAlternativePrefix, user.ID, input.Name, input.Filters.Page and input.Filters.PageSize
 	redisKey := fmt.Sprintf("%s:%d:%s:%d:%d", data.RedisInvestmentPortfolioAlternativePrefix, app.contextGetUser(r).ID, input.Name, input.Filters.Page, input.Filters.PageSize)
 	app.logger.Info("Redis Key:", zap.String("key", redisKey))
-	ctx := context.Background()
+	ctx := r.Context()
 	// set the struct we will need which will include the alternative ([]*data.EnrichedAlternativeInvestment) and metadata (*data.Metadata)
 	type alternativeData struct {
 		Alternative []*data.EnrichedAlternativeInvestment
@@ -1061,7 +1061,7 @@ func (app *application) getAllAlternativeInvestmentByUserIDHandler(w http.Respon
 		return
 	}
 	// get our alternative information
-	alternative, metadata, err := app.models.InvestmentPortfolioManager.GetAllAlternativeInvestmentByUserID(app.contextGetUser(r).ID, input.Name, input.Filters)
+	alternative, metadata, err := app.models.InvestmentPortfolioManager.GetAllAlternativeInvestmentByUserID(ctx, app.contextGetUser(r).ID, input.Name, input.Filters)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):

--- a/cmd/api/mfa.go
+++ b/cmd/api/mfa.go
@@ -52,7 +52,7 @@ func (app *application) setupMFAHandler(w http.ResponseWriter, r *http.Request) 
 	// Save the secret to the user
 	user.MFASecret = secret.Secret()
 	// if succesful, update the user's key// in the DB
-	err = app.models.Users.UpdateUser(user, app.config.encryption.key)
+	err = app.models.Users.UpdateUser(r.Context(), user, app.config.encryption.key)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -157,7 +157,7 @@ func (app *application) verifiy2FASetupHandler(w http.ResponseWriter, r *http.Re
 	// before we update the user, let us attampt to save & generate the recovery codes
 	// this is to ensure that the user has recovery codes in case they lose their device
 	// and if it fails, we do not update the user
-	recoveryCodes, err := app.models.MFAManager.CreateNewRecoveryCode(user.ID)
+	recoveryCodes, err := app.models.MFAManager.CreateNewRecoveryCode(r.Context(), user.ID)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -165,7 +165,7 @@ func (app *application) verifiy2FASetupHandler(w http.ResponseWriter, r *http.Re
 	// Update the user's MFA status
 	user.MFAEnabled = true
 	// Save the user to the DB
-	err = app.models.Users.UpdateUser(user, app.config.encryption.key)
+	err = app.models.Users.UpdateUser(r.Context(), user, app.config.encryption.key)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return

--- a/cmd/api/notification_handlers.go
+++ b/cmd/api/notification_handlers.go
@@ -38,6 +38,7 @@ func (app *application) updatedNotificationHandler(w http.ResponseWriter, r *htt
 	}
 	// update the notification's status
 	err = app.models.NotificationManager.UpdateNotificationReadAtAndStatus(
+		r.Context(),
 		notificationID,
 		sql.NullTime{Time: time.Now(), Valid: true},
 		status)
@@ -95,7 +96,7 @@ func (app *application) getAllNotificationsByUserIdHandler(w http.ResponseWriter
 		}
 	}
 	// get all notifications for a user
-	notifications, metadata, err := app.models.NotificationManager.GetAllNotificationsByUserId(app.contextGetUser(r).ID, input.NotificationType, input.Filters)
+	notifications, metadata, err := app.models.NotificationManager.GetAllNotificationsByUserId(r.Context(), app.contextGetUser(r).ID, input.NotificationType, input.Filters)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -123,7 +124,7 @@ func (app *application) deleteNotificationByIdHandler(w http.ResponseWriter, r *
 		return
 	}
 	// delete the notification by id
-	err = app.models.NotificationManager.DeleteNotificationById(notificationID, app.contextGetUser(r).ID)
+	err = app.models.NotificationManager.DeleteNotificationById(r.Context(), notificationID, app.contextGetUser(r).ID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -145,7 +146,7 @@ func (app *application) deleteNotificationByIdHandler(w http.ResponseWriter, r *
 // We return a 200 status code if the notifications were deleted successfully
 func (app *application) deleteAllNotificationsByUserIdHandler(w http.ResponseWriter, r *http.Request) {
 	// delete all notifications for a user
-	err := app.models.NotificationManager.DeleteAllNotificationsByUserId(app.contextGetUser(r).ID)
+	err := app.models.NotificationManager.DeleteAllNotificationsByUserId(r.Context(), app.contextGetUser(r).ID)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return

--- a/cmd/api/notifications.go
+++ b/cmd/api/notifications.go
@@ -95,7 +95,7 @@ func (app *application) loadAndSendPendingNotifications(userID int64) {
 	}
 
 	// Load from Database
-	err = app.loadAndProcessDBData(userID, &processedNotifications)
+	err = app.loadAndProcessDBData(ctx, userID, &processedNotifications)
 	if err != nil {
 		app.logger.Info("Error loading notifications from database:", zap.Error(err))
 	}
@@ -130,9 +130,12 @@ func (app *application) loadAndProcessRedisData(ctx context.Context, userID int6
 	return app.RedisDB.Del(ctx, pendingKey).Err()
 }
 
-// loadAndProcessDBData loads and processes pending notifications from the database
-func (app *application) loadAndProcessDBData(userID int64, processed *map[int64]bool) error {
-	pendingNotifications, err := app.models.NotificationManager.GetUnreadNotifications(userID)
+// loadAndProcessDBData loads and processes pending notifications from
+// the database. ctx is bound to the application lifecycle by the caller
+// (loadAndSendPendingNotifications) so the in-flight SELECT is cancelled
+// cleanly on graceful shutdown.
+func (app *application) loadAndProcessDBData(ctx context.Context, userID int64, processed *map[int64]bool) error {
+	pendingNotifications, err := app.models.NotificationManager.GetUnreadNotifications(ctx, userID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -332,9 +335,14 @@ func (app *application) storeNotificationInRedis(userID int64, notification data
 	return nil
 }
 
-// updateDatabaseNotificationStatus updates the status of a notification in the database
+// updateDatabaseNotificationStatus updates the status of a notification
+// in the database. Bound to app.ctx rather than the originating request
+// because callers (BroadcastNotification, PublishNotificationToRedis) are
+// firing on behalf of the recipient — who may be a different user
+// entirely — so the originator's tab close must not abort the write.
 func (app *application) updateDatabaseNotificationStatus(notificationID int64, status database.NotificationStatus) error {
 	err := app.models.NotificationManager.UpdateNotificationReadAtAndStatus(
+		app.ctx,
 		notificationID,
 		sql.NullTime{Time: time.Time{}, Valid: false},
 		status,
@@ -363,7 +371,7 @@ func (app *application) PublishNotificationToRedis(userID int64, notificationTyp
 		Meta:             metaJSON,
 		RedisKey:         &channel,
 	}
-	err = app.models.NotificationManager.CreateNewNotification(userID, savedNotification)
+	err = app.models.NotificationManager.CreateNewNotification(app.ctx, userID, savedNotification)
 	if err != nil {
 		return err
 	}

--- a/cmd/api/notifications.go
+++ b/cmd/api/notifications.go
@@ -446,7 +446,7 @@ func (app *application) listenToAwardNotifications() {
 					}
 					// convert the award ID to int32
 					// get the award by award ID
-					award, err := app.models.AwardManager.GetAwardByAwardID(payload.AwardID)
+					award, err := app.models.AwardManager.GetAwardByAwardID(app.ctx, payload.AwardID)
 					if err != nil {
 						app.logger.Error("Failed to get award by award ID", zap.Error(err))
 						continue

--- a/cmd/api/personal_finance_portfolio.go
+++ b/cmd/api/personal_finance_portfolio.go
@@ -18,7 +18,7 @@ func (app *application) getAllFinanceDetailsForAnalysisByUserIDHandler(w http.Re
 	// get the user ID
 	user := app.contextGetUser(r)
 	// get all the finance details for analysis by user ID
-	unifiedFinanceAnalysis, err := app.models.PersonalFinancePortfolio.GetAllFinanceDetailsForAnalysisByUserID(user.ID)
+	unifiedFinanceAnalysis, err := app.models.PersonalFinancePortfolio.GetAllFinanceDetailsForAnalysisByUserID(r.Context(), user.ID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -79,7 +79,7 @@ func (app *application) getPersonalFinancePrediction(w http.ResponseWriter, r *h
 	}
 
 	// check if a user has enough data points to make a prediction
-	status, err := app.models.PersonalFinancePortfolio.CheckIfUserHasEnoughPredictionData(app.contextGetUser(r).ID, input.Timeline, input.StartDate)
+	status, err := app.models.PersonalFinancePortfolio.CheckIfUserHasEnoughPredictionData(r.Context(), app.contextGetUser(r).ID, input.Timeline, input.StartDate)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -100,13 +100,13 @@ func (app *application) getPersonalFinancePrediction(w http.ResponseWriter, r *h
 	var personalFinancePrediction []*data.PredictionPersonalFinanceData
 	if input.Timeline == "weekly" {
 		app.logger.Info("Getting personal finance data for weekly")
-		personalFinancePrediction, err = app.models.PersonalFinancePortfolio.GetPersonalFinanceDataForWeeklyByUserID(user.ID, input.StartDate)
+		personalFinancePrediction, err = app.models.PersonalFinancePortfolio.GetPersonalFinanceDataForWeeklyByUserID(r.Context(), user.ID, input.StartDate)
 		if err != nil {
 			app.serverErrorResponse(w, r, err)
 			return
 		}
 	} else {
-		personalFinancePrediction, err = app.models.PersonalFinancePortfolio.GetPersonalFinanceDataForMonthByUserID(user.ID, input.StartDate)
+		personalFinancePrediction, err = app.models.PersonalFinancePortfolio.GetPersonalFinanceDataForMonthByUserID(r.Context(), user.ID, input.StartDate)
 		if err != nil {
 			app.serverErrorResponse(w, r, err)
 			return
@@ -269,7 +269,7 @@ func (app *application) getExpenseIncomeSummaryReportHandler(w http.ResponseWrit
 	}
 
 	// If not found in cache or an error occurred, proceed to fetch from the database
-	expenseIncomeSummaryReport, err := app.models.PersonalFinancePortfolio.GetExpenseIncomeSummaryReport(user.ID)
+	expenseIncomeSummaryReport, err := app.models.PersonalFinancePortfolio.GetExpenseIncomeSummaryReport(r.Context(), user.ID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):

--- a/cmd/api/personal_finance_portfolio.go
+++ b/cmd/api/personal_finance_portfolio.go
@@ -113,7 +113,7 @@ func (app *application) getPersonalFinancePrediction(w http.ResponseWriter, r *h
 		}
 	}
 	// get goals analysis
-	goals, err := app.models.FinancialManager.GetGoalsForUserInvestmentHelper(user.ID)
+	goals, err := app.models.FinancialManager.GetGoalsForUserInvestmentHelper(r.Context(), user.ID)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):

--- a/cmd/api/schedulers.go
+++ b/cmd/api/schedulers.go
@@ -151,7 +151,7 @@ func (app *application) startRssFeedScraper() {
 // It will be called every day at midnight to update the progress of the expired goals.
 func (app *application) trackGoalProgressStatus() {
 	app.logger.Info("Starting the goal progress status tracking cron job...", zap.String("time", time.Now().String()))
-	err := app.models.FinancialManager.UpdateGoalProgressOnExpiredGoals()
+	err := app.models.FinancialManager.UpdateGoalProgressOnExpiredGoals(app.ctx)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrEditConflict):
@@ -171,7 +171,7 @@ func (app *application) trackMonthlyGoals() {
 	app.logger.Info("Starting the monthly goals tracking cron job...", zap.String("time", time.Now().String()))
 	now := time.Now()
 	if app.isLastDayOfMonth(now) {
-		trackedGoals, err := app.models.FinancialManager.GetAndSaveAllGoalsForTracking()
+		trackedGoals, err := app.models.FinancialManager.GetAndSaveAllGoalsForTracking(app.ctx)
 		if err != nil {
 			app.logger.Error("Error tracking monthly goals", zap.Error(err))
 		}
@@ -213,7 +213,7 @@ func (app *application) trackRecurringExpenses() {
 		}
 
 		// Retrieve expenses that need to be tracked for the current page
-		recurringExpensesToTrack, metadata, err := app.models.FinancialTrackingManager.GetAllRecurringExpensesDueForProcessing(filter)
+		recurringExpensesToTrack, metadata, err := app.models.FinancialTrackingManager.GetAllRecurringExpensesDueForProcessing(app.ctx, filter)
 		if err != nil {
 			// Handle case where no more records are found, break out of the loop
 			if errors.Is(err, data.ErrGeneralRecordNotFound) {
@@ -239,7 +239,7 @@ func (app *application) trackRecurringExpenses() {
 			}
 
 			// Add the expense to the expenses table
-			err := app.models.FinancialTrackingManager.CreateNewExpense(recurringExpenseToTrack.UserID, expense)
+			err := app.models.FinancialTrackingManager.CreateNewExpense(app.ctx, recurringExpenseToTrack.UserID, expense)
 			if err != nil {
 				app.logger.Error("Error adding recurring expense to expenses table", zap.Error(err))
 				continue
@@ -247,7 +247,7 @@ func (app *application) trackRecurringExpenses() {
 
 			// Update the next tracking date for the current recurring expense
 			recurringExpenseToTrack.CalculateNextOccurrence()
-			err = app.models.FinancialTrackingManager.UpdateRecurringExpenseByID(recurringExpenseToTrack.UserID, recurringExpenseToTrack)
+			err = app.models.FinancialTrackingManager.UpdateRecurringExpenseByID(app.ctx, recurringExpenseToTrack.UserID, recurringExpenseToTrack)
 			if err != nil {
 				app.logger.Error("Error updating recurring expense", zap.Error(err))
 				continue
@@ -283,7 +283,7 @@ func (app *application) trackOverdueDebts() {
 			PageSize: burst,
 		}
 		// get all overdue debt
-		debts, metadata, err := app.models.FinancialTrackingManager.GetAllOverdueDebts(filter)
+		debts, metadata, err := app.models.FinancialTrackingManager.GetAllOverdueDebts(app.ctx, filter)
 		if err != nil {
 			if errors.Is(err, data.ErrGeneralRecordNotFound) {
 				app.logger.Info("No more overdue debts to track", zap.Error(err))
@@ -305,7 +305,7 @@ func (app *application) trackOverdueDebts() {
 			debt.RemainingBalance = debt.RemainingBalance.Add(accruedInterest) // Add interest to balance
 			debt.InterestLastCalculated = time.Now()                           // Update interest last calculated date
 			// Step 3: Save updated debt back to the database
-			err = app.models.FinancialTrackingManager.UpdateDebtByID(debt.UserID, debt)
+			err = app.models.FinancialTrackingManager.UpdateDebtByID(app.ctx, debt.UserID, debt)
 			if err != nil {
 				app.logger.Info("Error updating debt", zap.Error(err))
 				continue

--- a/cmd/api/schedulers.go
+++ b/cmd/api/schedulers.go
@@ -186,7 +186,7 @@ func (app *application) trackMonthlyGoals() {
 // It will be called every day at midnight to update the expired group invitations.
 func (app *application) trackExpiredGroupInvitations() {
 	app.logger.Info("Starting the expired group invitations tracking cron job..", zap.String("time", time.Now().String()))
-	err := app.models.FinancialGroupManager.UpdateExpiredGroupInvitations()
+	err := app.models.FinancialGroupManager.UpdateExpiredGroupInvitations(app.ctx)
 	if err != nil {
 		app.logger.Error("Error tracking expired group invitations", zap.Error(err))
 	}

--- a/cmd/api/schedulers.go
+++ b/cmd/api/schedulers.go
@@ -129,7 +129,7 @@ func (app *application) startRssFeedScraper() {
 	// number of feed bunches to fetch concurrently
 	noOfFeedsToFetch := int32(app.config.scraper.nooffeedstofetch)
 	// Get the feeds to fetch
-	feeds, err := app.models.FeedManager.GetNextFeedsToFetch(int32(noOfFeedsToFetch))
+	feeds, err := app.models.FeedManager.GetNextFeedsToFetch(app.ctx, int32(noOfFeedsToFetch))
 	if err != nil {
 		app.logger.Error("Error getting feeds to fetch", zap.Error(err))
 		return
@@ -341,7 +341,7 @@ func (app *application) trackExpiredNotifications() {
 			PageSize: burst,
 		}
 		// Retrieve notifications that need to be tracked for the current page
-		expiredNotifications, metadata, err := app.models.NotificationManager.GetAllExpiredNotifications(filter)
+		expiredNotifications, metadata, err := app.models.NotificationManager.GetAllExpiredNotifications(app.ctx, filter)
 		if err != nil {
 			// Handle case where no more records are found, break out of the loop
 			if errors.Is(err, data.ErrGeneralRecordNotFound) {
@@ -356,6 +356,7 @@ func (app *application) trackExpiredNotifications() {
 		for _, expiredNotification := range expiredNotifications {
 			// Update the status of the notification to expired
 			err := app.models.NotificationManager.UpdateNotificationReadAtAndStatus(
+				app.ctx,
 				expiredNotification.ID,
 				sql.NullTime{Time: time.Time{}, Valid: false},
 				data.NotificationStatusTypeExpired,

--- a/cmd/api/scraper.go
+++ b/cmd/api/scraper.go
@@ -22,7 +22,7 @@ func (app *application) rssFeedScraper(feed *data.Feed) {
 	// using our app.background(func(){}) through a for loop to iterate over the feeds starting a routine for each feed
 	app.background(func() {
 		// get the feed data
-		err := app.models.FeedManager.MarkFeedAsFetched(feed.ID)
+		err := app.models.FeedManager.MarkFeedAsFetched(app.ctx, feed.ID)
 		if err != nil {
 			app.logger.Info("An error occurred while marking feed as fetched", zap.String("Feed Name", feed.Name), zap.Int64("Feed ID", feed.ID))
 			return
@@ -47,7 +47,7 @@ func (app *application) rssFeedScraper(feed *data.Feed) {
 			}
 		}
 		// store the fetched data into our DB
-		err = app.models.FeedManager.CreateRssFeedPost(rssFeeds, feed.ID)
+		err = app.models.FeedManager.CreateRssFeedPost(app.ctx, rssFeeds, feed.ID)
 		if err != nil {
 			app.logger.Info("An error occurred while saving feed data", zap.String("Feed Name", feed.Name), zap.Int64("Feed ID", feed.ID), zap.String("Error", err.Error()))
 			return

--- a/cmd/api/search_options.go
+++ b/cmd/api/search_options.go
@@ -14,7 +14,7 @@ func (app *application) getDistinctBudgetCategoryHandler(w http.ResponseWriter, 
 	// extract user
 	userID := app.contextGetUser(r).ID
 	// get the data
-	budgetCategories, err := app.models.SearchOptions.GetDistinctBudgetCategory(userID)
+	budgetCategories, err := app.models.SearchOptions.GetDistinctBudgetCategory(r.Context(), userID)
 	if err != nil {
 		switch {
 		case err == data.ErrGeneralRecordNotFound:
@@ -39,7 +39,7 @@ func (app *application) getDistinctBudgetIdBudgetNameHandler(w http.ResponseWrit
 	// extract user
 	userID := app.contextGetUser(r).ID
 	// get the data
-	budgetIDNames, err := app.models.SearchOptions.GetDistinctBudgetIdBudgetName(userID)
+	budgetIDNames, err := app.models.SearchOptions.GetDistinctBudgetIdBudgetName(r.Context(), userID)
 	if err != nil {
 		switch {
 		case err == data.ErrGeneralRecordNotFound:

--- a/cmd/api/users.go
+++ b/cmd/api/users.go
@@ -60,7 +60,7 @@ func (app *application) registerUserHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	// insert our user to the DB
-	err = app.models.Users.CreateNewUser(user, app.config.encryption.key)
+	err = app.models.Users.CreateNewUser(r.Context(), user, app.config.encryption.key)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrDuplicateEmail):
@@ -75,7 +75,7 @@ func (app *application) registerUserHandler(w http.ResponseWriter, r *http.Reque
 	app.logger.Info("registering a new user", zap.String("email", user.Email), zap.Int("user id", int(user.ID)))
 	// After the user record has been created in the database, generate a new activation
 	// token for the user.
-	token, err := app.models.Tokens.New(user.ID, data.DefaultTokenExpiryTime, data.ScopeActivation)
+	token, err := app.models.Tokens.New(r.Context(), user.ID, data.DefaultTokenExpiryTime, data.ScopeActivation)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -148,7 +148,7 @@ func (app *application) activateUserHandler(w http.ResponseWriter, r *http.Reque
 	// Retrieve the details of the user associated with the token using the
 	// GetForToken() method. If no matching record is found, then we let the
 	// client know that the token they provided is not valid.
-	user, err := app.models.Users.GetForToken(data.ScopeActivation, input.TokenPlaintext, app.config.encryption.key)
+	user, err := app.models.Users.GetForToken(r.Context(), data.ScopeActivation, input.TokenPlaintext, app.config.encryption.key)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -164,7 +164,7 @@ func (app *application) activateUserHandler(w http.ResponseWriter, r *http.Reque
 	user.Activated = true
 	// Save the updated user record in our database, checking for any edit conflicts in
 	// the same way that we did for our movie records.
-	err = app.models.Users.UpdateUser(user, app.config.encryption.key)
+	err = app.models.Users.UpdateUser(r.Context(), user, app.config.encryption.key)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrEditConflict):
@@ -176,7 +176,7 @@ func (app *application) activateUserHandler(w http.ResponseWriter, r *http.Reque
 	}
 	// If everything went successfully, then we delete all activation tokens for the
 	// user.
-	err = app.models.Tokens.DeleteAllForUser(data.ScopeActivation, user.ID)
+	err = app.models.Tokens.DeleteAllForUser(r.Context(), data.ScopeActivation, user.ID)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -244,7 +244,7 @@ func (app *application) updateUserPasswordHandler(w http.ResponseWriter, r *http
 	}
 	// Retrieve the details of the user associated with the password reset token,
 	// returning an error message if no matching record was found.
-	user, err := app.models.Users.GetForToken(data.ScopePasswordReset, input.TokenPlaintext, app.config.encryption.key)
+	user, err := app.models.Users.GetForToken(r.Context(), data.ScopePasswordReset, input.TokenPlaintext, app.config.encryption.key)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrGeneralRecordNotFound):
@@ -263,7 +263,7 @@ func (app *application) updateUserPasswordHandler(w http.ResponseWriter, r *http
 	}
 	// Save the updated user record in our database, checking for any edit conflicts as
 	// normal.
-	err = app.models.Users.UpdateUser(user, app.config.encryption.key)
+	err = app.models.Users.UpdateUser(r.Context(), user, app.config.encryption.key)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrEditConflict):
@@ -274,7 +274,7 @@ func (app *application) updateUserPasswordHandler(w http.ResponseWriter, r *http
 		return
 	}
 	// If everything was successful, then delete all password reset tokens for the user.
-	err = app.models.Tokens.DeleteAllForUser(data.ScopePasswordReset, user.ID)
+	err = app.models.Tokens.DeleteAllForUser(r.Context(), data.ScopePasswordReset, user.ID)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -306,13 +306,13 @@ func (app *application) getUserInformationHandler(w http.ResponseWriter, r *http
 	// Get the user from the context
 	user := app.contextGetUser(r)
 	// get the awards for the user
-	awards, err := app.models.AwardManager.GetAllAwardsForUserByID(user.ID)
+	awards, err := app.models.AwardManager.GetAllAwardsForUserByID(r.Context(), user.ID)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
 	}
 	// get the account rating and statistics for the user
-	accountStats, err := app.models.AlgoManager.GetAccountStatisticsByUserId(user.ID, user.CreatedAt, awards)
+	accountStats, err := app.models.AlgoManager.GetAccountStatisticsByUserId(r.Context(), user.ID, user.CreatedAt, awards)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -394,7 +394,7 @@ func (app *application) updateUserInformationHandler(w http.ResponseWriter, r *h
 		return
 	}
 	// update the user in the database
-	err = app.models.Users.UpdateUser(user, app.config.encryption.key)
+	err = app.models.Users.UpdateUser(r.Context(), user, app.config.encryption.key)
 	if err != nil {
 		switch {
 		case errors.Is(err, data.ErrEditConflict):

--- a/internal/data/algo.go
+++ b/internal/data/algo.go
@@ -153,10 +153,11 @@ func (m AlgoManager) CalculateAccountRating(stats AccountStats, awards []*Award)
 	return finalScore
 }
 
-// GetAccountStatisticsByUserId() retrieves all the statistics needed for the account rating calculation
-// We take in the user ID
-func (m AlgoManager) GetAccountStatisticsByUserId(userID int64, accountCreationDate time.Time, awards []*Award) (*EnrichedAccountStats, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultAlgoManDBContextTimeout)
+// GetAccountStatisticsByUserId retrieves all the statistics needed for
+// the account rating calculation. ctx flows from the originating HTTP
+// request.
+func (m AlgoManager) GetAccountStatisticsByUserId(ctx context.Context, userID int64, accountCreationDate time.Time, awards []*Award) (*EnrichedAccountStats, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultAlgoManDBContextTimeout)
 	defer cancel()
 	// get the statistics
 	stats, err := m.DB.GetAccountStatisticsByUserId(ctx, userID)

--- a/internal/data/awards.go
+++ b/internal/data/awards.go
@@ -25,11 +25,11 @@ type Award struct {
 	UpdatedAt     time.Time `json:"updated_at"`
 }
 
-// CreateNewUserAward() is a method that creates a new user award
-// We accept a user ID and an award ID
-// We return a created at and an error if there is one
-func (m AwardManagerModel) CreateNewUserAward(userID int64, awardID int32) (time.Time, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultAwManDBContextTimeout)
+// CreateNewUserAward creates a new user award row. ctx flows from the
+// caller (typically a goroutine driven by the awards background scheduler
+// or a request handler).
+func (m AwardManagerModel) CreateNewUserAward(ctx context.Context, userID int64, awardID int32) (time.Time, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultAwManDBContextTimeout)
 	defer cancel()
 	// create a new user award
 	createdAt, err := m.DB.CreateNewUserAward(ctx, database.CreateNewUserAwardParams{
@@ -42,11 +42,9 @@ func (m AwardManagerModel) CreateNewUserAward(userID int64, awardID int32) (time
 	return createdAt, nil
 }
 
-// GetAwardByAwardID() is a method that returns an award by ID
-// We accept an award ID
-// We return an award and an error if there is one
-func (m AwardManagerModel) GetAwardByAwardID(awardID int32) (*Award, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultAwManDBContextTimeout)
+// GetAwardByAwardID returns an award by ID. ctx flows from the caller.
+func (m AwardManagerModel) GetAwardByAwardID(ctx context.Context, awardID int32) (*Award, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultAwManDBContextTimeout)
 	defer cancel()
 	// get an award by ID
 	awardRow, err := m.DB.GetAwardByAwardID(ctx, awardID)
@@ -58,10 +56,9 @@ func (m AwardManagerModel) GetAwardByAwardID(awardID int32) (*Award, error) {
 	return award, nil
 }
 
-// GetAllAwards() is a method that returns all the awards
-// We return a *slice of awards and an error if there is one
-func (m AwardManagerModel) GetAllAwards() ([]*Award, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultAwManDBContextTimeout)
+// GetAllAwards returns all awards. ctx flows from the caller.
+func (m AwardManagerModel) GetAllAwards(ctx context.Context) ([]*Award, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultAwManDBContextTimeout)
 	defer cancel()
 	// get all the awards
 	awardRows, err := m.DB.GetAllAwards(ctx)
@@ -81,11 +78,10 @@ func (m AwardManagerModel) GetAllAwards() ([]*Award, error) {
 	return awards, nil
 }
 
-// GetAllAwardsForUserByID() is a method that returns all the awards for a user by ID
-// We accept a user ID
-// We return a *slice of awards and an error if there is one
-func (m AwardManagerModel) GetAllAwardsForUserByID(userID int64) ([]*Award, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultAwManDBContextTimeout)
+// GetAllAwardsForUserByID returns all the awards for a user by ID. ctx
+// flows from the caller.
+func (m AwardManagerModel) GetAllAwardsForUserByID(ctx context.Context, userID int64) ([]*Award, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultAwManDBContextTimeout)
 	defer cancel()
 	// get all the awards for a user by ID
 	awardRows, err := m.DB.GetAllAwardsForUserByID(ctx, userID)

--- a/internal/data/comments.go
+++ b/internal/data/comments.go
@@ -91,10 +91,10 @@ func ValidateCommentReaction(v *validator.Validator, reaction *CommentReaction) 
 	ValidateURLID(v, reaction.CommentID, "comment_id")
 }
 
-// GetCommentsWithReactionsByAssociatedId gets all comments with reactions and user information
-// We take in the user ID, the associated type, and the associated ID and return an enriched comment slice and an error if there is one
-func (m CommentManagerModel) GetCommentsWithReactionsByAssociatedId(userID int64, associatedType database.CommentAssociatedType, associatedID int64, filters Filters) ([]*EnrichedComment, Metadata, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultCommManDBContextTimeout)
+// GetCommentsWithReactionsByAssociatedId gets all comments with reactions
+// and user information. ctx flows from the originating HTTP request.
+func (m CommentManagerModel) GetCommentsWithReactionsByAssociatedId(ctx context.Context, userID int64, associatedType database.CommentAssociatedType, associatedID int64, filters Filters) ([]*EnrichedComment, Metadata, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultCommManDBContextTimeout)
 	defer cancel()
 	// get the comments
 	comments, err := m.DB.GetCommentsWithReactionsByAssociatedId(ctx, database.GetCommentsWithReactionsByAssociatedIdParams{
@@ -127,10 +127,10 @@ func (m CommentManagerModel) GetCommentsWithReactionsByAssociatedId(userID int64
 	return enrichedComments, metadata, nil
 }
 
-// CreateNewComment creates a new comment in the database
-// We take in the user ID and the comment struct and return an error if there is one
-func (m CommentManagerModel) CreateNewComment(userID int64, comment *Comment) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultCommManDBContextTimeout)
+// CreateNewComment creates a new comment in the database. ctx flows from
+// the originating HTTP request.
+func (m CommentManagerModel) CreateNewComment(ctx context.Context, userID int64, comment *Comment) error {
+	ctx, cancel := contextGenerator(ctx, DefaultCommManDBContextTimeout)
 	defer cancel()
 	// insert
 	createdFeed, err := m.DB.CreateNewComment(ctx, database.CreateNewCommentParams{
@@ -157,11 +157,10 @@ func (m CommentManagerModel) CreateNewComment(userID int64, comment *Comment) er
 	return nil
 }
 
-// UpdateComment updates a comment in the database
-// We take in the user ID and the comment struct which includes the comment and version
-// We return an error if there is one
-func (m CommentManagerModel) UpdateComment(userID int64, comment *Comment) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultCommManDBContextTimeout)
+// UpdateComment updates a comment in the database. ctx flows from the
+// originating HTTP request.
+func (m CommentManagerModel) UpdateComment(ctx context.Context, userID int64, comment *Comment) error {
+	ctx, cancel := contextGenerator(ctx, DefaultCommManDBContextTimeout)
 	defer cancel()
 	// update
 	updatedFeed, err := m.DB.UpdateComment(ctx, database.UpdateCommentParams{
@@ -185,10 +184,10 @@ func (m CommentManagerModel) UpdateComment(userID int64, comment *Comment) error
 	return nil
 }
 
-// DeleteComment deletes a comment in the database
-// We take in the user ID and the comment ID and return an error if there is one
-func (m CommentManagerModel) DeleteComment(userID, commentID int64) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultCommManDBContextTimeout)
+// DeleteComment deletes a comment in the database. ctx flows from the
+// originating HTTP request.
+func (m CommentManagerModel) DeleteComment(ctx context.Context, userID, commentID int64) error {
+	ctx, cancel := contextGenerator(ctx, DefaultCommManDBContextTimeout)
 	defer cancel()
 	// delete
 	_, err := m.DB.DeleteComment(ctx, database.DeleteCommentParams{
@@ -207,10 +206,10 @@ func (m CommentManagerModel) DeleteComment(userID, commentID int64) error {
 	return nil
 }
 
-// GetCommentById gets a comment by its ID
-// We take in the comment ID and return the comment and an error if there is one
-func (m CommentManagerModel) GetCommentById(userID, commentID int64) (*Comment, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultCommManDBContextTimeout)
+// GetCommentById gets a comment by its ID. ctx flows from the
+// originating HTTP request.
+func (m CommentManagerModel) GetCommentById(ctx context.Context, userID, commentID int64) (*Comment, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultCommManDBContextTimeout)
 	defer cancel()
 	// get the comment
 	commentRow, err := m.DB.GetCommentById(ctx, database.GetCommentByIdParams{
@@ -231,10 +230,10 @@ func (m CommentManagerModel) GetCommentById(userID, commentID int64) (*Comment, 
 	return comment, nil
 }
 
-// CreateNewReaction creates a new reaction for a specific comment ID
-// We take in the user ID and a commentreaction struct and return an error if there is one
-func (m CommentManagerModel) CreateNewReaction(userID int64, reaction *CommentReaction) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultCommManDBContextTimeout)
+// CreateNewReaction creates a new reaction for a specific comment ID.
+// ctx flows from the originating HTTP request.
+func (m CommentManagerModel) CreateNewReaction(ctx context.Context, userID int64, reaction *CommentReaction) error {
+	ctx, cancel := contextGenerator(ctx, DefaultCommManDBContextTimeout)
 	defer cancel()
 	// insert
 	createdReaction, err := m.DB.CreateNewReaction(ctx, database.CreateNewReactionParams{
@@ -259,10 +258,10 @@ func (m CommentManagerModel) CreateNewReaction(userID int64, reaction *CommentRe
 	return nil
 }
 
-// DeleteReaction deletes a reaction for a specific comment ID
-// We take the userID and the Comment ID and return an error if there is one
-func (m CommentManagerModel) DeleteReaction(userID, commentID int64) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultCommManDBContextTimeout)
+// DeleteReaction deletes a reaction for a specific comment ID. ctx flows
+// from the originating HTTP request.
+func (m CommentManagerModel) DeleteReaction(ctx context.Context, userID, commentID int64) error {
+	ctx, cancel := contextGenerator(ctx, DefaultCommManDBContextTimeout)
 	defer cancel()
 	// delete
 	_, err := m.DB.DeleteReaction(ctx, database.DeleteReactionParams{

--- a/internal/data/feeds.go
+++ b/internal/data/feeds.go
@@ -139,11 +139,11 @@ func (m FeedManagerModel) MapFeedTypeToConstant(feedType string) (database.FeedT
 	}
 }
 
-// CreateNewFeed() is a method that creates a new feed
-// Feeds will be used to get news information that will be displayed to the user
-// We will take in a *feed, enrich with new data and return an error.
-func (m FeedManagerModel) CreateNewFeed(userID int64, feed *Feed) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+// CreateNewFeed creates a new feed. Feeds are used to surface news
+// information to the user. We take a *Feed, enrich it with new data, and
+// return an error. ctx flows from the originating HTTP request.
+func (m FeedManagerModel) CreateNewFeed(ctx context.Context, userID int64, feed *Feed) error {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	// insert
 	feedInfo, err := m.DB.CreateNewFeed(ctx, database.CreateNewFeedParams{
@@ -175,10 +175,11 @@ func (m FeedManagerModel) CreateNewFeed(userID int64, feed *Feed) error {
 	return nil
 }
 
-// UpdateFeed() is a method that will Update an existing Feed
-// We recieve a userID and *feed, and use that to update the feed
-func (m FeedManagerModel) UpdateFeed(userID int64, feed *Feed) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+// UpdateFeed updates an existing feed. We receive a userID and *Feed
+// and use that to perform the update. ctx flows from the originating
+// HTTP request.
+func (m FeedManagerModel) UpdateFeed(ctx context.Context, userID int64, feed *Feed) error {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	// update
 	updatedInfo, err := m.DB.UpdateFeed(ctx, database.UpdateFeedParams{
@@ -209,11 +210,10 @@ func (m FeedManagerModel) UpdateFeed(userID int64, feed *Feed) error {
 	return nil
 }
 
-//	DeleteFeedByID() is a method that will delete a feed by its ID
-//
-// We will recieve a feedID and return a feedID and an error
-func (m FeedManagerModel) DeleteFeedByID(userID, feedID int64) (*int64, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+// DeleteFeedByID deletes a feed by its ID. ctx flows from the
+// originating HTTP request.
+func (m FeedManagerModel) DeleteFeedByID(ctx context.Context, userID, feedID int64) (*int64, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	// delete
 	feedID, err := m.DB.DeleteFeedByID(ctx, database.DeleteFeedByIDParams{
@@ -232,10 +232,10 @@ func (m FeedManagerModel) DeleteFeedByID(userID, feedID int64) (*int64, error) {
 	return &feedID, nil
 }
 
-// GetFeedByID() is a method that will return a feed by its ID
-// We will recieve a feedID and return a *feed and an error
-func (m FeedManagerModel) GetFeedByID(feedID int64) (*Feed, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+// GetFeedByID returns a feed by its ID. ctx flows from the originating
+// HTTP request.
+func (m FeedManagerModel) GetFeedByID(ctx context.Context, feedID int64) (*Feed, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	// get feed
 	feedRow, err := m.DB.GetFeedByID(ctx, feedID)
@@ -253,11 +253,12 @@ func (m FeedManagerModel) GetFeedByID(feedID int64) (*Feed, error) {
 	return feed, nil
 }
 
-// GetNextFeedsToFetch() is a method that will return the next feeds to fetch
-// We will recieve a limit and return a slice of *feed and an error
-func (m FeedManagerModel) GetNextFeedsToFetch(limit int32) ([]*Feed, error) {
+// GetNextFeedsToFetch returns the next feeds to fetch. We receive a limit
+// and return a slice of *Feed. ctx flows from the caller (the RSS scraper
+// goroutine, which derives from app.ctx).
+func (m FeedManagerModel) GetNextFeedsToFetch(ctx context.Context, limit int32) ([]*Feed, error) {
 	fmt.Println("Getting next feeds to fetch: ", limit)
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	// get feeds
 	feedRows, err := m.DB.GetNextFeedsToFetch(ctx, limit)
@@ -276,10 +277,10 @@ func (m FeedManagerModel) GetNextFeedsToFetch(limit int32) ([]*Feed, error) {
 	return feeds, nil
 }
 
-// MarkFeedAsFetched() is a method that will mark a feed as fetched
-// We return an error if there is one
-func (m FeedManagerModel) MarkFeedAsFetched(feedID int64) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+// MarkFeedAsFetched marks a feed as fetched. ctx flows from the caller
+// (the RSS scraper goroutine, which derives from app.ctx).
+func (m FeedManagerModel) MarkFeedAsFetched(ctx context.Context, feedID int64) error {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	// mark feed as fetched
 	_, err := m.DB.MarkFeedAsFetched(ctx, feedID)
@@ -293,21 +294,22 @@ func (m FeedManagerModel) MarkFeedAsFetched(feedID int64) error {
 // ==============================================================================================
 // Posts
 // ==============================================================================================
-func (m FeedManagerModel) CreateRssFeedPost(rssFeed *RSSFeed, feedID int64) error {
-	// Get channel Info
+// CreateRssFeedPost inserts the parsed items from a fetched RSS feed.
+// ctx flows from the RSS scraper goroutine (derived from app.ctx) so the
+// in-flight INSERTs are cancelled cleanly on graceful shutdown.
+func (m FeedManagerModel) CreateRssFeedPost(ctx context.Context, rssFeed *RSSFeed, feedID int64) error {
 	ChannelTitle := rssFeed.Channel.Title
 	ChannelUrl := rssFeed.Channel.Link
 	ChannelDescription := rssFeed.Channel.Description
 	ChannelLanguage := rssFeed.Channel.Language
 	for _, item := range rssFeed.Channel.Item {
-		// We use dateparse to parse a variety of possible date/time data rather than using
-		// the time.Parse() function which is more strict.
-		// We use ParseAny()
+		// We use dateparse to parse a variety of possible date/time
+		// formats rather than time.Parse() which is more strict.
 		publishedAt, err := dateparse.ParseAny(item.PubDate)
 		if err != nil {
 			continue
 		}
-		_, err = m.DB.CreateRssFeedPost(context.Background(), database.CreateRssFeedPostParams{
+		_, err = m.DB.CreateRssFeedPost(ctx, database.CreateRssFeedPostParams{
 			// Channel info
 			Channeltitle:       ChannelTitle,
 			Channelurl:         sql.NullString{String: ChannelUrl, Valid: ChannelUrl != ""},
@@ -331,10 +333,10 @@ func (m FeedManagerModel) CreateRssFeedPost(rssFeed *RSSFeed, feedID int64) erro
 	return nil
 }
 
-// CreateNewFavoriteOnPost() is a method that will create a new favorite on a post
-// We acept a new post favorite and return an id, createdat and an error
-func (m FeedManagerModel) CreateNewFavoriteOnPost(userID int64, rssFavoritePost *RSSPostFavorite) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+// CreateNewFavoriteOnPost creates a new favorite on a post. ctx flows
+// from the originating HTTP request.
+func (m FeedManagerModel) CreateNewFavoriteOnPost(ctx context.Context, userID int64, rssFavoritePost *RSSPostFavorite) error {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	// create
 	favoriteInfo, err := m.DB.CreateNewFavoriteOnPost(ctx, database.CreateNewFavoriteOnPostParams{
@@ -357,10 +359,10 @@ func (m FeedManagerModel) CreateNewFavoriteOnPost(userID int64, rssFavoritePost 
 	return nil
 }
 
-// DeleteFavoriteOnPost() is a method that will delete a favorite on a post
-// We will recieve a userID, postID and return a postID and an error
-func (m FeedManagerModel) DeleteFavoriteOnPost(userID, postID int64) (*int64, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+// DeleteFavoriteOnPost deletes a favorite on a post. ctx flows from the
+// originating HTTP request.
+func (m FeedManagerModel) DeleteFavoriteOnPost(ctx context.Context, userID, postID int64) (*int64, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	// delete
 	postID, err := m.DB.DeleteFavoriteOnPost(ctx, database.DeleteFavoriteOnPostParams{
@@ -379,10 +381,10 @@ func (m FeedManagerModel) DeleteFavoriteOnPost(userID, postID int64) (*int64, er
 	return &postID, nil
 }
 
-// GetRssFeedPostByID() is a method that will return a post by its ID
-// We will recieve a postID and return a *RSSPostFavorite and an error
-func (m FeedManagerModel) GetRssFeedPostByID(postID int64) (*RSSFeed, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+// GetRssFeedPostByID returns a post by its ID. ctx flows from the
+// originating HTTP request.
+func (m FeedManagerModel) GetRssFeedPostByID(ctx context.Context, postID int64) (*RSSFeed, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	// get post
 	postRow, err := m.DB.GetRssFeedPostByID(ctx, postID)
@@ -400,11 +402,12 @@ func (m FeedManagerModel) GetRssFeedPostByID(postID int64) (*RSSFeed, error) {
 	return post, nil
 }
 
-// GetAllRSSPostWithFavoriteTag() is a method that will return all posts with a favorite tag
-// This will return a slice of *RSSPostWithFavoriteTag, a metadata struct and an error
-// It supports both search and pagination
-func (m FeedManagerModel) GetAllRSSPostWithFavoriteTag(userID, feedID int64, itemName, postCategory string, filters Filters) ([]*RSSPostWithFavoriteTag, Metadata, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+// GetAllRSSPostWithFavoriteTag returns all posts with a favorite tag.
+// Returns a slice of *RSSPostWithFavoriteTag, a metadata struct, and an
+// error. Supports both search and pagination. ctx flows from the
+// originating HTTP request.
+func (m FeedManagerModel) GetAllRSSPostWithFavoriteTag(ctx context.Context, userID, feedID int64, itemName, postCategory string, filters Filters) ([]*RSSPostWithFavoriteTag, Metadata, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	// get all posts
 	postRows, err := m.DB.GetAllRSSPostWithFavoriteTag(ctx, database.GetAllRSSPostWithFavoriteTagParams{

--- a/internal/data/financial_groups.go
+++ b/internal/data/financial_groups.go
@@ -292,9 +292,9 @@ func ValidateGroupExpense(v *validator.Validator, expense *GroupExpense) {
 
 // CheckIfGroupMembersAreMaxedOut() checks if the group has reached its maximum member count
 // We will take the group ID and return a boolean and an error
-func (m FinancialGroupManagerModel) CheckIfGroupMembersAreMaxedOut(groupID int64) (bool, error) {
+func (m FinancialGroupManagerModel) CheckIfGroupMembersAreMaxedOut(ctx context.Context, groupID int64) (bool, error) {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// check the group
 	memberData, err := m.DB.CheckIfGroupMembersAreMaxedOut(ctx, sql.NullInt64{Int64: groupID, Valid: true})
@@ -309,9 +309,9 @@ func (m FinancialGroupManagerModel) CheckIfGroupMembersAreMaxedOut(groupID int64
 
 // GetGroupById() retrieves a group by its ID
 // We will take the group ID as an argument and return the group and an error
-func (m FinancialGroupManagerModel) GetGroupById(groupID int64) (*Group, error) {
+func (m FinancialGroupManagerModel) GetGroupById(ctx context.Context, groupID int64) (*Group, error) {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// get the group
 	returnedGroup, err := m.DB.GetGroupById(ctx, groupID)
@@ -333,8 +333,8 @@ func (m FinancialGroupManagerModel) GetGroupById(groupID int64) (*Group, error) 
 // This endpoint supports pagination as well ass a name search for the group name
 // We take in a filter as well as a name's query
 // We return an []*Enriched, Metadata and error if any occurred
-func (m FinancialGroupManagerModel) GetAllPublicGroups(userID int64, groupName string, filters Filters) ([]*EnrichedPublicGroup, Metadata, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+func (m FinancialGroupManagerModel) GetAllPublicGroups(ctx context.Context, userID int64, groupName string, filters Filters) ([]*EnrichedPublicGroup, Metadata, error) {
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// get the group info
 	publicGroups, err := m.DB.GetAllPublicGroups(ctx, database.GetAllPublicGroupsParams{
@@ -385,8 +385,8 @@ func (m FinancialGroupManagerModel) GetAllPublicGroups(userID int64, groupName s
 
 // GetAllGroupsCreatedByUser() retrieves all the groups created by a user
 // We will take the user ID as an argument and return [] EnrichedGroup and an error
-func (m FinancialGroupManagerModel) GetAllGroupsCreatedByUser(userID int64) ([]*EnrichedGroup, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+func (m FinancialGroupManagerModel) GetAllGroupsCreatedByUser(ctx context.Context, userID int64) ([]*EnrichedGroup, error) {
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// get the groups
 	groups, err := m.DB.GetAllGroupsCreatedByUser(ctx, sql.NullInt64{Int64: userID, Valid: true})
@@ -428,9 +428,9 @@ func (m FinancialGroupManagerModel) GetAllGroupsCreatedByUser(userID int64) ([]*
 // Pending invitations jsnon array (which will be unmarshalled to the GroupInvitation struct)
 // The group goals json array (which will be unmarshalled to the GroupGoal struct)
 // And the totals for the total group transactions, total group expenses and the goal_with_most_transactions
-func (m FinancialGroupManagerModel) GetDetailedGroupById(userID, groupID int64) (*DetailedGroup, error) {
+func (m FinancialGroupManagerModel) GetDetailedGroupById(ctx context.Context, userID, groupID int64) (*DetailedGroup, error) {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// get the group
 	groupDetails, err := m.DB.GetDetailedGroupById(ctx, database.GetDetailedGroupByIdParams{
@@ -456,8 +456,8 @@ func (m FinancialGroupManagerModel) GetDetailedGroupById(userID, groupID int64) 
 
 // GetAllGroupsUserIsMemberOf() retrieves all the groups a user is a member of
 // We will take the user ID as an argument and return [] EnrichedGroup and an error
-func (m FinancialGroupManagerModel) GetAllGroupsUserIsMemberOf(userID int64) ([]*EnrichedGroup, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+func (m FinancialGroupManagerModel) GetAllGroupsUserIsMemberOf(ctx context.Context, userID int64) ([]*EnrichedGroup, error) {
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// get the groups
 	groups, err := m.DB.GetAllGroupsUserIsMemberOf(ctx, sql.NullInt64{Int64: userID, Valid: true})
@@ -496,9 +496,9 @@ func (m FinancialGroupManagerModel) GetAllGroupsUserIsMemberOf(userID int64) ([]
 
 // GetGroupTransactionsByGroupId() retrieves all the group transactions by the group ID, user ID and the FILTERs
 // We will take the group ID, user ID, and the filters as arguments and return [] EnrichedGroupTransaction, metadata and an error
-func (m FinancialGroupManagerModel) GetGroupTransactionsByGroupId(userID, groupID, goalID int64, filters Filters) (*EnrichedGroupTransaction, Metadata, error) {
+func (m FinancialGroupManagerModel) GetGroupTransactionsByGroupId(ctx context.Context, userID, groupID, goalID int64, filters Filters) (*EnrichedGroupTransaction, Metadata, error) {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 
 	// get the group transactions
@@ -554,9 +554,9 @@ func (m FinancialGroupManagerModel) GetGroupTransactionsByGroupId(userID, groupI
 
 // GetGroupExpensesByGroupId() retrieves all the group expenses by the group ID, user ID, Optional search by expense category and the FILTERs
 // We will take the group ID, user ID, expense category and the filters as arguments and return *EnrichedExpenses, metadata and an error
-func (m FinancialGroupManagerModel) GetGroupExpensesByGroupId(userID, groupID int64, category string, filters Filters) (*EnrichedExpense, Metadata, error) {
+func (m FinancialGroupManagerModel) GetGroupExpensesByGroupId(ctx context.Context, userID, groupID int64, category string, filters Filters) (*EnrichedExpense, Metadata, error) {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 
 	// get the group expenses
@@ -608,9 +608,9 @@ func (m FinancialGroupManagerModel) GetGroupExpensesByGroupId(userID, groupID in
 
 // CreateNewUserGroup() creates a new user group in the database and returns the ID of the new group
 // We will take a pointer to the Group struct as an argument and return an error
-func (m FinancialGroupManagerModel) CreateNewUserGroup(userID int64, group *Group) error {
+func (m FinancialGroupManagerModel) CreateNewUserGroup(ctx context.Context, userID int64, group *Group) error {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// insert the data
 	groupInformation, err := m.DB.CreateNewUserGroup(ctx, database.CreateNewUserGroupParams{
@@ -645,9 +645,9 @@ func (m FinancialGroupManagerModel) CreateNewUserGroup(userID int64, group *Grou
 // Only Admins can perform this, even though we will have a middleware for this, we
 // the update also includes the creator's user ID.
 // We expect the group ID, the creator's user ID, and the group struct to be passed in
-func (m FinancialGroupManagerModel) UpdateUserGroup(groupID, creatorUserID int64, group *Group) error {
+func (m FinancialGroupManagerModel) UpdateUserGroup(ctx context.Context, groupID, creatorUserID int64, group *Group) error {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// update the data
 	updatedAt, err := m.DB.UpdateUserGroup(ctx, database.UpdateUserGroupParams{
@@ -682,9 +682,9 @@ func (m FinancialGroupManagerModel) UpdateUserGroup(groupID, creatorUserID int64
 // We take in the groupID, the userID, the new role as well as the user ID of the person performing the action
 // This is to ensure that only the group admin or moderator can perform this action
 // We return the updated_At time and an error if any
-func (m FinancialGroupManagerModel) UpdateGroupUserRole(groupID, userID, updaterUserID int64, newRole database.MembershipRole) (time.Time, error) {
+func (m FinancialGroupManagerModel) UpdateGroupUserRole(ctx context.Context, groupID, userID, updaterUserID int64, newRole database.MembershipRole) (time.Time, error) {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// update the data
 	updatedAt, err := m.DB.UpdateGroupUserRole(ctx, database.UpdateGroupUserRoleParams{
@@ -707,9 +707,9 @@ func (m FinancialGroupManagerModel) UpdateGroupUserRole(groupID, userID, updater
 
 // GetGroupInvitationById() retrieves a group invitation by its ID
 // We also take in the invitee user email and return the group invitation and an error
-func (m FinancialGroupManagerModel) GetGroupInvitationById(groupID int64, inviteeUserEmail string) (*GroupInvitation, error) {
+func (m FinancialGroupManagerModel) GetGroupInvitationById(ctx context.Context, groupID int64, inviteeUserEmail string) (*GroupInvitation, error) {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// get the group invitation
 	groupInvitation, err := m.DB.GetGroupInvitationById(ctx, database.GetGroupInvitationByIdParams{
@@ -732,9 +732,9 @@ func (m FinancialGroupManagerModel) GetGroupInvitationById(groupID int64, invite
 
 // UpdateGroupInvitationStatus() updates the status of a group invitation
 // We just take the new status and return an error
-func (m FinancialGroupManagerModel) UpdateGroupInvitationStatus(newstatusinvitation database.InvitationStatusType, invitation *GroupInvitation) error {
+func (m FinancialGroupManagerModel) UpdateGroupInvitationStatus(ctx context.Context, newstatusinvitation database.InvitationStatusType, invitation *GroupInvitation) error {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// update the data
 	respondedAt, err := m.DB.UpdateGroupInvitationStatus(ctx, database.UpdateGroupInvitationStatusParams{
@@ -761,9 +761,9 @@ func (m FinancialGroupManagerModel) UpdateGroupInvitationStatus(newstatusinvitat
 // This allows a group ADMIN/ Moderator to invite users to their group
 // and will only work well when a group is private not public.
 // We take in a GroupInvitation struct and return an error
-func (m FinancialGroupManagerModel) CreateNewGroupInvitation(userID int64, invitation *GroupInvitation) error {
+func (m FinancialGroupManagerModel) CreateNewGroupInvitation(ctx context.Context, userID int64, invitation *GroupInvitation) error {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// insert the data
 	inviteDetail, err := m.DB.CreateNewGroupInvitation(ctx, database.CreateNewGroupInvitationParams{
@@ -793,9 +793,9 @@ func (m FinancialGroupManagerModel) CreateNewGroupInvitation(userID int64, invit
 // CreateNewPublicMembership() creates a new public membership for a user
 // We only require the user ID and the group ID
 // This is used when a user joins a public group
-func (m FinancialGroupManagerModel) CreateNewPublicMembership(userID, groupID int64) (int64, error) {
+func (m FinancialGroupManagerModel) CreateNewPublicMembership(ctx context.Context, userID, groupID int64) (int64, error) {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// insert the data
 	createdUser, err := m.DB.CreateNewPublicMembership(ctx, database.CreateNewPublicMembershipParams{
@@ -816,9 +816,9 @@ func (m FinancialGroupManagerModel) CreateNewPublicMembership(userID, groupID in
 
 // UpdateExpiredGroupInvitations() updates the status of expired group invitations
 // It is used by a cronjob, dauily to update the status of expired group invitations
-func (m FinancialGroupManagerModel) UpdateExpiredGroupInvitations() error {
+func (m FinancialGroupManagerModel) UpdateExpiredGroupInvitations(ctx context.Context) error {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// update the data
 	err := m.DB.UpdateExpiredGroupInvitations(ctx)
@@ -831,9 +831,9 @@ func (m FinancialGroupManagerModel) UpdateExpiredGroupInvitations() error {
 
 // CreateNewGroupGoal() creates a new group goal in the database
 // We take in a GroupGoal struct and return an error
-func (m FinancialGroupManagerModel) CreateNewGroupGoal(userID int64, groupGoal *GroupGoal) error {
+func (m FinancialGroupManagerModel) CreateNewGroupGoal(ctx context.Context, userID int64, groupGoal *GroupGoal) error {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// insert the data
 	goalDetail, err := m.DB.CreateNewGroupGoal(ctx, database.CreateNewGroupGoalParams{
@@ -868,9 +868,9 @@ func (m FinancialGroupManagerModel) CreateNewGroupGoal(userID int64, groupGoal *
 // Add this to the require permission group:admin/moderator
 // Even if the goals can be updates, only the name, deadline and description can be updated
 // This is to prevent any form of fraud and increase transparency in the group
-func (m FinancialGroupManagerModel) UpdateGroupGoal(userID int64, groupGoal *GroupGoal) error {
+func (m FinancialGroupManagerModel) UpdateGroupGoal(ctx context.Context, userID int64, groupGoal *GroupGoal) error {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// update the data
 	updatedAt, err := m.DB.UpdateGroupGoal(ctx, database.UpdateGroupGoalParams{
@@ -897,9 +897,9 @@ func (m FinancialGroupManagerModel) UpdateGroupGoal(userID int64, groupGoal *Gro
 
 // GetGroupGoalById() retrieves a group goal by its ID
 // We take in the group goal ID and return the group goal and an error
-func (m FinancialGroupManagerModel) GetGroupGoalById(groupGoalID int64) (*GroupGoal, error) {
+func (m FinancialGroupManagerModel) GetGroupGoalById(ctx context.Context, groupGoalID int64) (*GroupGoal, error) {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// get the group goal
 	groupGoal, err := m.DB.GetGroupGoalById(ctx, groupGoalID)
@@ -919,9 +919,9 @@ func (m FinancialGroupManagerModel) GetGroupGoalById(groupGoalID int64) (*GroupG
 
 // CreateNewGroupTransaction() creates a new group transaction in the database
 // We take in a GroupTransaction struct and return an error
-func (m FinancialGroupManagerModel) CreateNewGroupTransaction(userID int64, transaction *GroupTransaction) error {
+func (m FinancialGroupManagerModel) CreateNewGroupTransaction(ctx context.Context, userID int64, transaction *GroupTransaction) error {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// insert the data
 	transactionDetail, err := m.DB.CreateNewGroupTransaction(ctx, database.CreateNewGroupTransactionParams{
@@ -951,9 +951,9 @@ func (m FinancialGroupManagerModel) CreateNewGroupTransaction(userID int64, tran
 // DeleteGroupTransaction() deletes a group transaction by its ID and member_id/user_id of
 // the person who created the transaction
 // We return the ID of the deleted transaction and an error especially for sql no rows
-func (m FinancialGroupManagerModel) DeleteGroupTransaction(userID, transactionID int64) (int64, error) {
+func (m FinancialGroupManagerModel) DeleteGroupTransaction(ctx context.Context, userID, transactionID int64) (int64, error) {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// delete the data
 	deletedTransactionID, err := m.DB.DeleteGroupTransaction(ctx, database.DeleteGroupTransactionParams{
@@ -975,9 +975,9 @@ func (m FinancialGroupManagerModel) DeleteGroupTransaction(userID, transactionID
 // CheckIfGroupExistsAndUserIsMember() checks whether a group exists and if the user is a member
 // of that group. We take in the user's ID number and the group ID number and return an error
 // of the record not found
-func (m FinancialGroupManagerModel) CheckIfGroupExistsAndUserIsMember(userID, groupID int64) error {
+func (m FinancialGroupManagerModel) CheckIfGroupExistsAndUserIsMember(ctx context.Context, userID, groupID int64) error {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// check the group
 	_, err := m.DB.CheckIfGroupExistsAndUserIsMember(ctx, database.CheckIfGroupExistsAndUserIsMemberParams{
@@ -998,9 +998,9 @@ func (m FinancialGroupManagerModel) CheckIfGroupExistsAndUserIsMember(userID, gr
 
 // CreateNewGroupExpense() creates a new group expense in the database
 // We take in pointers to a group expense and userID and return an error if any
-func (m FinancialGroupManagerModel) CreateNewGroupExpense(userID int64, expense *GroupExpense) error {
+func (m FinancialGroupManagerModel) CreateNewGroupExpense(ctx context.Context, userID int64, expense *GroupExpense) error {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// insert the data
 	expenseDetail, err := m.DB.CreateNewGroupExpense(ctx, database.CreateNewGroupExpenseParams{
@@ -1025,9 +1025,9 @@ func (m FinancialGroupManagerModel) CreateNewGroupExpense(userID int64, expense 
 // DeleteGroupExpense() deletes a group expense by its ID and member_id/user_id of
 // the person who created the expense
 // We return the ID of the deleted expense and an error especially for sql no rows
-func (m FinancialGroupManagerModel) DeleteGroupExpense(userID, expenseID int64) (int64, error) {
+func (m FinancialGroupManagerModel) DeleteGroupExpense(ctx context.Context, userID, expenseID int64) (int64, error) {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// delete the data
 	deletedExpenseID, err := m.DB.DeleteGroupExpense(ctx, database.DeleteGroupExpenseParams{
@@ -1049,9 +1049,9 @@ func (m FinancialGroupManagerModel) DeleteGroupExpense(userID, expenseID int64) 
 // AdminDeleteGroupMember() allows an ADMIN user to remove/delete/boot a user from the group
 // We take in a group ID, the user ID of the user to be removed and the user ID of the group admin.
 // we return the deleted user's ID and an error if any
-func (m FinancialGroupManagerModel) AdminDeleteGroupMember(adminID, groupID, memberID int64) (int64, error) {
+func (m FinancialGroupManagerModel) AdminDeleteGroupMember(ctx context.Context, adminID, groupID, memberID int64) (int64, error) {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// delete the data
 	deletedMemberID, err := m.DB.AdminDeleteGroupMember(ctx, database.AdminDeleteGroupMemberParams{
@@ -1073,9 +1073,9 @@ func (m FinancialGroupManagerModel) AdminDeleteGroupMember(adminID, groupID, mem
 
 // UserLeaveGroup() allows a user to leave a group and delete themselves from the group
 // We take in the user ID and the group ID and return an error if any as well as the deleted user ID
-func (m FinancialGroupManagerModel) UserLeaveGroup(userID, groupID int64) (int64, error) {
+func (m FinancialGroupManagerModel) UserLeaveGroup(ctx context.Context, userID, groupID int64) (int64, error) {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// delete the data
 	deletedMemberID, err := m.DB.UserLeaveGroup(ctx, database.UserLeaveGroupParams{
@@ -1097,9 +1097,9 @@ func (m FinancialGroupManagerModel) UserLeaveGroup(userID, groupID int64) (int64
 // DeleteNonPendingGroupInvitationsForUser() deletes all non pending group invitations for a user for
 // as specific group. This prevents duplicate invitations which may cause constraint violations down the line
 // We take in the invitee email and the group id. We return an error if any
-func (m FinancialGroupManagerModel) DeleteNonPendingGroupInvitationsForUser(groupID int64, inviteeEmail string) error {
+func (m FinancialGroupManagerModel) DeleteNonPendingGroupInvitationsForUser(ctx context.Context, groupID int64, inviteeEmail string) error {
 	// get our context
-	ctx, cancel := contextGenerator(context.Background(), DefualtFinManGroupsContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefualtFinManGroupsContextTimeout)
 	defer cancel()
 	// delete the data
 	err := m.DB.DeleteNonPendingGroupInvitationsForUser(ctx, database.DeleteNonPendingGroupInvitationsForUserParams{

--- a/internal/data/financial_management.go
+++ b/internal/data/financial_management.go
@@ -303,8 +303,8 @@ func ValidateBudgetUpdate(v *validator.Validator, budget *Budget) {
 // CreateNewBudget() creates a new budget record in the database
 // It takes a pointer to a Budget struct and returns an error if
 // the operation fails.
-func (m FinancialManagerModel) CreateNewBudget(newBudget *Budget) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+func (m FinancialManagerModel) CreateNewBudget(ctx context.Context, newBudget *Budget) error {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	budget, err := m.DB.CreateNewBudget(ctx, database.CreateNewBudgetParams{
 		UserID:         newBudget.UserID,
@@ -330,8 +330,8 @@ func (m FinancialManagerModel) CreateNewBudget(newBudget *Budget) error {
 // getBudgetGoalExpenseSummary() is a helper method that will be used to retrieve
 // a summary of a user's budget, goals and expenses
 // We will return a *EnrichedBudget struct and an error if the operation fails.
-func (m FinancialManagerModel) GetBudgetGoalExpenseSummary(userID int64) ([]*EnrichedBudgetSummary, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+func (m FinancialManagerModel) GetBudgetGoalExpenseSummary(ctx context.Context, userID int64) ([]*EnrichedBudgetSummary, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	// Fetch the budget from the database
 	enrichedBugetRows, err := m.DB.GetBudgetGoalExpenseSummary(ctx, userID)
@@ -358,8 +358,8 @@ func (m FinancialManagerModel) GetBudgetGoalExpenseSummary(userID int64) ([]*Enr
 
 // DeleteBudgetByID() deletes a budget record from the database by its ID
 // It takes the budget ID as a parameter and returns an error if the operation fails.
-func (m FinancialManagerModel) DeleteBudgetByID(userID, budgetID int64) (*int64, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+func (m FinancialManagerModel) DeleteBudgetByID(ctx context.Context, userID, budgetID int64) (*int64, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	deletedID, err := m.DB.DeleteBudgetById(ctx, database.DeleteBudgetByIdParams{
 		UserID: userID,
@@ -380,8 +380,8 @@ func (m FinancialManagerModel) DeleteBudgetByID(userID, budgetID int64) (*int64,
 // UpdateBudgetByID() updates a budget record in the database by its ID
 // It takes the user ID and a pointer to a Budget struct as parameters
 // We do not allow users the CurrencyCode but they can change the conversion rate
-func (m FinancialManagerModel) UpdateUserBudget(userID int64, updatedBudget *Budget) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+func (m FinancialManagerModel) UpdateUserBudget(ctx context.Context, userID int64, updatedBudget *Budget) error {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	updatedAt, err := m.DB.UpdateBudgetById(ctx, database.UpdateBudgetByIdParams{
 		ID:             updatedBudget.Id,
@@ -411,8 +411,8 @@ func (m FinancialManagerModel) UpdateUserBudget(userID int64, updatedBudget *Bud
 // GetBudgetByID() retrieves a budget record from the database by its ID
 // It takes the budget ID as a parameter and returns a pointer to a Budget struct
 // and an error if the operation fails.
-func (m FinancialManagerModel) GetBudgetByID(id int64) (*Budget, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+func (m FinancialManagerModel) GetBudgetByID(ctx context.Context, id int64) (*Budget, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	budget, err := m.DB.GetBudgetByID(ctx, id)
 	if err != nil {
@@ -433,8 +433,8 @@ func (m FinancialManagerModel) GetBudgetByID(id int64) (*Budget, error) {
 // This supports pagination and filtering by date created as well as a budget name search query
 // It takes the user ID, search query, and pagination parameters as parameters
 // We also return a summary of each budget by invoking our GetAllGoalSummaryBudgetID() for each budget
-func (m FinancialManagerModel) GetBudgetsForUser(userID int64, searchQuery string, filters Filters) ([]*EnrichedBudget, Metadata, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+func (m FinancialManagerModel) GetBudgetsForUser(ctx context.Context, userID int64, searchQuery string, filters Filters) ([]*EnrichedBudget, Metadata, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	// Fetch budgets from the database
 	budgets, err := m.DB.GetBudgetsForUser(ctx, database.GetBudgetsForUserParams{
@@ -475,7 +475,7 @@ func (m FinancialManagerModel) GetBudgetsForUser(userID int64, searchQuery strin
 			return nil, Metadata{}, err
 		}
 		// return a goal summary and totals for each budget
-		goalSummaryTotals, err := m.GetAllGoalSummaryBudgetID(budget.Id, userID)
+		goalSummaryTotals, err := m.GetAllGoalSummaryBudgetID(ctx, budget.Id, userID)
 		if err != nil {
 			return nil, Metadata{}, err
 		}
@@ -584,8 +584,8 @@ func ValidateGoal(v *validator.Validator, goal *Goals) {
 
 // CreateNewGoal() creates a new goal record in the database
 // It takes a pointer to a Goals struct and returns an error if the operation fails.
-func (m FinancialManagerModel) CreateNewGoal(newGoal *Goals) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+func (m FinancialManagerModel) CreateNewGoal(ctx context.Context, newGoal *Goals) error {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	goal, err := m.DB.CreateNewGoal(ctx, database.CreateNewGoalParams{
 		UserID:              newGoal.UserID,
@@ -616,8 +616,8 @@ func (m FinancialManagerModel) CreateNewGoal(newGoal *Goals) error {
 
 // UpdateGoalByID() updates a goal record in the database by its ID
 // It takes the user ID and a pointer to a Goals struct as parameters
-func (m FinancialManagerModel) UpdateGoalByID(userID int64, updatedGoal *Goals) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+func (m FinancialManagerModel) UpdateGoalByID(ctx context.Context, userID int64, updatedGoal *Goals) error {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	updatedAt, err := m.DB.UpdateGoalByID(ctx, database.UpdateGoalByIDParams{
 		Name:                updatedGoal.Name,
@@ -652,8 +652,8 @@ func (m FinancialManagerModel) UpdateGoalByID(userID int64, updatedGoal *Goals) 
 // GetGoalByID() retrieves a goal record from the database by its ID
 // It takes the goal ID as a parameter and returns a pointer to a Goals struct
 // and an error if the operation fails.
-func (m FinancialManagerModel) GetGoalByID(userID, goalID int64) (*Goals, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+func (m FinancialManagerModel) GetGoalByID(ctx context.Context, userID, goalID int64) (*Goals, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	goal, err := m.DB.GetGoalByID(ctx, database.GetGoalByIDParams{
 		ID:     goalID,
@@ -677,8 +677,8 @@ func (m FinancialManagerModel) GetGoalByID(userID, goalID int64) (*Goals, error)
 // a sample subset of a users goals for investment purposes
 // These items are: name, current amount, target amount, monthly contribution, start date and the end date
 // We will return a *InvestmentGoal struct and an error if the operation fails.
-func (m FinancialManagerModel) GetGoalsForUserInvestmentHelper(userID int64) (*InvestmentGoal, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+func (m FinancialManagerModel) GetGoalsForUserInvestmentHelper(ctx context.Context, userID int64) (*InvestmentGoal, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	goals, err := m.DB.GetGoalsForUserInvestmentHelper(ctx, userID)
 	if err != nil {
@@ -711,8 +711,8 @@ func (m FinancialManagerModel) GetGoalsForUserInvestmentHelper(userID int64) (*I
 }
 
 // GetAllGoalsWithProgressionByUserID() retrieves all goal records associated with a user ID
-func (m FinancialManagerModel) GetAllGoalsWithProgressionByUserID(userID int64, goalName string, filters Filters) ([]*GoalsWithProgression, Metadata, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+func (m FinancialManagerModel) GetAllGoalsWithProgressionByUserID(ctx context.Context, userID int64, goalName string, filters Filters) ([]*GoalsWithProgression, Metadata, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	// Fetch goals from the database
 	goals, err := m.DB.GetAllGoalsWithProgressionByUserID(ctx, database.GetAllGoalsWithProgressionByUserIDParams{
@@ -754,8 +754,8 @@ func (m FinancialManagerModel) GetAllGoalsWithProgressionByUserID(userID int64, 
 // GetGoalTrackingHistory() retrieves all goal tracking records associated with a user ID
 // This supports pagination and filtering by tracking type  (finmantracking...)
 // It takes the user ID, tracking type, and pagination parameters as parameters
-func (m FinancialManagerModel) GetGoalTrackingHistory(userID int64, trackingType database.TrackingTypeEnum, filters Filters) ([]*EnrichedTrackedGoal, Metadata, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+func (m FinancialManagerModel) GetGoalTrackingHistory(ctx context.Context, userID int64, trackingType database.TrackingTypeEnum, filters Filters) ([]*EnrichedTrackedGoal, Metadata, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	// Fetch goal tracking from the database
 	trackedGoals, err := m.DB.GetGoalTrackingHistory(ctx, database.GetGoalTrackingHistoryParams{
@@ -822,8 +822,8 @@ func populateTrackedGoal(trackedGoalRow interface{}) *TrackedGoal {
 // so validation need not be as strict as when creating a goal
 // It takes a pointer to a GoalPlan struct and a user ID
 // We return an error if the operation fails.
-func (m FinancialManagerModel) CreateNewGoalPlan(userID int64, newGoalPlan *GoalPlan) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+func (m FinancialManagerModel) CreateNewGoalPlan(ctx context.Context, userID int64, newGoalPlan *GoalPlan) error {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	goalPlan, err := m.DB.CreateNewGoalPlan(ctx, database.CreateNewGoalPlanParams{
 		UserID:              userID,
@@ -853,8 +853,8 @@ func (m FinancialManagerModel) CreateNewGoalPlan(userID int64, newGoalPlan *Goal
 
 // UpdateGoalPlanByID() updates a goal plan record in the database by its ID and User ID
 // It takes the user ID and a pointer to a GoalPlan struct as parameters
-func (m FinancialManagerModel) UpdateGoalPlanByID(userID int64, updatedGoalPlan *GoalPlan) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+func (m FinancialManagerModel) UpdateGoalPlanByID(ctx context.Context, userID int64, updatedGoalPlan *GoalPlan) error {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	updatedAt, err := m.DB.UpdateGoalPlanByID(ctx, database.UpdateGoalPlanByIDParams{
 		Name:                updatedGoalPlan.Name,
@@ -886,8 +886,8 @@ func (m FinancialManagerModel) UpdateGoalPlanByID(userID int64, updatedGoalPlan 
 // GetGoalPlanByID() retrieves a goal plan record from the database by its ID and User ID
 // It takes the goal plan ID and user ID as parameters and returns a pointer to a GoalPlan struct
 // and an error if the operation fails.
-func (m FinancialManagerModel) GetGoalPlanByID(userID, goalPlanID int64) (*GoalPlan, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+func (m FinancialManagerModel) GetGoalPlanByID(ctx context.Context, userID, goalPlanID int64) (*GoalPlan, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	goalPlan, err := m.DB.GetGoalPlanByID(ctx, database.GetGoalPlanByIDParams{
 		ID:     goalPlanID,
@@ -910,8 +910,8 @@ func (m FinancialManagerModel) GetGoalPlanByID(userID, goalPlanID int64) (*GoalP
 // GetGoalPlansForUser() retrieves all goal plan records associated with a user
 // This supports pagination and filtering by date created.
 // It takes the user ID and pagination parameters as parameters
-func (m FinancialManagerModel) GetGoalPlansForUser(userID int64, filters Filters) ([]*GoalPlan, Metadata, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+func (m FinancialManagerModel) GetGoalPlansForUser(ctx context.Context, userID int64, filters Filters) ([]*GoalPlan, Metadata, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	// Fetch goal plans from the database
 	goalPlans, err := m.DB.GetGoalPlansForUser(ctx, database.GetGoalPlansForUserParams{
@@ -956,8 +956,8 @@ func (m FinancialManagerModel) GetGoalPlansForUser(userID int64, filters Filters
 // check goals that are due for tracking and track them
 // We get a limit as we will be running this in batches.
 // We return a pointer to a TrackedGoal struct and an error if the operation fails.
-func (m FinancialManagerModel) GetAndSaveAllGoalsForTracking() ([]*TrackedGoal, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+func (m FinancialManagerModel) GetAndSaveAllGoalsForTracking(ctx context.Context) ([]*TrackedGoal, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	trackedGoals, err := m.DB.GetAndSaveAllGoalsForTracking(ctx)
 	if err != nil {
@@ -991,8 +991,8 @@ func (m FinancialManagerModel) GetAndSaveAllGoalsForTracking() ([]*TrackedGoal, 
 // UpdateGoalProgressOnExpiredGoals() is the main function that will be used to update goals that have expired
 // Will be used in tandem and work 1 way with the cron job scheduler
 // We return nothing and an error if the operation fails.
-func (m FinancialManagerModel) UpdateGoalProgressOnExpiredGoals() error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+func (m FinancialManagerModel) UpdateGoalProgressOnExpiredGoals(ctx context.Context) error {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 	err := m.DB.UpdateGoalProgressOnExpiredGoals(ctx)
 	if err != nil {
@@ -1015,8 +1015,8 @@ func (m FinancialManagerModel) UpdateGoalProgressOnExpiredGoals() error {
 // We return the goal summaries and additional totals which contains the total goals, total monthly contribution
 // total surplus, budget total amount, budget currency and budget strictness
 // This is the main function that will be used to get and manage surplus by most of the handlers
-func (m FinancialManagerModel) GetAllGoalSummaryBudgetID(budgetID, userID int64) (*Goal_Summary_Totals, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinManDBContextTimeout)
+func (m FinancialManagerModel) GetAllGoalSummaryBudgetID(ctx context.Context, budgetID, userID int64) (*Goal_Summary_Totals, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinManDBContextTimeout)
 	defer cancel()
 
 	fmt.Println("Received data: budgetID:", budgetID, "userID:", userID)

--- a/internal/data/financial_tracker.go
+++ b/internal/data/financial_tracker.go
@@ -241,9 +241,8 @@ func ValidateDebt(v *validator.Validator, debt *Debt) {
 
 // CreateNewRecurringExpense() Creates a new recurrent expens in the recurrence table
 // A trigger automatically adds it to the expenses table to be tracked
-func (m *FinancialTrackingModel) CreateNewRecurringExpense(userID int64, recurringExpense *RecurringExpense) error {
-	// set our context
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinTrackDBContextTimeout)
+func (m *FinancialTrackingModel) CreateNewRecurringExpense(ctx context.Context, userID int64, recurringExpense *RecurringExpense) error {
+	ctx, cancel := contextGenerator(ctx, DefaultFinTrackDBContextTimeout)
 	defer cancel()
 	// create the expense
 	updatedDetails, err := m.DB.CreateNewRecurringExpense(ctx, database.CreateNewRecurringExpenseParams{
@@ -275,9 +274,8 @@ func (m *FinancialTrackingModel) CreateNewRecurringExpense(userID int64, recurri
 }
 
 // UpdateRecurringExpenseByID() updates a recurring expense by its ID
-func (m *FinancialTrackingModel) UpdateRecurringExpenseByID(userID int64, recurringExpense *RecurringExpense) error {
-	// set our context
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinTrackDBContextTimeout)
+func (m *FinancialTrackingModel) UpdateRecurringExpenseByID(ctx context.Context, userID int64, recurringExpense *RecurringExpense) error {
+	ctx, cancel := contextGenerator(ctx, DefaultFinTrackDBContextTimeout)
 	defer cancel()
 	// create the expense
 	updatedAt, err := m.DB.UpdateRecurringExpenseByID(ctx, database.UpdateRecurringExpenseByIDParams{
@@ -310,9 +308,8 @@ func (m *FinancialTrackingModel) UpdateRecurringExpenseByID(userID int64, recurr
 // This route supports pagination and a name search parameter for the
 // expense's name.
 // We return an array of expenses, metadata struct and an error if any was found
-func (m *FinancialTrackingModel) GetAllExpensesByUserID(userID int64, expenseName string, filters Filters) ([]*Expense, Metadata, error) {
-	// set our context
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinTrackDBContextTimeout)
+func (m *FinancialTrackingModel) GetAllExpensesByUserID(ctx context.Context, userID int64, expenseName string, filters Filters) ([]*Expense, Metadata, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinTrackDBContextTimeout)
 	defer cancel()
 	// get the expenses
 	expenses, err := m.DB.GetAllExpensesByUserID(ctx, database.GetAllExpensesByUserIDParams{
@@ -349,9 +346,8 @@ func (m *FinancialTrackingModel) GetAllExpensesByUserID(userID int64, expenseNam
 // GetAllRecurringExpensesByUserID() gets all the recurring expenses by a user ID
 // This route supports pagination
 // We return an array of []* EnrichedRecurringExpense, a metadata struct and an error if any was found
-func (m *FinancialTrackingModel) GetAllRecurringExpensesByUserID(userID int64, recurringExpenseName string, filters Filters) ([]*EnrichedRecurringExpense, Metadata, error) {
-	// set our context
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinTrackDBContextTimeout)
+func (m *FinancialTrackingModel) GetAllRecurringExpensesByUserID(ctx context.Context, userID int64, recurringExpenseName string, filters Filters) ([]*EnrichedRecurringExpense, Metadata, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinTrackDBContextTimeout)
 	defer cancel()
 	// get the expenses
 	recurringExpenses, err := m.DB.GetAllRecurringExpensesByUserID(ctx, database.GetAllRecurringExpensesByUserIDParams{
@@ -395,9 +391,8 @@ func (m *FinancialTrackingModel) GetAllRecurringExpensesByUserID(userID int64, r
 }
 
 // GetRecurringExpenseByID() gets a recurring expense by its ID
-func (m *FinancialTrackingModel) GetRecurringExpenseByID(userID, recurringExpenseID int64) (*RecurringExpense, error) {
-	// set our context
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinTrackDBContextTimeout)
+func (m *FinancialTrackingModel) GetRecurringExpenseByID(ctx context.Context, userID, recurringExpenseID int64) (*RecurringExpense, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinTrackDBContextTimeout)
 	defer cancel()
 	// get the expense
 	recurringExpense, err := m.DB.GetRecurringExpenseByID(ctx, database.GetRecurringExpenseByIDParams{
@@ -422,9 +417,8 @@ func (m *FinancialTrackingModel) GetRecurringExpenseByID(userID, recurringExpens
 // That is, we get all recurring expenses that have a next occurrence that is less than or equal to the current time
 // We will need an offset and a limit so that we support batch processing.
 // This method is made to work in tandem with our cron job
-func (m *FinancialTrackingModel) GetAllRecurringExpensesDueForProcessing(filters Filters) ([]*RecurringExpense, Metadata, error) {
-	// set our context
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinTrackDBContextTimeout)
+func (m *FinancialTrackingModel) GetAllRecurringExpensesDueForProcessing(ctx context.Context, filters Filters) ([]*RecurringExpense, Metadata, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinTrackDBContextTimeout)
 	defer cancel()
 	// get the expenses
 	recurringExpenses, err := m.DB.GetAllRecurringExpensesDueForProcessing(ctx, database.GetAllRecurringExpensesDueForProcessingParams{
@@ -460,9 +454,8 @@ func (m *FinancialTrackingModel) GetAllRecurringExpensesDueForProcessing(filters
 // CreateNewExpense() creates a new expense in the expenses table
 // This expense is a one way expense in that it is not recurring
 // But the caller still needs to verify that the surplus is enough to cover the expense
-func (m *FinancialTrackingModel) CreateNewExpense(userID int64, expense *Expense) error {
-	// make context
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinTrackDBContextTimeout)
+func (m *FinancialTrackingModel) CreateNewExpense(ctx context.Context, userID int64, expense *Expense) error {
+	ctx, cancel := contextGenerator(ctx, DefaultFinTrackDBContextTimeout)
 	defer cancel()
 	// create the expense
 	createdExpense, err := m.DB.CreateNewExpense(ctx, database.CreateNewExpenseParams{
@@ -489,9 +482,8 @@ func (m *FinancialTrackingModel) CreateNewExpense(userID int64, expense *Expense
 
 // UpdateExpenseByID() is a method that updates an expense by its ID and user ID
 // We enrich it back with the updated at timestamp
-func (m *FinancialTrackingModel) UpdateExpenseByID(userID int64, expense *Expense) error {
-	// set our context
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinTrackDBContextTimeout)
+func (m *FinancialTrackingModel) UpdateExpenseByID(ctx context.Context, userID int64, expense *Expense) error {
+	ctx, cancel := contextGenerator(ctx, DefaultFinTrackDBContextTimeout)
 	defer cancel()
 	// create the expense
 	updatedAt, err := m.DB.UpdateExpenseByID(ctx, database.UpdateExpenseByIDParams{
@@ -520,9 +512,8 @@ func (m *FinancialTrackingModel) UpdateExpenseByID(userID int64, expense *Expens
 
 // GetExpenseByID() gets an expense by both the ID and the user ID
 // We return back an expense and an error if any was found
-func (m *FinancialTrackingModel) GetExpenseByID(userID, expenseID int64) (*Expense, error) {
-	// set our context
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinTrackDBContextTimeout)
+func (m *FinancialTrackingModel) GetExpenseByID(ctx context.Context, userID, expenseID int64) (*Expense, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinTrackDBContextTimeout)
 	defer cancel()
 	// get the expense
 	expense, err := m.DB.GetExpenseByID(ctx, database.GetExpenseByIDParams{
@@ -550,9 +541,8 @@ func (m *FinancialTrackingModel) GetExpenseByID(userID, expenseID int64) (*Expen
 // CreateNewIncome() creates a new income in the income table
 // We get a user ID and a pointer to an income struct
 // We return an error if any was found
-func (m *FinancialTrackingModel) CreateNewIncome(userID int64, income *Income) error {
-	// set our context
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinTrackDBContextTimeout)
+func (m *FinancialTrackingModel) CreateNewIncome(ctx context.Context, userID int64, income *Income) error {
+	ctx, cancel := contextGenerator(ctx, DefaultFinTrackDBContextTimeout)
 	defer cancel()
 	// create the income
 	incomeDetails, err := m.DB.CreateNewIncome(ctx, database.CreateNewIncomeParams{
@@ -580,9 +570,8 @@ func (m *FinancialTrackingModel) CreateNewIncome(userID int64, income *Income) e
 // GetAllIncomesByUserID() gets all the incomes by a user ID.
 // This route supports pagination and a name search parameter for the income's source
 // We return an array of enriched incomes[] *EnrichedIncome, a metadata struct and an error if any was found
-func (m *FinancialTrackingModel) GetAllIncomesByUserID(userID int64, incomeSource string, filters Filters) ([]*EnrichedIncome, Metadata, error) {
-	// set our context
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinTrackDBContextTimeout)
+func (m *FinancialTrackingModel) GetAllIncomesByUserID(ctx context.Context, userID int64, incomeSource string, filters Filters) ([]*EnrichedIncome, Metadata, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinTrackDBContextTimeout)
 	defer cancel()
 	// get the incomes
 	incomes, err := m.DB.GetAllIncomesByUserID(ctx, database.GetAllIncomesByUserIDParams{
@@ -623,9 +612,8 @@ func (m *FinancialTrackingModel) GetAllIncomesByUserID(userID int64, incomeSourc
 
 // UpdateIncome() Updates an existing income by th eincomes userID and ID
 // We return an error if any and an updated Income
-func (m *FinancialTrackingModel) UpdateIncomeByID(userID int64, income *Income) error {
-	// set our context
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinTrackDBContextTimeout)
+func (m *FinancialTrackingModel) UpdateIncomeByID(ctx context.Context, userID int64, income *Income) error {
+	ctx, cancel := contextGenerator(ctx, DefaultFinTrackDBContextTimeout)
 	defer cancel()
 	// make the update
 	updatedAT, err := m.DB.UpdateIncomeByID(ctx, database.UpdateIncomeByIDParams{
@@ -655,9 +643,8 @@ func (m *FinancialTrackingModel) UpdateIncomeByID(userID int64, income *Income) 
 
 // GetIncomeByID() gets an income by its ID and user ID
 // We return an error if any was found
-func (m *FinancialTrackingModel) GetIncomeByID(userID, incomeID int64) (*Income, error) {
-	// set our context
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinTrackDBContextTimeout)
+func (m *FinancialTrackingModel) GetIncomeByID(ctx context.Context, userID, incomeID int64) (*Income, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinTrackDBContextTimeout)
 	defer cancel()
 	// get the income
 	income, err := m.DB.GetIncomeByID(ctx, database.GetIncomeByIDParams{
@@ -685,9 +672,8 @@ func (m *FinancialTrackingModel) GetIncomeByID(userID, incomeID int64) (*Income,
 // CreateNewDebt() creates a new debt in the debts table
 // We get a user ID and a pointer to a debt struct
 // We return an error if any was found
-func (m *FinancialTrackingModel) CreateNewDebt(userID int64, debt *Debt) error {
-	// set our context
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinTrackDBContextTimeout)
+func (m *FinancialTrackingModel) CreateNewDebt(ctx context.Context, userID int64, debt *Debt) error {
+	ctx, cancel := contextGenerator(ctx, DefaultFinTrackDBContextTimeout)
 	defer cancel()
 	// create the debt
 	debtDetails, err := m.DB.CreateNewDebt(ctx, database.CreateNewDebtParams{
@@ -724,9 +710,8 @@ func (m *FinancialTrackingModel) CreateNewDebt(userID int64, debt *Debt) error {
 
 // UpdateDebtByID() updates a debt WHEN given both the ID and the user ID
 // We return an error if any was found
-func (m *FinancialTrackingModel) UpdateDebtByID(userID int64, debt *Debt) error {
-	// set our context
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinTrackDBContextTimeout)
+func (m *FinancialTrackingModel) UpdateDebtByID(ctx context.Context, userID int64, debt *Debt) error {
+	ctx, cancel := contextGenerator(ctx, DefaultFinTrackDBContextTimeout)
 	defer cancel()
 	// create the debt
 	updatedAt, err := m.DB.UpdateDebtByID(ctx, database.UpdateDebtByIDParams{
@@ -764,9 +749,8 @@ func (m *FinancialTrackingModel) UpdateDebtByID(userID int64, debt *Debt) error 
 
 // GetDebtByID() gets a debt by its ID and user ID
 // We return an error if any was found
-func (m *FinancialTrackingModel) GetDebtByID(userID, debtID int64) (*Debt, error) {
-	// set our context
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinTrackDBContextTimeout)
+func (m *FinancialTrackingModel) GetDebtByID(ctx context.Context, userID, debtID int64) (*Debt, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinTrackDBContextTimeout)
 	defer cancel()
 	// get the debt
 	debt, err := m.DB.GetDebtByID(ctx, debtID)
@@ -788,9 +772,8 @@ func (m *FinancialTrackingModel) GetDebtByID(userID, debtID int64) (*Debt, error
 // This will will support both pagination and a name search parameter.
 // We return an array of []*DebtWithPayments, passing each debt id to GetDebtPaymentsByDebtUserID() to get the payments
 // a metadata struct and an error if any was found
-func (m *FinancialTrackingModel) GetAllDebtsByUserID(userID int64, debtName string, filters Filters) ([]*DebtWithPayments, Metadata, error) {
-	// set our context
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinTrackDBContextTimeout)
+func (m *FinancialTrackingModel) GetAllDebtsByUserID(ctx context.Context, userID int64, debtName string, filters Filters) ([]*DebtWithPayments, Metadata, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinTrackDBContextTimeout)
 	defer cancel()
 	// get the debts
 	debts, err := m.DB.GetAllDebtsByUserID(ctx, database.GetAllDebtsByUserIDParams{
@@ -818,6 +801,7 @@ func (m *FinancialTrackingModel) GetAllDebtsByUserID(userID int64, debtName stri
 		totalRecords = int(debt.TotalDebts)
 		// get the payments
 		payments, metadata, err := m.GetDebtPaymentsByDebtUserID(
+			ctx,
 			userID,
 			debt.ID,
 			time.Time{}, // use the earliest time as the start date
@@ -844,9 +828,8 @@ func (m *FinancialTrackingModel) GetAllDebtsByUserID(userID int64, debtName stri
 // GetDebtPaymentsByDebtUserID() gets all the debt payments by a debt ID and user ID
 // This route supports both pagination as well as date search parameters (start and end date)
 // We return an []*EnrichedDebtPayment, a metadata struct and an error if any was found
-func (m *FinancialTrackingModel) GetDebtPaymentsByDebtUserID(userID, debtID int64, startDate, endDate time.Time, filters Filters) ([]*EnrichedDebtPayment, Metadata, error) {
-	// set our context
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinTrackDBContextTimeout)
+func (m *FinancialTrackingModel) GetDebtPaymentsByDebtUserID(ctx context.Context, userID, debtID int64, startDate, endDate time.Time, filters Filters) ([]*EnrichedDebtPayment, Metadata, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinTrackDBContextTimeout)
 	defer cancel()
 	// get the debt payments
 	debtPayments, err := m.DB.GetDebtPaymentsByDebtUserID(ctx, database.GetDebtPaymentsByDebtUserIDParams{
@@ -890,9 +873,8 @@ func (m *FinancialTrackingModel) GetDebtPaymentsByDebtUserID(userID, debtID int6
 
 // CreateNewDebtPayment() creates a new debt payment in the debt payments table
 // We return an error if any was found
-func (m *FinancialTrackingModel) CreateNewDebtPayment(userID int64, debtRepayment *DebtRepayment) error {
-	// set our context
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinTrackDBContextTimeout)
+func (m *FinancialTrackingModel) CreateNewDebtPayment(ctx context.Context, userID int64, debtRepayment *DebtRepayment) error {
+	ctx, cancel := contextGenerator(ctx, DefaultFinTrackDBContextTimeout)
 	defer cancel()
 	// create the debt payment
 	debtPayment, err := m.DB.CreateNewDebtPayment(ctx, database.CreateNewDebtPaymentParams{
@@ -916,9 +898,8 @@ func (m *FinancialTrackingModel) CreateNewDebtPayment(userID int64, debtRepaymen
 // GetAllOverdueDebts() gets all the debts that are overdue
 // This is meant to be used in tandem with a cron job
 // We also return a Metadata struct and an error if any was found
-func (m *FinancialTrackingModel) GetAllOverdueDebts(filters Filters) ([]*Debt, Metadata, error) {
-	// set our context
-	ctx, cancel := contextGenerator(context.Background(), DefaultFinTrackDBContextTimeout)
+func (m *FinancialTrackingModel) GetAllOverdueDebts(ctx context.Context, filters Filters) ([]*Debt, Metadata, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultFinTrackDBContextTimeout)
 	defer cancel()
 	// get the debts
 	debts, err := m.DB.GetAllOverdueDebts(ctx, database.GetAllOverdueDebtsParams{

--- a/internal/data/general.go
+++ b/internal/data/general.go
@@ -63,10 +63,11 @@ func ValidateContactUs(v *validator.Validator, contactUs *ContactUs) {
 	ValidateName(v, contactUs.Message, "message")
 }
 
-// CreateContactUs adds a contact Us request for a user with a specific email
-// We recieve a userID, if any, and a contact us struct
-func (m GeneralManagerModel) CreateContactUs(userID int64, contactUs *ContactUs) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultGenManDBContextTimeout)
+// CreateContactUs adds a contact-us request for a user with a specific
+// email. We receive a userID (if any) and a contact-us struct. ctx flows
+// from the originating HTTP request.
+func (m GeneralManagerModel) CreateContactUs(ctx context.Context, userID int64, contactUs *ContactUs) error {
+	ctx, cancel := contextGenerator(ctx, DefaultGenManDBContextTimeout)
 	defer cancel()
 	// create a contact us request
 	updatedContactUs, err := m.DB.CreateContactUs(ctx, database.CreateContactUsParams{

--- a/internal/data/investment_portfolio.go
+++ b/internal/data/investment_portfolio.go
@@ -349,8 +349,8 @@ func (m InvestmentPortfolioModel) MapInvestmentTypeToConstant(investmentType str
 // CreateNewStockInvestment() creates a new stock investment in the database.
 // We take in a user id, and a pointer to a stock investment.
 // We return an error if there was an issue creating the stock investment.
-func (m InvestmentPortfolioModel) CreateNewStockInvestment(userID int64, stockInvestment *StockInvestment) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) CreateNewStockInvestment(ctx context.Context, userID int64, stockInvestment *StockInvestment) error {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 	// Create a new stock investment in the database.
 	newStockInfo, err := m.DB.CreateNewStockInvestment(ctx, database.CreateNewStockInvestmentParams{
@@ -379,8 +379,8 @@ func (m InvestmentPortfolioModel) CreateNewStockInvestment(userID int64, stockIn
 // UpdateStockInvestment() updates a stock investment in the database.
 // We take in a pointer to a stock investment.
 // We return an error if there was an issue updating the stock investment.
-func (m InvestmentPortfolioModel) UpdateStockInvestment(userID int64, stockInvestment *StockInvestment) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) UpdateStockInvestment(ctx context.Context, userID int64, stockInvestment *StockInvestment) error {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 	// Update the stock investment in the database.
 	updatedInfo, err := m.DB.UpdateStockInvestment(ctx, database.UpdateStockInvestmentParams{
@@ -412,8 +412,8 @@ func (m InvestmentPortfolioModel) UpdateStockInvestment(userID int64, stockInves
 // GetStockByStockID() retrieves a stock investment by stock id.
 // We take in a stock id.
 // We return a pointer to a stock investment and an error if there was an issue retrieving the stock investment.
-func (m InvestmentPortfolioModel) GetStockByStockID(stockID int64) (*StockInvestment, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) GetStockByStockID(ctx context.Context, stockID int64) (*StockInvestment, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 	// Retrieve the stock investment from the database.
 	stockInfo, err := m.DB.GetStockByStockID(ctx, stockID)
@@ -434,8 +434,8 @@ func (m InvestmentPortfolioModel) GetStockByStockID(stockID int64) (*StockInvest
 // GetStockInvestmentByUserIDAndStockSymbol() retrieves a stock investment by user id and stock symbol.
 // We take in a user id and a stock symbol.
 // We return a pointer to a stock investment and an error if there was an issue retrieving the stock investment.
-func (m InvestmentPortfolioModel) GetStockInvestmentByUserIDAndStockSymbol(userID int64, stockSymbol string) (*StockInvestment, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) GetStockInvestmentByUserIDAndStockSymbol(ctx context.Context, userID int64, stockSymbol string) (*StockInvestment, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 	// Retrieve the stock investment from the database.
 	stockInfo, err := m.DB.GetStockInvestmentByUserIDAndStockSymbol(ctx, database.GetStockInvestmentByUserIDAndStockSymbolParams{
@@ -454,8 +454,8 @@ func (m InvestmentPortfolioModel) GetStockInvestmentByUserIDAndStockSymbol(userI
 // DeleteStockInvestmentByID() deletes a stock investment.
 // We take in a userID and a stock ID.
 // We return the stock ID of the deleted stock investment and an error if there was an issue deleting the stock investment.
-func (m InvestmentPortfolioModel) DeleteStockInvestmentByID(userID, stockID int64) (int64, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) DeleteStockInvestmentByID(ctx context.Context, userID, stockID int64) (int64, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 	// Delete the stock investment from the database.
 	deletedStockID, err := m.DB.DeleteStockInvestmentByID(ctx, database.DeleteStockInvestmentByIDParams{
@@ -478,8 +478,8 @@ func (m InvestmentPortfolioModel) DeleteStockInvestmentByID(userID, stockID int6
 // This route supports both pagination as well as a name search for the stock symbol.
 // We return an []*enrickedstockinvestment, metadata and an error if there was an issue retrieving the stock investments.
 // For the stock transactions, we will unmarshal to the transaction investments. For the stock analysis, we will unmarshal to the stock analysis.
-func (m InvestmentPortfolioModel) GetAllStockInvestmentByUserID(userID int64, stockSymbol string, filters Filters) ([]*EnrichedStockInvestment, Metadata, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) GetAllStockInvestmentByUserID(ctx context.Context, userID int64, stockSymbol string, filters Filters) ([]*EnrichedStockInvestment, Metadata, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 	// Retrieve the stock investments from the database.
 	stockInvestments, err := m.DB.GetAllStockInvestmentByUserID(ctx, database.GetAllStockInvestmentByUserIDParams{
@@ -551,8 +551,8 @@ func (m InvestmentPortfolioModel) GetAllStockInvestmentByUserID(userID int64, st
 // CreateNewBondInvestment() creates a new bond investment in the database.
 // We take in a user id, and a pointer to a bond investment.
 // We return an error if there was an issue creating the bond investment.
-func (m InvestmentPortfolioModel) CreateNewBondInvestment(userID int64, bondInvestment *BondInvestment) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) CreateNewBondInvestment(ctx context.Context, userID int64, bondInvestment *BondInvestment) error {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 	// Create a new bond investment in the database.
 	newBondInfo, err := m.DB.CreateNewBondInvestment(ctx, database.CreateNewBondInvestmentParams{
@@ -581,8 +581,8 @@ func (m InvestmentPortfolioModel) CreateNewBondInvestment(userID int64, bondInve
 // DeleteInvestmentTransactionByID() deletes an investment transaction.
 // We take in a userID and a transaction ID.
 // We return the transaction ID of the deleted investment transaction and an error if there was an issue deleting the investment transaction.
-func (m InvestmentPortfolioModel) DeleteInvestmentTransactionByID(userID, transactionID int64) (int64, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) DeleteInvestmentTransactionByID(ctx context.Context, userID, transactionID int64) (int64, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 	// Delete the investment transaction from the database.
 	deletedTransactionID, err := m.DB.DeleteInvestmentTransactionByID(ctx, database.DeleteInvestmentTransactionByIDParams{
@@ -604,8 +604,8 @@ func (m InvestmentPortfolioModel) DeleteInvestmentTransactionByID(userID, transa
 // UpdateBondInvestment() updates a bond investment in the database.
 // We take in a pointer to a bond investment and a User ID.
 // We return an error if there was an issue updating the bond investment.
-func (m InvestmentPortfolioModel) UpdateBondInvestment(userID int64, bondInvestment *BondInvestment) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) UpdateBondInvestment(ctx context.Context, userID int64, bondInvestment *BondInvestment) error {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 	// Update the bond investment in the database.
 	updatedAt, err := m.DB.UpdateBondInvestment(ctx, database.UpdateBondInvestmentParams{
@@ -635,8 +635,8 @@ func (m InvestmentPortfolioModel) UpdateBondInvestment(userID int64, bondInvestm
 // DeleteBondInvestmentByID() deletes a bond investment.
 // We take in a userID and a bond ID.
 // We return the bond ID of the deleted bond investment and an error if there was an issue deleting the bond investment.
-func (m InvestmentPortfolioModel) DeleteBondInvestmentByID(userID, bondID int64) (int64, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) DeleteBondInvestmentByID(ctx context.Context, userID, bondID int64) (int64, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 	// Delete the bond investment from the database.
 	deletedBondID, err := m.DB.DeleteBondInvestmentByID(ctx, database.DeleteBondInvestmentByIDParams{
@@ -659,8 +659,8 @@ func (m InvestmentPortfolioModel) DeleteBondInvestmentByID(userID, bondID int64)
 // This route supports both pagination as well as a name search for the bond symbol.
 // We return an []*enrickedbondinvestment, metadata and an error if there was an issue retrieving the bond investments.
 // For the bond transactions, we will unmarshal to the transaction investments. For the bond analysis, we will unmarshal to the bond analysis.
-func (m InvestmentPortfolioModel) GetAllBondInvestmentByUserID(userID int64, bondSymbol string, filters Filters) ([]*EnrichedBondInvestment, Metadata, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) GetAllBondInvestmentByUserID(ctx context.Context, userID int64, bondSymbol string, filters Filters) ([]*EnrichedBondInvestment, Metadata, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 	// Retrieve the bond investments from the database.
 	bondInvestments, err := m.DB.GetAllBondInvestmentByUserID(ctx, database.GetAllBondInvestmentByUserIDParams{
@@ -731,8 +731,8 @@ func (m InvestmentPortfolioModel) GetAllBondInvestmentByUserID(userID int64, bon
 // GetBondByBondID() retrieves a bond investment by bond id.
 // We take in a bond id.
 // We return a pointer to a bond investment and an error if there was an issue retrieving the bond investment.
-func (m InvestmentPortfolioModel) GetBondByBondID(bondID int64) (*BondInvestment, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) GetBondByBondID(ctx context.Context, bondID int64) (*BondInvestment, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 	// Retrieve the bond investment from the database.
 	bondInfo, err := m.DB.GetBondByBondID(ctx, bondID)
@@ -753,8 +753,8 @@ func (m InvestmentPortfolioModel) GetBondByBondID(bondID int64) (*BondInvestment
 // CreateNewAlternativeInvestment() creates a new alternative investment in the database.
 // We take in a user id, and a pointer to an alternative investment.
 // We return an error if there was an issue creating the alternative investment.
-func (m InvestmentPortfolioModel) CreateNewAlternativeInvestment(userID int64, alternativeInvestment *AlternativeInvestment) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) CreateNewAlternativeInvestment(ctx context.Context, userID int64, alternativeInvestment *AlternativeInvestment) error {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 	// Create a new alternative investment in the database.
 	newAlternativeInfo, err := m.DB.CreateNewAlternativeInvestment(ctx, database.CreateNewAlternativeInvestmentParams{
@@ -784,8 +784,8 @@ func (m InvestmentPortfolioModel) CreateNewAlternativeInvestment(userID int64, a
 // UpdateAlternativeInvestment() updates an alternative investment in the database.
 // We take in a pointer to an alternative investment and a User ID.
 // We return an error if there was an issue updating the alternative investment.
-func (m InvestmentPortfolioModel) UpdateAlternativeInvestment(userID int64, alternativeInvestment *AlternativeInvestment) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) UpdateAlternativeInvestment(ctx context.Context, userID int64, alternativeInvestment *AlternativeInvestment) error {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 	// Update the alternative investment in the database.
 	updatedAt, err := m.DB.UpdateAlternativeInvestment(ctx, database.UpdateAlternativeInvestmentParams{
@@ -820,8 +820,8 @@ func (m InvestmentPortfolioModel) UpdateAlternativeInvestment(userID int64, alte
 // DeleteAlternativeInvestmentByID() deletes an alternative investment.
 // We take in a userID and an alternative ID.
 // We return the alternative ID of the deleted alternative investment and an error if there was an issue deleting the alternative investment.
-func (m InvestmentPortfolioModel) DeleteAlternativeInvestmentByID(userID, alternativeID int64) (int64, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) DeleteAlternativeInvestmentByID(ctx context.Context, userID, alternativeID int64) (int64, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 	// Delete the alternative investment from the database.
 	deletedAlternativeID, err := m.DB.DeleteAlternativeInvestmentByID(ctx, database.DeleteAlternativeInvestmentByIDParams{
@@ -844,8 +844,8 @@ func (m InvestmentPortfolioModel) DeleteAlternativeInvestmentByID(userID, altern
 // This route supports both pagination as well as a name search for the investment name.
 // We return an []*enrickedalternativeinvestment, metadata and an error if there was an issue retrieving the alternative investments.
 // For the alternative transactions, we will unmarshal to the transaction investments.
-func (m InvestmentPortfolioModel) GetAllAlternativeInvestmentByUserID(userID int64, investmentName string, filters Filters) ([]*EnrichedAlternativeInvestment, Metadata, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) GetAllAlternativeInvestmentByUserID(ctx context.Context, userID int64, investmentName string, filters Filters) ([]*EnrichedAlternativeInvestment, Metadata, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 	// Retrieve the alternative investments from the database.
 	alternativeInvestments, err := m.DB.GetAllAlternativeInvestmentByUserID(ctx, database.GetAllAlternativeInvestmentByUserIDParams{
@@ -903,8 +903,8 @@ func (m InvestmentPortfolioModel) GetAllAlternativeInvestmentByUserID(userID int
 // GetAlternativeInvestmentByAlternativeID() retrieves an alternative investment by alternative id.
 // We take in an alternative id.
 // We return a pointer to an alternative investment and an error if there was an issue retrieving the alternative investment.
-func (m InvestmentPortfolioModel) GetAlternativeInvestmentByAlternativeID(alternativeID int64) (*AlternativeInvestment, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) GetAlternativeInvestmentByAlternativeID(ctx context.Context, alternativeID int64) (*AlternativeInvestment, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 	// Retrieve the alternative investment from the database.
 	alternativeInfo, err := m.DB.GetAlternativeInvestmentByAlternativeID(ctx, alternativeID)
@@ -925,8 +925,8 @@ func (m InvestmentPortfolioModel) GetAlternativeInvestmentByAlternativeID(altern
 // CreateNewInvestmentTransaction() creates a new investment transaction in the database.
 // We take in a user id, a transaction type, and a pointer to an investment transaction.
 // We return an error if there was an issue creating the investment transaction.
-func (m InvestmentPortfolioModel) CreateNewInvestmentTransaction(userID int64, investmentTransaction *InvestmentTransaction) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) CreateNewInvestmentTransaction(ctx context.Context, userID int64, investmentTransaction *InvestmentTransaction) error {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 	// Create a new investment transaction in the database.
 	newTransactionInfo, err := m.DB.CreateNewInvestmentTransaction(ctx, database.CreateNewInvestmentTransactionParams{
@@ -959,8 +959,8 @@ func (m InvestmentPortfolioModel) CreateNewInvestmentTransaction(userID int64, i
 // Each recieved investment has a column called investment_type, which will be used to determine the type of investment.
 // The investment_type will be a Stock, Bond or Alternative.
 // We return an error if there was an issue retrieving the investment data.
-func (m InvestmentPortfolioModel) GetAllInvestmentsByUserID(userID int64) (*InvestmentAnalysis, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) GetAllInvestmentsByUserID(ctx context.Context, userID int64) (*InvestmentAnalysis, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 
 	// Retrieve all investments from the database.
@@ -1020,8 +1020,8 @@ func (m InvestmentPortfolioModel) GetAllInvestmentsByUserID(userID int64) (*Inve
 
 // CreateStockAnalysis() creates a stock analysis for a user's stock investment.
 // This method recieves a *StockAnalysisStatistics struct and returns an error if there was an issue creating the stock analysis.
-func (m InvestmentPortfolioModel) CreateStockAnalysis(userID int64, riskFreeRate decimal.Decimal, symbol string, stockAnalysis *StockAnalysis) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) CreateStockAnalysis(ctx context.Context, userID int64, riskFreeRate decimal.Decimal, symbol string, stockAnalysis *StockAnalysis) error {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 
 	// convert array of decimal.Decimal to array of strings
@@ -1051,8 +1051,8 @@ func (m InvestmentPortfolioModel) CreateStockAnalysis(userID int64, riskFreeRate
 
 // CreateBondAnalysis() creates a bond analysis for a user's bond investment.
 // This method recieves a *BondAnalysisStatistics struct and returns an error if there was an issue creating the bond analysis.
-func (m InvestmentPortfolioModel) CreateBondAnalysis(userID int64, symbol string, bondAnalysis *BondAnalysis) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) CreateBondAnalysis(ctx context.Context, userID int64, symbol string, bondAnalysis *BondAnalysis) error {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 
 	// convert array of decimal.Decimal to array of strings
@@ -1085,8 +1085,8 @@ func (m InvestmentPortfolioModel) CreateBondAnalysis(userID int64, symbol string
 
 // CreateLLMAnalysisResponse() creates a new LLM analysis response in the database.
 // we accept a user ID and an *LLMAnalyzedPortfolio. We return an error if there was an issue creating the LLM analysis response.
-func (m InvestmentPortfolioModel) CreateLLMAnalysisResponse(userID int64, analyzedPortfolio *LLMAnalyzedPortfolio) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) CreateLLMAnalysisResponse(ctx context.Context, userID int64, analyzedPortfolio *LLMAnalyzedPortfolio) error {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 
 	// Convert map[string]interface{} to json.RawMessage
@@ -1113,8 +1113,8 @@ func (m InvestmentPortfolioModel) CreateLLMAnalysisResponse(userID int64, analyz
 // GetLatestLLMAnalysisResponseByUserID() retrieves the latest LLM analysis response for a user.
 // We take in a user ID and return a pointer to an LLMAnalysisResponse struct.
 // We return an error if there was an issue retrieving the LLM analysis response.
-func (m InvestmentPortfolioModel) GetLatestLLMAnalysisResponseByUserID(userID int64) (*LLMAnalyzedPortfolio, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) GetLatestLLMAnalysisResponseByUserID(ctx context.Context, userID int64) (*LLMAnalyzedPortfolio, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 
 	// Retrieve the latest LLM analysis response from the database.
@@ -1150,8 +1150,8 @@ func (m InvestmentPortfolioModel) GetLatestLLMAnalysisResponseByUserID(userID in
 // GetAllInvestmentInfoByUserID() retrieves all investment information for a user.
 // We take in a user ID and return a slice of InvestmentInfo structs.
 // We return an error if there was an issue retrieving the investment information.
-func (m InvestmentPortfolioModel) GetAllInvestmentInfoByUserID(userID int64) ([]*InvestmentSummary, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultInvPortContextTimeout)
+func (m InvestmentPortfolioModel) GetAllInvestmentInfoByUserID(ctx context.Context, userID int64) ([]*InvestmentSummary, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultInvPortContextTimeout)
 	defer cancel()
 	// Retrieve all investment information from the database.
 	investmentInfo, err := m.DB.GetAllInvestmentInfoByUserID(ctx, userID)

--- a/internal/data/mfa.go
+++ b/internal/data/mfa.go
@@ -91,12 +91,12 @@ func ValidateFullMFA(v *validator.Validator, mfaToken *MFAToken) {
 	ValidateEmail(v, mfaToken.Email)
 }
 
-// CreateNewRecoveryCode() creates recovery codes for a user after a successful MFA opt-IN
-// We use generateRecoveryCodea() to create 5 recovery codes which we will receive
-// We shall proceed to save the recovery codes to the database
-// We shall return the *RecoveryCodeDetail and error
-func (m MFAManager) CreateNewRecoveryCode(userID int64) (*RecoveryCodeDetail, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultMFAManTimeout)
+// CreateNewRecoveryCode creates recovery codes for a user after a
+// successful MFA opt-in. We use generateRecoveryCodes() to create 5
+// recovery codes which we will receive, save to the database, and return.
+// ctx flows from the originating HTTP request.
+func (m MFAManager) CreateNewRecoveryCode(ctx context.Context, userID int64) (*RecoveryCodeDetail, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultMFAManTimeout)
 	defer cancel()
 	// Generate the recovery codes
 	recoveryCodes, err := generateRecoveryCodes(5)
@@ -125,10 +125,10 @@ func (m MFAManager) CreateNewRecoveryCode(userID int64) (*RecoveryCodeDetail, er
 	return recoveryCodeDetails, nil
 }
 
-// GetRecoveryCodesByUserID() fetches the recovery codes for a user by their user ID
-// We shall return the *RecoveryCodeDetail and error
-func (m MFAManager) GetRecoveryCodesByUserID(userID int64) (*RecoveryCodeDetail, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultMFAManTimeout)
+// GetRecoveryCodesByUserID fetches the recovery codes for a user by their
+// user ID. ctx flows from the originating HTTP request.
+func (m MFAManager) GetRecoveryCodesByUserID(ctx context.Context, userID int64) (*RecoveryCodeDetail, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultMFAManTimeout)
 	defer cancel()
 	// Fetch the recovery codes from the database
 	codeDetail, err := m.DB.GetRecoveryCodesByUserID(ctx, userID)
@@ -150,11 +150,11 @@ func (m MFAManager) GetRecoveryCodesByUserID(userID int64) (*RecoveryCodeDetail,
 	return recoveryCodeDetails, nil
 }
 
-// MarkRecoveryCodeAsUsed() marks a recovery code as used by its ID and user ID
-// We also return an editconflict error if the recovery code has already been used
-// We shall return the error
-func (m MFAManager) MarkRecoveryCodeAsUsed(id, userID int64) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultMFAManTimeout)
+// MarkRecoveryCodeAsUsed marks a recovery code as used by its ID and user
+// ID. We also return an edit-conflict error if the recovery code has
+// already been used. ctx flows from the originating HTTP request.
+func (m MFAManager) MarkRecoveryCodeAsUsed(ctx context.Context, id, userID int64) error {
+	ctx, cancel := contextGenerator(ctx, DefaultMFAManTimeout)
 	defer cancel()
 	// Mark the recovery code as used in the database
 	_, err := m.DB.MarkRecoveryCodeAsUsed(ctx, database.MarkRecoveryCodeAsUsedParams{
@@ -173,10 +173,10 @@ func (m MFAManager) MarkRecoveryCodeAsUsed(id, userID int64) error {
 	return nil
 }
 
-// DeleteRecoveryCodeByID() deletes a recovery code by its ID
-// We shall return the error
-func (m MFAManager) DeleteRecoveryCodeByID(id, userID int64) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultMFAManTimeout)
+// DeleteRecoveryCodeByID deletes a recovery code by its ID. ctx flows
+// from the originating HTTP request.
+func (m MFAManager) DeleteRecoveryCodeByID(ctx context.Context, id, userID int64) error {
+	ctx, cancel := contextGenerator(ctx, DefaultMFAManTimeout)
 	defer cancel()
 	// Delete the recovery code from the database
 	_, err := m.DB.DeleteRecoveryCodeByID(ctx, database.DeleteRecoveryCodeByIDParams{

--- a/internal/data/notifications.go
+++ b/internal/data/notifications.go
@@ -93,11 +93,12 @@ func MapNotificationStatusTypeToConst(statusType string) (database.NotificationS
 	}
 }
 
-// CreateNewNotification() creates a new notification in the system.
-// we take in a user id, and a pointer to a notification.
-// We return an error if there was an issue creating the notification.
-func (m NotificationManagerModel) CreateNewNotification(userID int64, mynotification *Notification) error {
-	ctx, cancel := contextGenerator(context.Background(), DefualtNotManContextTimeout)
+// CreateNewNotification creates a new notification in the system. ctx
+// flows from the caller (a request handler when the notification is
+// triggered by user action, or app.ctx when it is fired from a background
+// listener).
+func (m NotificationManagerModel) CreateNewNotification(ctx context.Context, userID int64, mynotification *Notification) error {
+	ctx, cancel := contextGenerator(ctx, DefualtNotManContextTimeout)
 	defer cancel()
 	// Create a new notification in the database
 	notificationDetail, err := m.DB.CreateNewNotification(ctx, database.CreateNewNotificationParams{
@@ -121,12 +122,10 @@ func (m NotificationManagerModel) CreateNewNotification(userID int64, mynotifica
 	return nil
 }
 
-// UpdateNotificationReadAtAndStatus() updates a notification by updating
-// the read at and status of a notification.
-// We take in a notification id, a read at time, and a status.
-// We return an error if there was an issue updating the notification.
-func (m NotificationManagerModel) UpdateNotificationReadAtAndStatus(notificationID int64, readAt sql.NullTime, status database.NotificationStatus) error {
-	ctx, cancel := contextGenerator(context.Background(), DefualtNotManContextTimeout)
+// UpdateNotificationReadAtAndStatus updates a notification by updating
+// the read-at and status of a notification. ctx flows from the caller.
+func (m NotificationManagerModel) UpdateNotificationReadAtAndStatus(ctx context.Context, notificationID int64, readAt sql.NullTime, status database.NotificationStatus) error {
+	ctx, cancel := contextGenerator(ctx, DefualtNotManContextTimeout)
 	defer cancel()
 	// Update the notification in the database
 	updatedAt, err := m.DB.UpdateNotificationReadAtAndStatus(ctx, database.UpdateNotificationReadAtAndStatusParams{
@@ -147,11 +146,11 @@ func (m NotificationManagerModel) UpdateNotificationReadAtAndStatus(notification
 	return nil
 }
 
-// GetAllNotificationsByUserId() gets all the notifications for a user.
-// This method supports both pagination as a notification_type search.
-// We take in a user id, notification type and a filter and return a slice of notifications and an error if there was an issue.
-func (m NotificationManagerModel) GetAllNotificationsByUserId(userID int64, notificationType string, filters Filters) ([]*Notification, Metadata, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefualtNotManContextTimeout)
+// GetAllNotificationsByUserId gets all the notifications for a user. This
+// method supports both pagination and a notification_type search. ctx
+// flows from the originating HTTP request.
+func (m NotificationManagerModel) GetAllNotificationsByUserId(ctx context.Context, userID int64, notificationType string, filters Filters) ([]*Notification, Metadata, error) {
+	ctx, cancel := contextGenerator(ctx, DefualtNotManContextTimeout)
 	defer cancel()
 	// Get all the notifications from the database
 	notificationsRows, err := m.DB.GetAllNotificationsByUserId(ctx, database.GetAllNotificationsByUserIdParams{
@@ -188,12 +187,11 @@ func (m NotificationManagerModel) GetAllNotificationsByUserId(userID int64, noti
 	return notifications, metadata, nil
 }
 
-// GetUnreadNotifications() gets all the unread notifications for a user i.e
-// all notifications that are marked as pending and also whose expired at time
-// is greater than the now.
-// We take in a user id and return a slice of notifications and an error if there was an issue.
-func (m NotificationManagerModel) GetUnreadNotifications(userID int64) ([]*Notification, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefualtNotManContextTimeout)
+// GetUnreadNotifications gets all the unread notifications for a user
+// (status = pending AND expires_at > NOW). ctx flows from the caller
+// (typically the SSE-pending-notifications loader, which uses app.ctx).
+func (m NotificationManagerModel) GetUnreadNotifications(ctx context.Context, userID int64) ([]*Notification, error) {
+	ctx, cancel := contextGenerator(ctx, DefualtNotManContextTimeout)
 	defer cancel()
 	// Get all the unread notifications from the database
 	notificationsRows, err := m.DB.GetUnreadNotifications(ctx, userID)
@@ -221,12 +219,11 @@ func (m NotificationManagerModel) GetUnreadNotifications(userID int64) ([]*Notif
 	return notifications, nil
 }
 
-// GetAllExpiredNotifications() gets all the expired notifications for a user i.e
-// all notifications that are marked as pending and also whose expired at time
-// is less than the now.
-// We take in a filter and return a slice of notifications and an error if there was an issue.
-func (m NotificationManagerModel) GetAllExpiredNotifications(filters Filters) ([]*Notification, Metadata, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefualtNotManContextTimeout)
+// GetAllExpiredNotifications gets all the expired notifications (status
+// = pending AND expires_at < NOW). ctx flows from the caller (the
+// scheduled cron job, which derives from app.ctx).
+func (m NotificationManagerModel) GetAllExpiredNotifications(ctx context.Context, filters Filters) ([]*Notification, Metadata, error) {
+	ctx, cancel := contextGenerator(ctx, DefualtNotManContextTimeout)
 	defer cancel()
 	// Get all the expired notifications from the database
 	notificationsRows, err := m.DB.GetAllExpiredNotifications(ctx, database.GetAllExpiredNotificationsParams{
@@ -261,10 +258,10 @@ func (m NotificationManagerModel) GetAllExpiredNotifications(filters Filters) ([
 	return notifications, metadata, nil
 }
 
-// DeleteNotificationById() deletes a notification by id.
-// We take in a notification id and a userID and return an error if there was an issue deleting the notification.
-func (m NotificationManagerModel) DeleteNotificationById(notificationID int64, userID int64) error {
-	ctx, cancel := contextGenerator(context.Background(), DefualtNotManContextTimeout)
+// DeleteNotificationById deletes a notification by id. ctx flows from
+// the originating HTTP request.
+func (m NotificationManagerModel) DeleteNotificationById(ctx context.Context, notificationID int64, userID int64) error {
+	ctx, cancel := contextGenerator(ctx, DefualtNotManContextTimeout)
 	defer cancel()
 	// Delete the notification from the database
 	_, err := m.DB.DeleteNotificationById(ctx, database.DeleteNotificationByIdParams{
@@ -283,10 +280,10 @@ func (m NotificationManagerModel) DeleteNotificationById(notificationID int64, u
 	return nil
 }
 
-// DeleteAllNotificationsByUserId() deletes all notifications for a user.
-// We take in a user id and return an error if there was an issue deleting the notifications.
-func (m NotificationManagerModel) DeleteAllNotificationsByUserId(userID int64) error {
-	ctx, cancel := contextGenerator(context.Background(), DefualtNotManContextTimeout)
+// DeleteAllNotificationsByUserId deletes all notifications for a user.
+// ctx flows from the originating HTTP request.
+func (m NotificationManagerModel) DeleteAllNotificationsByUserId(ctx context.Context, userID int64) error {
+	ctx, cancel := contextGenerator(ctx, DefualtNotManContextTimeout)
 	defer cancel()
 	// Delete all notifications from the database
 	err := m.DB.DeleteAllNotificationsByUserId(ctx, userID)

--- a/internal/data/personal_finance_portfolio.go
+++ b/internal/data/personal_finance_portfolio.go
@@ -228,14 +228,12 @@ func ValidatePredictionParameters(v *validator.Validator, timeline string) {
 	v.Check(timeline == "monthly" || timeline == "weekly", "timeline", "must be either 'monthly' or 'weekly'")
 }
 
-// GetAllFinanceDetailsForAnalysisByUserID() returns all the finance details for a user
-// The data is returned in JSON format and includes income, expenses, budgets, and debts.
-// We will need to unmarshal this data into the appropriate structs in the frontend based
-// on the "type" field in the JSON.
-// We return a UnifiedFinanceAnalysis struct that contains all the finance analysis data and
-// an error if the operation fails.
-func (m PersonalFinancePortfolioModel) GetAllFinanceDetailsForAnalysisByUserID(userID int64) (*UnifiedFinanceAnalysis, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultPerFinPortDBContextTimeout)
+// GetAllFinanceDetailsForAnalysisByUserID returns all the finance details
+// for a user. The data is returned in JSON format and includes income,
+// expenses, budgets, and debts. The frontend unmarshals based on the
+// "type" field. ctx flows from the originating HTTP request.
+func (m PersonalFinancePortfolioModel) GetAllFinanceDetailsForAnalysisByUserID(ctx context.Context, userID int64) (*UnifiedFinanceAnalysis, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultPerFinPortDBContextTimeout)
 	defer cancel()
 
 	// Get the personal finance rows for the user
@@ -286,12 +284,12 @@ func (m PersonalFinancePortfolioModel) GetAllFinanceDetailsForAnalysisByUserID(u
 	return unifiedFinanceAnalysis, nil
 }
 
-// CheckIfUserHasEnoughPredictionData() checks if the user has enough prediction data
-// to make a prediction. We will send a constant that will alert the caller whether to use
-// per week in the call to the micro service or per month. We will return a string constant
-// and an error if the operation fails.
-func (m PersonalFinancePortfolioModel) CheckIfUserHasEnoughPredictionData(userID int64, timeline string, dateOccurred time.Time) (string, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultPerFinPortDBContextTimeout)
+// CheckIfUserHasEnoughPredictionData checks if the user has enough
+// prediction data to make a prediction. Returns a constant that tells
+// the caller whether to use per-week or per-month in the call to the
+// microservice. ctx flows from the originating HTTP request.
+func (m PersonalFinancePortfolioModel) CheckIfUserHasEnoughPredictionData(ctx context.Context, userID int64, timeline string, dateOccurred time.Time) (string, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultPerFinPortDBContextTimeout)
 	defer cancel()
 
 	// Get the total number of finance rows for the user
@@ -316,12 +314,11 @@ func (m PersonalFinancePortfolioModel) CheckIfUserHasEnoughPredictionData(userID
 	}
 }
 
-// GetPersonalFinanceDataForMonthByUserID() returns all the finance details for a user from
-// a given start date to today. We take in the user id and the start date and return a
-// A PredictionPersonalFinanceData struct that contains all the finance analysis data and
-// an error if the operation fails.
-func (m PersonalFinancePortfolioModel) GetPersonalFinanceDataForMonthByUserID(userID int64, startDate time.Time) ([]*PredictionPersonalFinanceData, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultPerFinPortDBContextTimeout)
+// GetPersonalFinanceDataForMonthByUserID returns all the finance details
+// for a user from a given start date to today. ctx flows from the
+// originating HTTP request.
+func (m PersonalFinancePortfolioModel) GetPersonalFinanceDataForMonthByUserID(ctx context.Context, userID int64, startDate time.Time) ([]*PredictionPersonalFinanceData, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultPerFinPortDBContextTimeout)
 	defer cancel()
 
 	// Get the personal finance rows for the user
@@ -358,13 +355,11 @@ func (m PersonalFinancePortfolioModel) GetPersonalFinanceDataForMonthByUserID(us
 	return predictionPersonalFinanceData, nil
 }
 
-// GetPersonalFinanceDataForWeeklyByUserID() returns all the finance details for a user from
-// a given start date to today. We take in the user id and the start date and return a
-// A PredictionPersonalFinanceData struct that contains all the finance analysis data and
-// an error if the operation fails.
-// This is different from the monthly version because it returns data for a week instead of a month.
-func (m PersonalFinancePortfolioModel) GetPersonalFinanceDataForWeeklyByUserID(userID int64, startDate time.Time) ([]*PredictionPersonalFinanceData, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultPerFinPortDBContextTimeout)
+// GetPersonalFinanceDataForWeeklyByUserID is the weekly variant of
+// GetPersonalFinanceDataForMonthByUserID. ctx flows from the originating
+// HTTP request.
+func (m PersonalFinancePortfolioModel) GetPersonalFinanceDataForWeeklyByUserID(ctx context.Context, userID int64, startDate time.Time) ([]*PredictionPersonalFinanceData, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultPerFinPortDBContextTimeout)
 	defer cancel()
 
 	// Get the personal finance rows for the user
@@ -470,10 +465,11 @@ func (m PersonalFinancePortfolioModel) ProcessPersonalFinanceData(predictionData
 	}, nil
 }
 
-// GetExpenseIncomeSummaryReport() returns a summary report of the expenses and incomes
-// It returns all expenses and incomes per month for a specific user
-func (m PersonalFinancePortfolioModel) GetExpenseIncomeSummaryReport(userID int64) ([]*ExpensesIncomesMonthlySummary, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultPerFinPortDBContextTimeout)
+// GetExpenseIncomeSummaryReport returns a summary report of expenses and
+// incomes per month for a specific user. ctx flows from the originating
+// HTTP request.
+func (m PersonalFinancePortfolioModel) GetExpenseIncomeSummaryReport(ctx context.Context, userID int64) ([]*ExpensesIncomesMonthlySummary, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultPerFinPortDBContextTimeout)
 	defer cancel()
 
 	// Get the personal finance rows for the user

--- a/internal/data/search_options.go
+++ b/internal/data/search_options.go
@@ -27,8 +27,10 @@ type BudgetIDNameSearchOption struct {
 	Name string `json:"name"`
 }
 
-func (s SearchOptionsModel) GetDistinctBudgetCategory(userID int64) ([]*BudgetCategorySearchOption, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultSearchOptionDBContextTimeout)
+// GetDistinctBudgetCategory returns the distinct budget categories for a
+// user. ctx flows from the originating HTTP request.
+func (s SearchOptionsModel) GetDistinctBudgetCategory(ctx context.Context, userID int64) ([]*BudgetCategorySearchOption, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultSearchOptionDBContextTimeout)
 	defer cancel()
 	// get data for the search options
 	budgetCategories, err := s.DB.GetDistinctBudgetCategory(ctx, userID)
@@ -56,9 +58,10 @@ func (s SearchOptionsModel) GetDistinctBudgetCategory(userID int64) ([]*BudgetCa
 	return searchOptions, nil
 }
 
-// GetDistincBudgetIdBudgetName returns the distinct budget id and budget name
-func (s SearchOptionsModel) GetDistinctBudgetIdBudgetName(userID int64) ([]*BudgetIDNameSearchOption, error) {
-	ctx, cancel := contextGenerator(context.Background(), DefaultSearchOptionDBContextTimeout)
+// GetDistinctBudgetIdBudgetName returns the distinct budget id and budget
+// name for a user. ctx flows from the originating HTTP request.
+func (s SearchOptionsModel) GetDistinctBudgetIdBudgetName(ctx context.Context, userID int64) ([]*BudgetIDNameSearchOption, error) {
+	ctx, cancel := contextGenerator(ctx, DefaultSearchOptionDBContextTimeout)
 	defer cancel()
 	// get data for the search options
 	budgets, err := s.DB.GetDistinctBudgetIdBudgetName(ctx, userID)

--- a/internal/data/tokens.go
+++ b/internal/data/tokens.go
@@ -125,20 +125,20 @@ func generateRecoveryCodes(codeCount int) (*RecoveryCodes, error) {
 	return token, nil
 }
 
-func (m TokenModel) New(userID int64, ttl time.Duration, scope string) (*Token, error) {
+// New generates a token then inserts it. ctx flows from the originating
+// HTTP request so client disconnects abort the in-flight INSERT.
+func (m TokenModel) New(ctx context.Context, userID int64, ttl time.Duration, scope string) (*Token, error) {
 	api_key, err := generateToken(userID, ttl, scope)
 	if err != nil {
 		return nil, err
 	}
-	//fmt.Printf("API Key: %v\n || User ID: %d", api_key, userID)
-	// insert the api key into the database
-	err = m.Insert(api_key)
+	err = m.Insert(ctx, api_key)
 	return api_key, err
 }
 
-func (m TokenModel) Insert(api_key *Token) error {
-	// create our timeout context. All of them will just be 5 seconds
-	ctx, cancel := contextGenerator(context.Background(), DefaultTokenDBContextTimeout)
+// Insert persists a token row. ctx flows from the caller.
+func (m TokenModel) Insert(ctx context.Context, api_key *Token) error {
+	ctx, cancel := contextGenerator(ctx, DefaultTokenDBContextTimeout)
 	defer cancel()
 	_, err := m.DB.CreateNewToken(ctx, database.CreateNewTokenParams{
 		Hash:   api_key.Hash,
@@ -149,10 +149,10 @@ func (m TokenModel) Insert(api_key *Token) error {
 	return err
 }
 
-// DeleteAllForUser() deletes all tokens for a specific user and scope.
-func (m TokenModel) DeleteAllForUser(scope string, userID int64) error {
-	// create our timeout context. All of them will just be 5 seconds
-	ctx, cancel := contextGenerator(context.Background(), DefaultTokenDBContextTimeout)
+// DeleteAllForUser deletes all tokens for a specific user and scope. ctx
+// flows from the caller.
+func (m TokenModel) DeleteAllForUser(ctx context.Context, scope string, userID int64) error {
+	ctx, cancel := contextGenerator(ctx, DefaultTokenDBContextTimeout)
 	defer cancel()
 	err := m.DB.DeletAllTokensForUser(ctx, database.DeletAllTokensForUserParams{
 		UserID: userID,

--- a/internal/data/users.go
+++ b/internal/data/users.go
@@ -222,11 +222,13 @@ func (m UserModel) MapTimeHorizonTypeToConstant(timeHorizon string) database.Nul
 	}
 }
 
-// CreateNewUser() creates a new user in the database. The function takes a pointer to a User struct
-// and an encryption key as input. We decrypt the key, use it to encrypt necessary items before we save
-// it back to the DB.
-func (m UserModel) CreateNewUser(user *User, encryption_key string) error {
-	ctx, cancel := contextGenerator(context.Background(), DefaultUserDBContextTimeout)
+// CreateNewUser creates a new user in the database. The function takes a
+// pointer to a User struct and an encryption key as input. We decode the
+// key, use it to encrypt necessary items before we save it back to the DB.
+// ctx flows from the originating HTTP request so client disconnects abort
+// the in-flight INSERT.
+func (m UserModel) CreateNewUser(ctx context.Context, user *User, encryption_key string) error {
+	ctx, cancel := contextGenerator(ctx, DefaultUserDBContextTimeout)
 	defer cancel()
 	// decrypt our hex
 	decodedKey, err := DecodeEncryptionKey(encryption_key)
@@ -274,16 +276,16 @@ func (m UserModel) CreateNewUser(user *User, encryption_key string) error {
 	return nil
 }
 
-// GetForToken() retrieves the details of a user based on a token, scope, and encryption key.
-func (m UserModel) GetForToken(tokenScope, tokenPlaintext, encryption_key string) (*User, error) {
-	// decrypt our hex
+// GetForToken retrieves the details of a user based on a token, scope, and
+// encryption key. ctx flows from the originating HTTP request so client
+// disconnects abort the in-flight SELECT.
+func (m UserModel) GetForToken(ctx context.Context, tokenScope, tokenPlaintext, encryption_key string) (*User, error) {
 	decodedKey, err := DecodeEncryptionKey(encryption_key)
 	if err != nil {
 		return nil, err
 	}
-	// Calculate sha256 hash of plaintext
 	tokenHash := sha256.Sum256([]byte(tokenPlaintext))
-	ctx, cancel := contextGenerator(context.Background(), DefaultUserDBContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefaultUserDBContextTimeout)
 	defer cancel()
 	// get the user
 	user, err := m.DB.GetForToken(ctx, database.GetForTokenParams{
@@ -311,17 +313,16 @@ func (m UserModel) GetForToken(tokenScope, tokenPlaintext, encryption_key string
 	return tokenuser, nil
 }
 
-// GetByEmail() retrieves the details of a user based on an email
-// An Encryption key is also passed to decrypt any data that was encrypted
-// Such as the phone number or the MFA secret.
-func (m UserModel) GetByEmail(email, encryption_key string) (*User, error) {
-	// decrypt our hex
+// GetByEmail retrieves the details of a user based on an email. An
+// encryption key is also passed to decrypt any data that was encrypted
+// (such as the phone number or the MFA secret). ctx flows from the
+// originating HTTP request.
+func (m UserModel) GetByEmail(ctx context.Context, email, encryption_key string) (*User, error) {
 	decodedKey, err := DecodeEncryptionKey(encryption_key)
 	if err != nil {
 		return nil, err
 	}
-	// Get our context
-	ctx, cancel := contextGenerator(context.Background(), DefaultUserDBContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefaultUserDBContextTimeout)
 	defer cancel()
 	// Get the user
 	user, err := m.DB.GetUserByEmail(ctx, email)
@@ -344,17 +345,16 @@ func (m UserModel) GetByEmail(email, encryption_key string) (*User, error) {
 	return emailUser, nil
 }
 
-// UpdateUser() updates the details of a user in the database.
-// The function takes a pointer to a User struct and an encryption key as input.
-// We decode the key, use it to encrypt necessary items before we save it back to the DB
-func (m UserModel) UpdateUser(user *User, encryption_key string) error {
-	// decrypt our hex
+// UpdateUser updates the details of a user in the database. The function
+// takes a pointer to a User struct and an encryption key as input. We
+// decode the key, use it to encrypt necessary items before we save it back
+// to the DB. ctx flows from the originating HTTP request.
+func (m UserModel) UpdateUser(ctx context.Context, user *User, encryption_key string) error {
 	decodedKey, err := DecodeEncryptionKey(encryption_key)
 	if err != nil {
 		return err
 	}
-	// get context
-	ctx, cancel := contextGenerator(context.Background(), DefaultUserDBContextTimeout)
+	ctx, cancel := contextGenerator(ctx, DefaultUserDBContextTimeout)
 	defer cancel()
 	// encrypt and set the phone number
 	encryptedPhoneNumber, err := EncryptData(user.PhoneNumber, decodedKey)


### PR DESCRIPTION
## Summary

Continues the P2 modernization track by threading `context.Context` through the entire data layer so every DB query, Redis operation, and downstream HTTP call becomes cancellable from the originating HTTP request (or `app.ctx` for background work).

Before this PR, every `internal/data/*` method opened its own `contextGenerator(context.Background(), ...)` timeout, so DB work continued for the full timeout even after the client disconnected, the request handler returned, or the process received a shutdown signal. After this PR there are zero `context.Background()` calls left in `internal/data/`.

## Why this matters

- Client disconnects now actually abort in-flight INSERT / UPDATE / DELETE statements instead of holding a connection for the full per-domain timeout.
- Schedulers and SSE pubsub now run on `app.ctx`, so SIGINT / SIGTERM stop them cleanly rather than waiting for the next per-call timeout.
- Per-request tracing / cancellation / deadline propagation now works end-to-end from `chi` through to `pgx`/`database/sql`.

## What changed (4 logical commits)

1. **auth group** -- `users`, `tokens`, `mfa`, `awards`, `search_options`, `algo`, `general` and their callers.
2. **social group** -- `notifications`, `comments`, `feeds`, `personal_finance_portfolio` and their callers (notifications + scraper background goroutines pass `app.ctx`).
3. **financial_management + financial_tracker** -- 19 + 20 budget/goal/expense/income/debt methods plus all handlers and schedulers.
4. **investment_portfolio + financial_groups** -- 24 + 25 methods plus handlers, helpers (`investmentTransactionValidatorHelper`, `updateInvestmentTransactionHelper`), the LLM portfolio request, the cached list endpoints, and the `UpdateExpiredGroupInvitations` scheduler.

Handlers pass `r.Context()`; background goroutines (schedulers, SSE pubsub, RSS scraper, decoupled notification fan-out) pass `app.ctx`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `staticcheck ./...`
- [x] `govulncheck ./...` -- no vulnerabilities
- [x] `go test -race -count=1 ./...` -- all packages pass
- [x] `make audit` -- full suite clean
- [ ] Manual: kill an in-flight long-running request (e.g. portfolio analysis) and confirm Postgres logs show statement cancellation rather than a full 5s timeout.
- [ ] Manual: send SIGTERM during a scheduler tick and confirm the scheduler goroutine exits within the grace window.
