### PR TITLE
feat(observability): structured per-request logging with X-Request-ID correlation

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,49 @@ the available commands for a quick lookup (INCOMPLETE, use help for full list).
 > - `portfolio_singleflight_collapsed_total` (counter; sustained zero is
 >   normal if your cache is warm or workload is sequential)
 
+> **Structured request logging (P3.B):** Every HTTP request emits exactly
+> one structured log line through `zap`, after the response is fully
+> written. The middleware sits OUTSIDE `recoverPanic` so a panic still
+> produces a 500-status log line (the one ops should be paged on); 401s
+> from `authenticate` and 429s from the rate limiter also each get a
+> single line. Long-lived SSE connections deliberately skip per-request
+> logging to avoid misleading "completed" lines on disconnect.
+>
+> Every request is also stamped with a correlation ID. Inbound
+> `X-Request-ID` headers are accepted (cap 128 chars, allowlisted to
+> `[A-Za-z0-9._-]` to block log injection); anything else is regenerated
+> server-side as 16 hex chars from `crypto/rand`. The chosen ID is echoed
+> back in the response header so clients can include it in bug reports.
+>
+> Per-request log fields (`msg="http request"`):
+> - `method`, `path` (no query string; tokens often live there)
+> - `status`, `bytes`, `latency_ms`
+> - `req_id` - request correlation ID
+> - `conn_id` - per-connection ID stamped by `ConnContext` (P1)
+> - `user_id` - `0` for unauthenticated, else `user.ID` populated by
+>   `authenticate` via the `requestLog` holder
+> - `remote_ip` (via `tomasen/realip`, same source the limiter uses)
+> - `user_agent` (truncated at 256 bytes)
+>
+> Example line:
+> ```json
+> {"level":"info","msg":"http request","method":"GET","path":"/v1/investments/analysis","status":200,"bytes":4821,"latency_ms":1843,"remote_ip":"203.0.113.7","req_id":"a1b2c3d4e5f60718","conn_id":42,"user_id":7,"user_agent":"OptiVest-Web/2.1"}
+> ```
+>
+> Handlers that want their own log lines to participate in the same
+> correlation should call `app.loggerFromRequest(r)` instead of using
+> `app.logger` directly: the returned logger is pre-enriched with
+> `req_id`, `conn_id`, and `user_id`.
+>
+> Operational metrics on `/debug/vars`:
+> - `request_log_total` - total requests observed
+> - `request_log_4xx_total` - subset that returned a client error
+> - `request_log_5xx_total` - subset that returned a server error (alert)
+> - `request_id_generated_total` - inbound requests without an ID header
+> - `request_id_rejected_total` - inbound IDs replaced for failing the
+>   sanitization policy (sustained non-zero suggests a misbehaving caller
+>   or active log-injection attempt)
+
 Using `make run`, will run the API with a default connection string located 
 in `cmd\api\.env`. If you're using `powershell`, you need to load the values otherwise you will get
 a `cannot load env file` error. Use the PS code below to load it or change the env variable:

--- a/cmd/api/context.go
+++ b/cmd/api/context.go
@@ -14,8 +14,10 @@ type contextKey string
 // constant. We'll use this constant as the key for getting and setting user information
 // in the request context.
 const (
-	userContextKey   = contextKey("user")
-	connIDContextKey = contextKey("conn_id")
+	userContextKey       = contextKey("user")
+	connIDContextKey     = contextKey("conn_id")
+	requestIDContextKey  = contextKey("req_id")
+	requestLogContextKey = contextKey("req_log")
 )
 
 // contextConnID returns the per-connection ID stamped by ConnContext on
@@ -24,6 +26,38 @@ const (
 func contextConnID(ctx context.Context) int64 {
 	id, _ := ctx.Value(connIDContextKey).(int64)
 	return id
+}
+
+// contextRequestID returns the per-request ID set by the requestID
+// middleware. Returns "" if the context did not flow through that middleware
+// (e.g. a synthetic request constructed in tests).
+func contextRequestID(ctx context.Context) string {
+	s, _ := ctx.Value(requestIDContextKey).(string)
+	return s
+}
+
+// requestLog is a mutable, request-scoped record that the logRequests
+// middleware uses to assemble its single per-request log line. Middlewares
+// deeper in the chain (notably authenticate) can write fields into this
+// struct via contextRequestLog; the logger reads them after next.ServeHTTP
+// returns.
+//
+// I picked a shared mutable holder over the more idiomatic "wrap r with a
+// new context per write" approach because the context update would not
+// propagate back up to the outer logging middleware (each WithValue produces
+// a new request struct visible only to inner handlers). A single pointer in
+// the original context lets every layer collaborate without restructuring
+// the request.
+type requestLog struct {
+	userID int64 // 0 means unauthenticated / anonymous
+}
+
+// contextRequestLog returns the per-request log holder set by the
+// logRequests middleware, or nil if the context did not flow through it
+// (e.g. a synthetic request in tests). Callers must always nil-check.
+func contextRequestLog(ctx context.Context) *requestLog {
+	rl, _ := ctx.Value(requestLogContextKey).(*requestLog)
+	return rl
 }
 
 // The contextSetUser() method returns a new copy of the request with the provided

--- a/cmd/api/logging.go
+++ b/cmd/api/logging.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"expvar"
+	"net/http"
+	"time"
+
+	"github.com/felixge/httpsnoop"
+	"github.com/tomasen/realip"
+	"go.uber.org/zap"
+)
+
+// requestIDHeader is the canonical HTTP header for cross-service request
+// correlation. Inbound values are accepted (so a CDN or upstream proxy can
+// stamp an ID once and have it propagate end-to-end), with sanitization to
+// prevent log-injection.
+const requestIDHeader = "X-Request-ID"
+
+// requestIDMaxLen caps how many bytes I trust from an inbound X-Request-ID
+// header. 128 bytes comfortably covers UUIDs, ULIDs, snowflakes, and most
+// custom schemes while bounding the cost of an attacker spamming huge IDs
+// into our log pipeline.
+const requestIDMaxLen = 128
+
+// generatedRequestIDBytes controls the entropy of the server-side fallback
+// ID. 8 bytes hex-encoded gives 16 readable chars and 64 bits of entropy,
+// which is enough to make collisions essentially impossible at our request
+// volume while keeping log lines compact.
+const generatedRequestIDBytes = 8
+
+// requestLog metrics. These complement the existing rate_limiter_* and
+// portfolio_* counters by exposing per-request observability that operators
+// can graph from /debug/vars without touching the log pipeline:
+//   - request_log_total              total requests observed by logRequests
+//   - request_log_5xx_total          subset that returned a server error
+//   - request_log_4xx_total          subset that returned a client error
+//   - request_id_generated_total     subset that did not arrive with an ID
+//   - request_id_rejected_total      inbound IDs rejected for being too long
+//     or containing illegal characters
+var (
+	requestLogTotal    = expvar.NewInt("request_log_total")
+	requestLog5xxTotal = expvar.NewInt("request_log_5xx_total")
+	requestLog4xxTotal = expvar.NewInt("request_log_4xx_total")
+	requestIDGenerated = expvar.NewInt("request_id_generated_total")
+	requestIDRejected  = expvar.NewInt("request_id_rejected_total")
+)
+
+// requestID middleware stamps every inbound request with a stable
+// correlation ID, available via contextRequestID(r.Context()) for the rest
+// of the chain and echoed back to the client in the X-Request-ID response
+// header so they can include it in bug reports.
+//
+// Behaviour:
+//   - If the request arrives with X-Request-ID, validate and reuse it.
+//   - If not, or if the inbound value is empty/oversized/contains an
+//     unsafe character, generate a fresh ID via crypto/rand.
+//   - The accepted-or-generated ID is set on the response header before
+//     the next handler runs, so a panic recovery still surfaces the ID.
+//
+// Sanitization: I accept ASCII letters, digits, dash, underscore, dot.
+// Anything else triggers regeneration. This blocks log-injection
+// (CR/LF/quotes), keeps the field grep-friendly, and is permissive enough
+// to cover UUID, ULID, snowflake, and most custom IDs without surprises.
+func (app *application) requestID(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.Header.Get(requestIDHeader)
+		if id == "" {
+			id = generateRequestID()
+			requestIDGenerated.Add(1)
+		} else if !isAcceptableRequestID(id) {
+			id = generateRequestID()
+			requestIDRejected.Add(1)
+		}
+
+		w.Header().Set(requestIDHeader, id)
+		ctx := context.WithValue(r.Context(), requestIDContextKey, id)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// generateRequestID returns a hex-encoded random ID. crypto/rand is
+// overkill for collision-avoidance but trivially cheap (single syscall on
+// Linux) and removes any "is this random enough?" concerns. If the OS RNG
+// fails I fall back to a timestamp-based ID rather than panic; the request
+// is still answerable, the ID is just less unique.
+func generateRequestID() string {
+	buf := make([]byte, generatedRequestIDBytes)
+	if _, err := rand.Read(buf); err != nil {
+		// Extremely unlikely; degrade gracefully. The nanosecond timestamp
+		// is unique enough that two simultaneous failures still produce
+		// distinct IDs in practice.
+		return "ts-" + time.Now().UTC().Format("20060102T150405.000000000")
+	}
+	return hex.EncodeToString(buf)
+}
+
+// isAcceptableRequestID enforces the sanitization policy described on
+// requestID. Length cap first (cheap), then per-byte allowlist.
+func isAcceptableRequestID(s string) bool {
+	if len(s) == 0 || len(s) > requestIDMaxLen {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case c == '-' || c == '_' || c == '.':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// logRequests middleware emits exactly one structured zap line per HTTP
+// request, after the request has been fully served. Wraps the response
+// writer via httpsnoop so I can capture the status code and bytes written
+// without re-implementing the WriteHeader/Write tap dance.
+//
+// Fields emitted:
+//
+//	method        e.g. GET, POST
+//	path          r.URL.Path (deliberately not RequestURI; query strings
+//	              can contain tokens or PII)
+//	status        final HTTP status code
+//	bytes         response body bytes written
+//	latency_ms    integer milliseconds (graphable directly)
+//	remote_ip     real client IP via tomasen/realip (same source the
+//	              limiter uses, for consistent correlation)
+//	req_id        the value set by requestID middleware
+//	conn_id       per-connection ID stamped by ConnContext (server.go)
+//	user_id       0 if the request never authenticated, else user.ID
+//	user_agent    truncated at 256 bytes; helpful triage signal
+//
+// Log levels:
+//
+//	2xx, 3xx -> Info
+//	4xx      -> Info (still expected; spammy clients show as 4xx volume)
+//	5xx      -> Error (this is the line ops should be paging on)
+//
+// Placement: this middleware sits OUTSIDE rateLimit/authenticate so that
+// 401s and 429s still produce a log line. authenticate writes the user ID
+// into the requestLog holder (see contextRequestLog) which I read here.
+func (app *application) logRequests(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Stash a mutable holder in the context BEFORE next.ServeHTTP so
+		// inner middleware can populate it and have those writes visible
+		// when I read the holder back here. WithValue gives downstream
+		// middleware/handlers a different request struct, but the pointer
+		// stored as the value is shared, which is exactly what I want.
+		holder := &requestLog{}
+		ctx := context.WithValue(r.Context(), requestLogContextKey, holder)
+		r = r.WithContext(ctx)
+
+		metrics := httpsnoop.CaptureMetrics(next, w, r)
+
+		requestLogTotal.Add(1)
+		switch {
+		case metrics.Code >= 500:
+			requestLog5xxTotal.Add(1)
+		case metrics.Code >= 400:
+			requestLog4xxTotal.Add(1)
+		}
+
+		ua := r.UserAgent()
+		if len(ua) > 256 {
+			ua = ua[:256]
+		}
+
+		fields := []zap.Field{
+			zap.String("method", r.Method),
+			zap.String("path", r.URL.Path),
+			zap.Int("status", metrics.Code),
+			zap.Int64("bytes", metrics.Written),
+			zap.Int64("latency_ms", metrics.Duration.Milliseconds()),
+			zap.String("remote_ip", realip.FromRequest(r)),
+			zap.String("req_id", contextRequestID(r.Context())),
+			zap.Int64("conn_id", contextConnID(r.Context())),
+			zap.Int64("user_id", holder.userID),
+			zap.String("user_agent", ua),
+		}
+
+		if metrics.Code >= 500 {
+			app.logger.Error("http request", fields...)
+		} else {
+			app.logger.Info("http request", fields...)
+		}
+	})
+}
+
+// loggerFromRequest returns a zap logger pre-enriched with this request's
+// correlation fields (req_id, conn_id, user_id). Handlers that want their
+// per-request logs to participate in the same correlation should prefer
+// this over reading app.logger directly.
+//
+// I intentionally do NOT cache the enriched logger on the application
+// struct: handlers may call this after authenticate has populated the
+// holder, so the user_id should be read fresh on every call.
+func (app *application) loggerFromRequest(r *http.Request) *zap.Logger {
+	ctx := r.Context()
+	var userID int64
+	if holder := contextRequestLog(ctx); holder != nil {
+		userID = holder.userID
+	}
+	return app.logger.With(
+		zap.String("req_id", contextRequestID(ctx)),
+		zap.Int64("conn_id", contextConnID(ctx)),
+		zap.Int64("user_id", userID),
+	)
+}

--- a/cmd/api/logging_test.go
+++ b/cmd/api/logging_test.go
@@ -1,0 +1,495 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Blue-Davinci/OptiVest/internal/data"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// fieldByKey returns the value of a zap field on a recorded log entry, or
+// the zero zapcore.Field if no such field is present. Tests use this to
+// assert specific fields without index-fragility.
+func fieldByKey(entry observer.LoggedEntry, key string) zapcore.Field {
+	for _, f := range entry.Context {
+		if f.Key == key {
+			return f
+		}
+	}
+	return zapcore.Field{}
+}
+
+// TestRequestID_GeneratedWhenAbsent verifies that an inbound request with
+// no X-Request-ID header gets one generated server-side, surfaced both in
+// the response header (so the client can correlate) and in the request
+// context (so downstream middleware/handlers can log with it).
+func TestRequestID_GeneratedWhenAbsent(t *testing.T) {
+	app, _ := observedApp(t)
+	var seenInContext string
+	h := app.requestID(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenInContext = contextRequestID(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/foo", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	got := rec.Header().Get(requestIDHeader)
+	if got == "" {
+		t.Fatal("expected X-Request-ID response header to be set, got empty")
+	}
+	if seenInContext != got {
+		t.Fatalf("context request id %q does not match response header %q", seenInContext, got)
+	}
+	if len(got) != generatedRequestIDBytes*2 {
+		t.Fatalf("expected hex ID of length %d, got %d (%q)", generatedRequestIDBytes*2, len(got), got)
+	}
+}
+
+// TestRequestID_PassthroughValid verifies that a clean inbound X-Request-ID
+// is preserved end-to-end. This is what makes cross-service correlation
+// work: an upstream proxy stamps once, every layer keeps that ID.
+func TestRequestID_PassthroughValid(t *testing.T) {
+	app, _ := observedApp(t)
+	var seen string
+	h := app.requestID(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen = contextRequestID(r.Context())
+	}))
+
+	const wantID = "edge-cdn-abc123_def.456"
+	req := httptest.NewRequest(http.MethodGet, "/foo", nil)
+	req.Header.Set(requestIDHeader, wantID)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if seen != wantID {
+		t.Fatalf("expected passthrough %q, got %q", wantID, seen)
+	}
+	if rec.Header().Get(requestIDHeader) != wantID {
+		t.Fatalf("expected response header echo %q, got %q", wantID, rec.Header().Get(requestIDHeader))
+	}
+}
+
+// TestRequestID_RejectsUnsafeOrOversize verifies the sanitization policy:
+// inbound IDs that contain unsafe characters (CR/LF for log injection,
+// shell metas, spaces) or exceed requestIDMaxLen must be replaced with a
+// freshly generated ID. This is the security-relevant behaviour of the
+// middleware.
+func TestRequestID_RejectsUnsafeOrOversize(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"crlf injection", "abc\r\nFAKE: line"},
+		{"space", "id with space"},
+		{"shell metas", "abc;rm -rf /"},
+		{"unicode", "abcдef"},
+		{"oversize", strings.Repeat("a", requestIDMaxLen+1)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app, _ := observedApp(t)
+			var seen string
+			h := app.requestID(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				seen = contextRequestID(r.Context())
+			}))
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set(requestIDHeader, tc.input)
+			h.ServeHTTP(httptest.NewRecorder(), req)
+
+			if seen == tc.input {
+				t.Fatalf("dangerous input %q was passed through unchanged", tc.input)
+			}
+			if !isAcceptableRequestID(seen) {
+				t.Fatalf("regenerated ID %q does not pass the acceptance policy", seen)
+			}
+		})
+	}
+}
+
+// TestLogRequests_EmitsAllFields exercises the happy path: a successful
+// request through the full requestID -> logRequests stack must produce
+// exactly one zap line carrying every documented field with the expected
+// values.
+func TestLogRequests_EmitsAllFields(t *testing.T) {
+	app, recorded := observedApp(t)
+	chain := app.requestID(app.logRequests(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = w.Write([]byte("hello world"))
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/widgets/42", nil)
+	req.Header.Set(requestIDHeader, "trace-xyz-1")
+	req.Header.Set("User-Agent", "go-test/1.0")
+	req.RemoteAddr = "203.0.113.7:55555"
+	chain.ServeHTTP(httptest.NewRecorder(), req)
+
+	entries := recorded.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly one log entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if e.Message != "http request" {
+		t.Fatalf("unexpected message %q", e.Message)
+	}
+
+	want := map[string]any{
+		"method":     "GET",
+		"path":       "/widgets/42",
+		"status":     int64(http.StatusTeapot),
+		"bytes":      int64(len("hello world")),
+		"req_id":     "trace-xyz-1",
+		"user_agent": "go-test/1.0",
+		"user_id":    int64(0),
+	}
+	for k, v := range want {
+		got := fieldByKey(e, k)
+		if got.Key == "" {
+			t.Errorf("missing field %q", k)
+			continue
+		}
+		switch want := v.(type) {
+		case string:
+			if got.String != want {
+				t.Errorf("field %q: want %q, got %q", k, want, got.String)
+			}
+		case int64:
+			if got.Integer != want {
+				t.Errorf("field %q: want %d, got %d", k, want, got.Integer)
+			}
+		}
+	}
+
+	// latency_ms must be present and non-negative; the actual value is
+	// timing-dependent and not worth pinning.
+	lat := fieldByKey(e, "latency_ms")
+	if lat.Key == "" {
+		t.Error("missing latency_ms field")
+	} else if lat.Integer < 0 {
+		t.Errorf("latency_ms is negative: %d", lat.Integer)
+	}
+}
+
+// TestLogRequests_LevelOnServerError verifies that 5xx responses promote
+// the log line to Error level. This is the line ops should be alerting on,
+// so the level matters more than any specific field value.
+func TestLogRequests_LevelOnServerError(t *testing.T) {
+	app, recorded := observedApp(t)
+	chain := app.requestID(app.logRequests(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})))
+
+	chain.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/explode", nil))
+
+	entries := recorded.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected one entry, got %d", len(entries))
+	}
+	if entries[0].Level != zapcore.ErrorLevel {
+		t.Fatalf("expected Error level for 5xx, got %s", entries[0].Level)
+	}
+	if v := fieldByKey(entries[0], "status"); v.Integer != int64(http.StatusInternalServerError) {
+		t.Fatalf("expected status 500, got %d", v.Integer)
+	}
+}
+
+// TestLogRequests_LevelOnClientError keeps client errors at Info so they
+// do not pollute alerting. They still increment the 4xx expvar counter for
+// graphing.
+func TestLogRequests_LevelOnClientError(t *testing.T) {
+	app, recorded := observedApp(t)
+	chain := app.requestID(app.logRequests(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "no", http.StatusBadRequest)
+	})))
+
+	chain.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	entries := recorded.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected one entry, got %d", len(entries))
+	}
+	if entries[0].Level != zapcore.InfoLevel {
+		t.Fatalf("expected Info level for 4xx, got %s", entries[0].Level)
+	}
+}
+
+// TestLogRequests_PicksUpUserIDWrittenByInnerMiddleware proves that the
+// shared *requestLog holder pattern actually works: a synthetic inner
+// middleware writes user.ID into the holder, and the OUTER logging
+// middleware sees that write when it emits the line. This is the
+// invariant the whole design hinges on; if the wrong context layer is
+// used, user_id silently goes back to 0.
+func TestLogRequests_PicksUpUserIDWrittenByInnerMiddleware(t *testing.T) {
+	app, recorded := observedApp(t)
+
+	innerMW := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if h := contextRequestLog(r.Context()); h != nil {
+				h.userID = 42
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+
+	chain := app.requestID(app.logRequests(innerMW(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))))
+
+	chain.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	entries := recorded.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected one entry, got %d", len(entries))
+	}
+	if v := fieldByKey(entries[0], "user_id"); v.Integer != 42 {
+		t.Fatalf("expected user_id=42 to propagate from inner middleware, got %d", v.Integer)
+	}
+}
+
+// TestLogRequests_PanicSafe verifies that a panicking inner handler still
+// produces a single log line with a 500 status, by composing the
+// middleware in the SAME outer-to-inner order the production router uses:
+//
+//	requestID -> logRequests -> recoverPanic -> handler
+//
+// The ordering matters: httpsnoop.CaptureMetrics (used inside logRequests)
+// re-propagates inner panics, so logRequests must sit OUTSIDE recoverPanic.
+// If anyone ever flips that, this test fails loudly because the "http
+// request" log line never appears.
+func TestLogRequests_PanicSafe(t *testing.T) {
+	app, recorded := observedApp(t)
+	chain := app.requestID(app.logRequests(app.recoverPanic(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		panic("kaboom")
+	}))))
+
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 after recover, got %d", rec.Code)
+	}
+	entries := recorded.All()
+	// recoverPanic itself logs an error via serverErrorResponse, plus
+	// our request line. Find the http request line specifically.
+	var httpEntry *observer.LoggedEntry
+	for i := range entries {
+		if entries[i].Message == "http request" {
+			httpEntry = &entries[i]
+			break
+		}
+	}
+	if httpEntry == nil {
+		t.Fatalf("missing 'http request' log line; got: %#v", entries)
+	}
+	if httpEntry.Level != zapcore.ErrorLevel {
+		t.Errorf("post-panic line should be Error, got %s", httpEntry.Level)
+	}
+	if v := fieldByKey(*httpEntry, "status"); v.Integer != int64(http.StatusInternalServerError) {
+		t.Errorf("post-panic status should be 500, got %d", v.Integer)
+	}
+}
+
+// TestLogRequests_BytesWrittenAccurateAcrossMultipleWrites confirms that
+// httpsnoop (the wrapper this middleware relies on) sums bytes from
+// multiple Write calls correctly. If httpsnoop ever changes that
+// behaviour, this test will catch it before ops graphs lie.
+func TestLogRequests_BytesWrittenAccurateAcrossMultipleWrites(t *testing.T) {
+	app, recorded := observedApp(t)
+	chain := app.requestID(app.logRequests(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("hello "))
+		_, _ = w.Write([]byte("world"))
+	})))
+	chain.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	entries := recorded.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected one entry, got %d", len(entries))
+	}
+	if v := fieldByKey(entries[0], "bytes"); v.Integer != int64(len("hello world")) {
+		t.Fatalf("expected bytes=%d, got %d", len("hello world"), v.Integer)
+	}
+}
+
+// TestAuthenticate_PopulatesRequestLogHolder is a small integration test
+// for the one-line addition I made to the authenticate middleware: after a
+// successful auth (here forced via a stub so we don't need the DB layer),
+// the request log holder must carry the user ID, ready for logRequests to
+// pick up.
+//
+// Going through the real authenticate function would require wiring
+// Models, Redis, DB, and a token; instead I exercise the same code path
+// with a contextSetUser equivalent and the holder write that authenticate
+// performs. The behaviour under test is the holder population, not the
+// auth lookup itself (which has its own coverage).
+func TestAuthenticate_PopulatesRequestLogHolder(t *testing.T) {
+	app, recorded := observedApp(t)
+
+	stubAuth := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			user := &data.User{ID: 7, Activated: true}
+			r = app.contextSetUser(r, user)
+			if h := contextRequestLog(r.Context()); h != nil {
+				h.userID = user.ID
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+
+	chain := app.requestID(app.logRequests(stubAuth(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))))
+
+	chain.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	entries := recorded.All()
+	if len(entries) != 1 {
+		t.Fatalf("expected one entry, got %d", len(entries))
+	}
+	if v := fieldByKey(entries[0], "user_id"); v.Integer != 7 {
+		t.Fatalf("expected user_id=7, got %d", v.Integer)
+	}
+}
+
+// TestLoggerFromRequest_EnrichesWithCorrelationFields verifies the
+// public helper used by handlers: any line they emit through the returned
+// logger must already carry req_id, conn_id, and user_id.
+func TestLoggerFromRequest_EnrichesWithCorrelationFields(t *testing.T) {
+	app, recorded := observedApp(t)
+
+	h := app.requestID(app.logRequests(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if holder := contextRequestLog(r.Context()); holder != nil {
+			holder.userID = 99
+		}
+		// Stash a synthetic conn_id so we can also assert it propagates.
+		ctx := context.WithValue(r.Context(), connIDContextKey, int64(123))
+		r = r.WithContext(ctx)
+		app.loggerFromRequest(r).Info("handler-line", zap.String("custom", "v"))
+		w.WriteHeader(http.StatusOK)
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(requestIDHeader, "trace-handler")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	var handlerEntry *observer.LoggedEntry
+	for i, e := range recorded.All() {
+		if e.Message == "handler-line" {
+			handlerEntry = &recorded.All()[i]
+			break
+		}
+	}
+	if handlerEntry == nil {
+		t.Fatalf("expected to find 'handler-line' in recorded logs, got: %#v", recorded.All())
+	}
+	if v := fieldByKey(*handlerEntry, "req_id"); v.String != "trace-handler" {
+		t.Errorf("expected req_id=trace-handler, got %q", v.String)
+	}
+	if v := fieldByKey(*handlerEntry, "conn_id"); v.Integer != 123 {
+		t.Errorf("expected conn_id=123, got %d", v.Integer)
+	}
+	if v := fieldByKey(*handlerEntry, "user_id"); v.Integer != 99 {
+		t.Errorf("expected user_id=99, got %d", v.Integer)
+	}
+	if v := fieldByKey(*handlerEntry, "custom"); v.String != "v" {
+		t.Errorf("expected custom=v on handler line, got %q", v.String)
+	}
+}
+
+// TestLogRequests_OneLinePerRequestUnderConcurrency stress-tests the
+// middleware under the race detector to make sure (a) every concurrent
+// request emits exactly one log line and (b) each request's line carries
+// its OWN user ID, not a sibling's. This is the failure mode if the
+// holder were ever shared across requests instead of per-context.
+func TestLogRequests_OneLinePerRequestUnderConcurrency(t *testing.T) {
+	app, recorded := observedApp(t)
+
+	// Inner middleware writes a deterministic user_id derived from the
+	// inbound X-Request-ID so the test can correlate emitted lines back
+	// to their originating goroutine.
+	stamp := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			id := contextRequestID(r.Context())
+			var n int64
+			_, err := fmt.Sscanf(id, "req-%d", &n)
+			if err == nil {
+				if h := contextRequestLog(r.Context()); h != nil {
+					h.userID = n
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+
+	chain := app.requestID(app.logRequests(stamp(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))))
+
+	const n = 100
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set(requestIDHeader, fmt.Sprintf("req-%d", i))
+			chain.ServeHTTP(httptest.NewRecorder(), req)
+		}(i)
+	}
+	wg.Wait()
+
+	all := recorded.All()
+	if len(all) != n {
+		t.Fatalf("expected %d log lines, got %d", n, len(all))
+	}
+
+	// Every emitted line must have user_id matching the numeric portion
+	// of its req_id, proving holders did not leak between requests.
+	for _, e := range all {
+		reqID := fieldByKey(e, "req_id").String
+		var want int64
+		if _, err := fmt.Sscanf(reqID, "req-%d", &want); err != nil {
+			t.Errorf("malformed req_id %q in log entry", reqID)
+			continue
+		}
+		got := fieldByKey(e, "user_id").Integer
+		if got != want {
+			t.Errorf("user_id leak: req_id=%s carried user_id=%d, expected %d", reqID, got, want)
+		}
+	}
+}
+
+// TestIsAcceptableRequestID_TableDrivenPolicy locks in the per-byte
+// allowlist. Treating this as a separate unit (in addition to the
+// integration test on requestID) makes regressions on the policy itself
+// much easier to bisect.
+func TestIsAcceptableRequestID_TableDrivenPolicy(t *testing.T) {
+	cases := []struct {
+		s    string
+		want bool
+	}{
+		{"", false},
+		{"abc", true},
+		{"ABC123", true},
+		{"abc-DEF_ghi.123", true},
+		{"abc def", false},
+		{"abc;def", false},
+		{"abc\ndef", false},
+		{"абв", false},
+		{strings.Repeat("a", requestIDMaxLen), true},
+		{strings.Repeat("a", requestIDMaxLen+1), false},
+	}
+	for _, tc := range cases {
+		if got := isAcceptableRequestID(tc.s); got != tc.want {
+			t.Errorf("isAcceptableRequestID(%q) = %v, want %v", tc.s, got, tc.want)
+		}
+	}
+}

--- a/cmd/api/middleware.go
+++ b/cmd/api/middleware.go
@@ -70,6 +70,14 @@ func (app *application) authenticate(next http.Handler) http.Handler {
 		// Call the contextSetUser() helper to add the user information to the request
 		// context.
 		r = app.contextSetUser(r, user)
+		// Stash the user ID on the per-request log holder so logRequests
+		// (which sits OUTSIDE this middleware) can include user_id in its
+		// final per-request line. The holder is a shared pointer placed in
+		// context by logRequests; if it is nil I am running without the
+		// logging middleware (e.g. in a test) and there is nothing to do.
+		if holder := contextRequestLog(r.Context()); holder != nil {
+			holder.userID = user.ID
+		}
 		// Call the next handler in the chain.
 		next.ServeHTTP(w, r)
 	})
@@ -143,8 +151,8 @@ var (
 //     authenticate in the global middleware chain — see routes.go.
 //   - On allow, sets standard rate-limit response headers so well-behaved
 //     clients can self-throttle:
-//       X-RateLimit-Limit       <burst>
-//       X-RateLimit-Remaining   <tokens left in window>
+//     X-RateLimit-Limit       <burst>
+//     X-RateLimit-Remaining   <tokens left in window>
 //   - On deny, also sets Retry-After (seconds, integer per RFC 7231) and
 //     X-RateLimit-Reset (seconds until the bucket refills) so clients have
 //     two equivalent ways to read the back-off.

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -18,8 +18,12 @@ func (app *application) sseRoutes() http.Handler {
 		AllowCredentials: false,
 		MaxAge:           300, // Maximum value not ignored bycls any of major browsers
 	}))
-	//Use alice to make a global middleware chain.
-	sseMiddleware := alice.New(app.recoverPanic, app.authenticate, app.requireAuthenticatedUser, app.requireActivatedUser).Then
+	// SSE middleware chain. Deliberately omits logRequests: SSE
+	// connections are long-lived (minutes to hours) and a single
+	// "request completed" line at disconnect time is more misleading than
+	// useful. requestID still runs so that anything the SSE handler
+	// itself logs is correlatable with the original HTTP request.
+	sseMiddleware := alice.New(app.requestID, app.recoverPanic, app.authenticate, app.requireAuthenticatedUser, app.requireActivatedUser).Then
 	// Make our categorized routes
 	v1Router := chi.NewRouter()
 	v1Router.With(sseMiddleware).Get("/sse", app.ServeSSE)
@@ -39,8 +43,29 @@ func (app *application) routes() http.Handler {
 		AllowCredentials: false,
 		MaxAge:           300, // Maximum value not ignored by any of major browsers
 	}))
-	//Use alice to make a global middleware chain.
-	globalMiddleware := alice.New(app.metrics, app.recoverPanic, app.rateLimit, app.authenticate).Then
+	// Global middleware chain, outer to inner:
+	//   metrics      - expvar counters and httpsnoop wrapper for the whole
+	//                  pipeline. Kept outermost so every request is at
+	//                  least counted.
+	//   requestID    - stamps X-Request-ID (passthrough or generated).
+	//                  Must run before logRequests so the log line carries
+	//                  the ID, and before authenticate so any authentication
+	//                  log lines also carry it. Trivially side-effect-free,
+	//                  safe to sit outside recoverPanic.
+	//   logRequests  - one structured zap line per request. Critically must
+	//                  sit OUTSIDE recoverPanic: httpsnoop.CaptureMetrics
+	//                  re-propagates inner panics, so if recoverPanic were
+	//                  outside, a panicking handler would never produce a
+	//                  log line. With this ordering recoverPanic catches
+	//                  the panic, writes a 500, and CaptureMetrics returns
+	//                  cleanly with Code=500 so logRequests still emits
+	//                  the (Error-level) line ops are paged on.
+	//   recoverPanic - catches panics, returns 500.
+	//   rateLimit    - per-IP GCRA via Redis. 429s still get one log line
+	//                  because logRequests is outside.
+	//   authenticate - reads bearer token, populates user context and the
+	//                  requestLog holder for logRequests.
+	globalMiddleware := alice.New(app.metrics, app.requestID, app.logRequests, app.recoverPanic, app.rateLimit, app.authenticate).Then
 
 	// dynamic protected middleware
 	dynamicMiddleware := alice.New(app.requireAuthenticatedUser, app.requireActivatedUser)


### PR DESCRIPTION
## Summary

Every HTTP request now emits exactly one structured zap line, giving ops a real audit trail and ending the era of scattered ad-hoc `app.logger.Info("doing thing")` calls in handlers.

The line carries: `method`, `path`, `status`, `bytes`, `latency_ms`, `req_id`, `conn_id`, `user_id`, `remote_ip`, `user_agent`. Level is `Info` for 2xx-4xx and `Error` for 5xx so 500s are the line ops should be paged on.

## What changed

- **New `requestID` middleware** - accepts inbound `X-Request-ID` (capped at 128 chars, allowlisted to `[A-Za-z0-9._-]` to block log injection) or generates one server-side from `crypto/rand` (16 hex chars). Echoed back on the response header for client-side correlation.
- **New `logRequests` middleware** - wraps the response via the existing `httpsnoop` import, captures status/bytes/latency, emits one structured line.
- **`authenticate` populates `user_id`** - via a shared `*requestLog` pointer placed in the context by `logRequests`. This pattern is necessary because `r.WithContext(...)` produces a new request struct that the OUTER logging middleware never sees.
- **New `app.loggerFromRequest(r)` helper** - returns a zap logger pre-enriched with `req_id`/`conn_id`/`user_id` so handlers can join the same correlation in their own log lines.
- **Middleware chain reordered** to:

      metrics -> requestID -> logRequests -> recoverPanic -> rateLimit -> authenticate -> handler

  `logRequests` MUST sit outside `recoverPanic` because `httpsnoop.CaptureMetrics` re-propagates inner panics. With this ordering, `recoverPanic` catches the panic, writes a 500, and `CaptureMetrics` returns cleanly so the Error-level log line still fires. There is a regression test that asserts this invariant.
- **SSE chain** keeps `requestID` (so handler-emitted lines correlate) but deliberately omits `logRequests` because a single per-request line at disconnect time is misleading for long-lived streams.
- **README** updated with the field list, an example JSON log line, and the new expvar metric names.

## Operational metrics on `/debug/vars`

- `request_log_total`
- `request_log_4xx_total`
- `request_log_5xx_total` - alert signal
- `request_id_generated_total`
- `request_id_rejected_total` - alert signal for log-injection attempts or misbehaving callers

## Test plan

- [x] Build: `go build ./...`
- [x] Vet: `go vet ./...`
- [x] Staticcheck: clean
- [x] govulncheck: no vulnerabilities
- [x] Race tests: `go test -race ./...` - all pass
- [x] New test cases (`cmd/api/logging_test.go`):
  - X-Request-ID generated when absent (length, hex shape, header echoed, in context)
  - X-Request-ID passthrough when valid
  - Sanitization rejects: CRLF, spaces, shell metas, unicode, oversize
  - Happy-path field assertions (method, path, status, bytes, latency_ms present, req_id, user_agent, user_id default)
  - 5xx promotes log to Error level
  - 4xx stays at Info level
  - user_id propagation from inner middleware survives across the OUTER logger read
  - Panic-safe under the production ordering (`requestID -> logRequests -> recoverPanic -> handler`)
  - Bytes accumulate correctly across multiple `Write` calls
  - `authenticate`-equivalent stub populates the holder
  - `loggerFromRequest` enriches with all three correlation fields
  - 100-goroutine concurrent stress under `-race` confirms no holder leakage between requests
  - Table-driven `isAcceptableRequestID` policy lock-in