### PR TITLE
feat(http_client): forward inbound X-Request-ID and structured logging on every outbound call

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,23 @@ the available commands for a quick lookup (INCOMPLETE, use help for full list).
 > - `request_id_rejected_total` - inbound IDs replaced for failing the
 >   sanitization policy (sustained non-zero suggests a misbehaving caller
 >   or active log-injection attempt)
+>
+> Outbound calls (Alpha Vantage, FRED, FMP, OCR.Space, the predictor
+> micro-service, SambaNova, RSS scraping) are wrapped through
+> `cmd/api/http_clients.go`. Each call:
+> - is bound to the caller's `context.Context`, so a client disconnect
+>   or timeout cancels the upstream request promptly;
+> - forwards the inbound `X-Request-ID` on the outbound when it is set
+>   on the ctx (and never clobbers a header the caller already chose);
+> - emits one structured `http outbound` log line per call carrying
+>   `method`, `host`, `path`, `status`, `bytes`, `latency_ms`, `req_id`,
+>   `conn_id`, `user_id`. The full URL is deliberately NOT logged because
+>   several upstream providers carry their API key in the query string;
+>   see `SECURITY.md` for the rotation runbook if a leak occurs.
+>
+> Log levels mirror the inbound logger: `5xx` and transport errors are
+> `Error` (page on this), `ctx` cancel/deadline is `Info` (expected
+> client behaviour, not an upstream fault), everything else is `Info`.
 
 Using `make run`, will run the API with a default connection string located 
 in `cmd\api\.env`. If you're using `powershell`, you need to load the values otherwise you will get

--- a/cmd/api/ai_operations.go
+++ b/cmd/api/ai_operations.go
@@ -77,11 +77,11 @@ func (app *application) buildInvestmentPortfolioLLMRequest(ctx context.Context, 
     }
 }`
 	// get the analyzed portfolio
-	analyzedPortfolio, err := app.buildLLMRequestHelper(profile, instructions)
+	analyzedPortfolio, err := app.buildLLMRequestHelper(ctx, profile, instructions)
 	if err != nil {
 		return nil, err
 	}
-	app.logger.Info("Done building LLM request for investment portfolio")
+	app.loggerFromContext(ctx).Info("Done building LLM request for investment portfolio")
 	// save the analyzed portfolio to the database using CreateLLMAnalysisResponse
 	err = app.models.InvestmentPortfolioManager.CreateLLMAnalysisResponse(ctx, user.ID, analyzedPortfolio)
 	if err != nil {
@@ -91,7 +91,7 @@ func (app *application) buildInvestmentPortfolioLLMRequest(ctx context.Context, 
 	return analyzedPortfolio, nil
 }
 
-func (app *application) buildPersonalFinanceLLMRequest(user *data.User, unifiedPersonalFinanceAnalysis *data.UnifiedFinanceAnalysis) (*data.LLMAnalyzedPortfolio, error) {
+func (app *application) buildPersonalFinanceLLMRequest(ctx context.Context, user *data.User, unifiedPersonalFinanceAnalysis *data.UnifiedFinanceAnalysis) (*data.LLMAnalyzedPortfolio, error) {
 	// Create a profile
 	profile := UserPersonalFinanceProfile{
 		UserTimeHorizon:         user.TimeHorizon,
@@ -124,12 +124,12 @@ func (app *application) buildPersonalFinanceLLMRequest(user *data.User, unifiedP
 		}
 	  }`
 
-	return app.buildLLMRequestHelper(profile, instructions)
+	return app.buildLLMRequestHelper(ctx, profile, instructions)
 }
 
 // buildOCRRecieptAnalysisRequest sends a request to the LLM API with the OCR analysis data
 // and returns the analyzed OCR data.
-func (app *application) buildOCRRecieptAnalysisLLMRequest(ocrAnalysis *data.OCRResponse) (*data.LLMAnalyzedPortfolio, error) {
+func (app *application) buildOCRRecieptAnalysisLLMRequest(ctx context.Context, ocrAnalysis *data.OCRResponse) (*data.LLMAnalyzedPortfolio, error) {
 	// no profile for this one, let us create instructions
 	instructions := `
 {
@@ -155,15 +155,18 @@ func (app *application) buildOCRRecieptAnalysisLLMRequest(ocrAnalysis *data.OCRR
   }
 }
 `
-	return app.buildLLMRequestHelper(ocrAnalysis, instructions)
+	return app.buildLLMRequestHelper(ctx, ocrAnalysis, instructions)
 }
 
-// buildLLMRequestHelper builds and sends the LLM request for analysis
-func (app *application) buildLLMRequestHelper(profile interface{}, instructionsTemplate string) (*data.LLMAnalyzedPortfolio, error) {
+// buildLLMRequestHelper builds and sends the LLM request for analysis. ctx
+// flows from the originating handler so a client disconnect aborts the
+// long-running upstream stream and the outbound log line carries the
+// inbound request correlation.
+func (app *application) buildLLMRequestHelper(ctx context.Context, profile interface{}, instructionsTemplate string) (*data.LLMAnalyzedPortfolio, error) {
 	// Marshal the profile data
 	profileData, err := json.Marshal(profile)
 	if err != nil {
-		app.logger.Info("Error marshalling profile data")
+		app.loggerFromContext(ctx).Info("Error marshalling profile data")
 		return nil, err
 	}
 
@@ -175,7 +178,7 @@ func (app *application) buildLLMRequestHelper(profile interface{}, instructionsT
 	url := app.config.api.apikeys.sambanova.url
 	apiKey := app.config.api.apikeys.sambanova.key
 
-	fullResponse, err := app.LLMRequest(url, map[string]string{
+	fullResponse, err := app.LLMRequest(ctx, url, map[string]string{
 		"Authorization": "Bearer " + apiKey,
 	}, finalLLMRequest)
 	if err != nil {

--- a/cmd/api/api_manager.go
+++ b/cmd/api/api_manager.go
@@ -41,7 +41,7 @@ func (app *application) convertAndGetExchangeRate(ctx context.Context, source_cu
 	url := fmt.Sprintf("%s/%s/pair/%s/%s", app.config.api.apikeys.exchangerates.url,
 		app.config.api.apikeys.exchangerates.key, source_currency, target_currency)
 
-	exchange, err := GETRequest[data.ExchangeRateResponse](app.http_client, url, nil)
+	exchange, err := GETRequest[data.ExchangeRateResponse](ctx, app.http_client, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/api/helpers.go
+++ b/cmd/api/helpers.go
@@ -218,11 +218,15 @@ func (app *application) verifyCurrencyInRedis(currency string) error {
 	return nil
 }
 
-// getAndSaveAvailableCurrencies() gets the available currencies from the exchange rate API
-func (app *application) getAndSaveAvailableCurrencies() error {
+// getAndSaveAvailableCurrencies pulls the latest exchange-rate snapshot
+// for the configured default currency and persists it in Redis. Called
+// from a cron, so the caller passes app.ctx (the lifecycle context) to
+// keep startup-time cancellation working: a SIGTERM during startup must
+// still abort the outbound call.
+func (app *application) getAndSaveAvailableCurrencies(ctx context.Context) error {
 	url := fmt.Sprintf("%s/%s/latest/%s", app.config.api.apikeys.exchangerates.url,
 		app.config.api.apikeys.exchangerates.key, app.config.api.defaultcurrency)
-	currencies, err := GETRequest[data.CurrencyRates](app.http_client, url, nil)
+	currencies, err := GETRequest[data.CurrencyRates](ctx, app.http_client, url, nil)
 	if err != nil {
 		return err
 	}
@@ -609,10 +613,10 @@ func (app *application) postCategoryDecider(isEducational bool) string {
 	return "finance"
 }
 
-// processOCRRequestHelper() is a helper function that will process the OCR request
-// We will send a POST request to the OCR.Space API endpoint to get the text from the image
-// We will then return the OCRResponse
-func (app *application) proces1sOCRRequestHelper(url string) (*data.OCRResponse, error) {
+// processOCRRequestHelper sends the receipt-image URL to the OCR.Space API
+// and returns the parsed OCRResponse. ctx flows from the caller so the
+// upstream call is cancelled when the originating HTTP client disconnects.
+func (app *application) proces1sOCRRequestHelper(ctx context.Context, url string) (*data.OCRResponse, error) {
 	// we need a form Body for this, so we create a form body
 	var requestBody bytes.Buffer
 	writer := multipart.NewWriter(&requestBody)
@@ -650,6 +654,7 @@ func (app *application) proces1sOCRRequestHelper(url string) (*data.OCRResponse,
 	//app.logger.Info(requestBody.String())
 	// call our POSTREQUEST http client with OCRResponse
 	response, err := POSTRequest[data.OCRResponse](
+		ctx,
 		app.http_client,
 		app.config.api.apikeys.ocrspace.url,
 		headers,

--- a/cmd/api/http_clients.go
+++ b/cmd/api/http_clients.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -17,14 +19,19 @@ import (
 	"go.uber.org/zap"
 )
 
-// Client represents the central HTTP client with retry capabilities
+// Optivet_Client is the central HTTP client wrapper used for every outbound
+// call. It owns a retryable client plus an optional logger; when the logger
+// is set, GETRequest/POSTRequest emit one structured line per call so an
+// inbound request can be traced through to its specific upstream hop.
 type Optivet_Client struct {
 	httpClient *retryablehttp.Client
+	logger     *zap.Logger
 }
 
-// NewClient initializes and returns a new Client with custom configurations
-func NewClient(timeout time.Duration, retries int) *Optivet_Client {
-	// Create a retryable HTTP client with custom settings
+// NewClient builds an Optivet_Client. The logger is optional; pass nil to
+// suppress outbound tracing. The retry policy stays linear-jitter with the
+// caller's RetryMax so the existing reliability behaviour is preserved.
+func NewClient(timeout time.Duration, retries int, logger *zap.Logger) *Optivet_Client {
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = retries
 	retryClient.HTTPClient.Timeout = timeout
@@ -34,217 +41,329 @@ func NewClient(timeout time.Duration, retries int) *Optivet_Client {
 
 	return &Optivet_Client{
 		httpClient: retryClient,
+		logger:     logger,
 	}
 }
 
-// GETRequest sends a GET request to the specified URL and unmarshals the response into a generic type T
-func GETRequest[T any](c *Optivet_Client, url string, headers map[string]string) (T, error) {
-	var result T
+// outboundRequestIDHeader is the canonical correlation header. The inbound
+// requestID middleware accepts the same name; using it on outbound preserves
+// the same ID end-to-end if the upstream service forwards it (e.g. internal
+// services). External providers ignore it, which is fine.
+const outboundRequestIDHeader = "X-Request-ID"
 
-	// Create a new request
-	req, err := retryablehttp.NewRequest("GET", url, nil)
-	if err != nil {
-		return result, err
+// outboundLoggerFromContext returns a per-call enriched logger derived from
+// the client's base logger. Returns nil when the client was constructed
+// without a logger so callers can short-circuit cheaply.
+func (c *Optivet_Client) outboundLoggerFromContext(ctx context.Context) *zap.Logger {
+	if c == nil || c.logger == nil {
+		return nil
+	}
+	var userID int64
+	if holder := contextRequestLog(ctx); holder != nil {
+		userID = holder.userID
+	}
+	return c.logger.With(
+		zap.String("req_id", contextRequestID(ctx)),
+		zap.Int64("conn_id", contextConnID(ctx)),
+		zap.Int64("user_id", userID),
+	)
+}
+
+// stampOutboundRequestID copies the inbound correlation ID onto the outbound
+// request. Skips the write when the ctx never flowed through the request
+// middleware (background work, tests) or when the caller has already set
+// the header explicitly.
+func stampOutboundRequestID(req *retryablehttp.Request, ctx context.Context) {
+	if req == nil {
+		return
+	}
+	if req.Header.Get(outboundRequestIDHeader) != "" {
+		return
+	}
+	id := contextRequestID(ctx)
+	if id == "" {
+		return
+	}
+	req.Header.Set(outboundRequestIDHeader, id)
+}
+
+// safeHostPath parses the URL and returns just the host and path. The full
+// URL is deliberately NOT logged because several upstream providers carry
+// API keys as query-string parameters, and any token we surface in logs is
+// effectively a leak. See SECURITY.md.
+func safeHostPath(rawURL string) (host, path string) {
+	u, err := url.Parse(rawURL)
+	if err != nil || u == nil {
+		return "", ""
+	}
+	return u.Host, u.Path
+}
+
+// logOutbound emits one structured log line per outbound call. Levels:
+//   - status >= 500           Error (operator should page on this)
+//   - transport / non-ctx err Error
+//   - ctx canceled / deadline Info  (expected; user disconnected or our
+//     timeout fired - not an upstream fault)
+//   - everything else         Info
+//
+// The log shape mirrors the inbound logRequests middleware (method, status,
+// bytes, latency_ms, req_id, conn_id, user_id) so a single Loki/Grafana
+// query can stitch an inbound line to its outbound children.
+func logOutbound(log *zap.Logger, method, rawURL string, status int, bytes int64, start time.Time, ctx context.Context, callErr error) {
+	if log == nil {
+		return
+	}
+	host, path := safeHostPath(rawURL)
+	fields := []zap.Field{
+		zap.String("method", method),
+		zap.String("host", host),
+		zap.String("path", path),
+		zap.Int("status", status),
+		zap.Int64("bytes", bytes),
+		zap.Int64("latency_ms", time.Since(start).Milliseconds()),
+	}
+	if callErr != nil {
+		fields = append(fields, zap.String("err", callErr.Error()))
 	}
 
-	// Set headers
+	switch {
+	case errors.Is(ctx.Err(), context.Canceled), errors.Is(ctx.Err(), context.DeadlineExceeded):
+		log.Info("http outbound", fields...)
+	case status >= 500, callErr != nil:
+		log.Error("http outbound", fields...)
+	default:
+		log.Info("http outbound", fields...)
+	}
+}
+
+// GETRequest sends a context-bound GET to the specified URL and unmarshals
+// the JSON response into T. The caller's ctx is propagated to the underlying
+// http.Request, so a client disconnect or upstream timeout cancels the call
+// promptly. The inbound X-Request-ID is forwarded on the outbound when one
+// is set on the ctx, and a single structured log line is emitted summarising
+// the call (see logOutbound for the schema).
+func GETRequest[T any](ctx context.Context, c *Optivet_Client, requestURL string, headers map[string]string) (T, error) {
+	var result T
+	log := c.outboundLoggerFromContext(ctx)
+	start := time.Now()
+
+	req, err := retryablehttp.NewRequest(http.MethodGet, requestURL, nil)
+	if err != nil {
+		logOutbound(log, http.MethodGet, requestURL, 0, 0, start, ctx, err)
+		return result, err
+	}
+	req = req.WithContext(ctx)
 	for key, value := range headers {
 		req.Header.Set(key, value)
 	}
+	stampOutboundRequestID(req, ctx)
 
-	// Perform the request
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
+		logOutbound(log, http.MethodGet, requestURL, 0, 0, start, ctx, err)
 		return result, err
 	}
 	defer resp.Body.Close()
 
-	// Check if the response status is not 2xx
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		message := fmt.Sprintf("non-2xx response code: %d | url: %s", resp.StatusCode, url)
-		return result, errors.New(message)
+		message := fmt.Sprintf("non-2xx response code: %d | url: %s", resp.StatusCode, requestURL)
+		err := errors.New(message)
+		logOutbound(log, http.MethodGet, requestURL, resp.StatusCode, 0, start, ctx, err)
+		return result, err
 	}
 
-	// Read the response body
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
+		logOutbound(log, http.MethodGet, requestURL, resp.StatusCode, 0, start, ctx, err)
 		return result, err
 	}
 
-	// Unmarshal the response into the provided generic type
-	err = json.Unmarshal(body, &result)
-	if err != nil {
+	if err := json.Unmarshal(body, &result); err != nil {
+		logOutbound(log, http.MethodGet, requestURL, resp.StatusCode, int64(len(body)), start, ctx, err)
 		return result, err
 	}
-	//fmt.Printf("Response: %v", result)
 
+	logOutbound(log, http.MethodGet, requestURL, resp.StatusCode, int64(len(body)), start, ctx, nil)
 	return result, nil
 }
 
-// POSTRequest sends a POST request with a body to the specified URL and unmarshals the response into a generic type T
-func POSTRequest[T any](c *Optivet_Client, url string, headers map[string]string, body interface{}, isMultipart bool) (T, error) {
+// POSTRequest sends a context-bound POST to the specified URL with either a
+// JSON-marshalled body or a pre-built multipart bytes.Buffer. Same context
+// propagation, header stamping, and structured logging behaviour as
+// GETRequest.
+func POSTRequest[T any](ctx context.Context, c *Optivet_Client, requestURL string, headers map[string]string, body interface{}, isMultipart bool) (T, error) {
 	var result T
+	log := c.outboundLoggerFromContext(ctx)
+	start := time.Now()
 
-	// Create the request body based on whether it's multipart or JSON
 	var reqBody io.Reader
-
-	// Determine if we are dealing with a multipart request or not
 	if isMultipart {
-		// If multipart, assert body to be bytes.Buffer, not *bytes.Buffer
 		bufferBody, ok := body.(bytes.Buffer)
 		if !ok {
-			return result, fmt.Errorf("expected body to be bytes.Buffer for multipart request")
+			err := fmt.Errorf("expected body to be bytes.Buffer for multipart request")
+			logOutbound(log, http.MethodPost, requestURL, 0, 0, start, ctx, err)
+			return result, err
 		}
-		reqBody = &bufferBody // Pass a pointer to the bytes.Buffer
+		reqBody = &bufferBody
 	} else {
-		// Otherwise, marshal body to JSON
 		jsonBody, err := json.Marshal(body)
 		if err != nil {
+			logOutbound(log, http.MethodPost, requestURL, 0, 0, start, ctx, err)
 			return result, err
 		}
 		reqBody = bytes.NewBuffer(jsonBody)
 	}
 
-	// Create a new POST request
-	req, err := retryablehttp.NewRequest("POST", url, reqBody)
+	req, err := retryablehttp.NewRequest(http.MethodPost, requestURL, reqBody)
 	if err != nil {
+		logOutbound(log, http.MethodPost, requestURL, 0, 0, start, ctx, err)
 		return result, err
 	}
-
-	// Set headers (ensure the correct content-type is set for multipart or JSON)
+	req = req.WithContext(ctx)
 	for key, value := range headers {
 		req.Header.Set(key, value)
 	}
+	stampOutboundRequestID(req, ctx)
 
-	// Perform the request
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
+		logOutbound(log, http.MethodPost, requestURL, 0, 0, start, ctx, err)
 		return result, err
 	}
 	defer resp.Body.Close()
 
-	// Check if the response status is not 2xx
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return result, fmt.Errorf("non-2xx response code: %d", resp.StatusCode)
+		err := fmt.Errorf("non-2xx response code: %d", resp.StatusCode)
+		logOutbound(log, http.MethodPost, requestURL, resp.StatusCode, 0, start, ctx, err)
+		return result, err
 	}
 
-	// Read the response body
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
+		logOutbound(log, http.MethodPost, requestURL, resp.StatusCode, 0, start, ctx, err)
 		return result, err
 	}
 
-	// Unmarshal the response into the provided generic type
-	err = json.Unmarshal(bodyBytes, &result)
-	if err != nil {
+	if err := json.Unmarshal(bodyBytes, &result); err != nil {
+		logOutbound(log, http.MethodPost, requestURL, resp.StatusCode, int64(len(bodyBytes)), start, ctx, err)
 		return result, err
 	}
 
+	logOutbound(log, http.MethodPost, requestURL, resp.StatusCode, int64(len(bodyBytes)), start, ctx, nil)
 	return result, nil
 }
 
-// LLMRequest() sends a POST request to the specified URL with the provided headers and body
-// and reads the response in chunks to accumulate the full response
-func (app *application) LLMRequest(url string, headers map[string]string, body string) (string, error) {
-	// Convert the body to bytes directly without marshaling again
+// LLMRequest sends a context-bound POST to the SambaNova chat-completions
+// endpoint and reads the streaming response, accumulating chunk content into
+// a single string. ctx propagates so a client disconnect cancels the
+// long-running upstream stream promptly. The same outbound-correlation
+// behaviour as GETRequest/POSTRequest applies: X-Request-ID is forwarded
+// when present, and one structured log line summarises the call.
+//
+// The streaming reader uses a 1 MiB scanner buffer because SambaNova chunks
+// can exceed bufio.Scanner's default 64 KiB limit on long responses.
+func (app *application) LLMRequest(ctx context.Context, requestURL string, headers map[string]string, body string) (string, error) {
+	log := app.loggerFromContext(ctx)
+	start := time.Now()
 	jsonBody := []byte(body)
-	clientC := NewClient(60*time.Second, 3)
+	clientC := NewClient(60*time.Second, 3, app.logger)
 
-	// Create a new POST request using retryablehttp
-	req, err := retryablehttp.NewRequest("POST", url, bytes.NewBuffer(jsonBody))
+	req, err := retryablehttp.NewRequest(http.MethodPost, requestURL, bytes.NewBuffer(jsonBody))
 	if err != nil {
+		logOutbound(log, http.MethodPost, requestURL, 0, 0, start, ctx, err)
 		return "", err
 	}
-
-	// Set headers
+	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", "application/json")
 	for key, value := range headers {
 		req.Header.Set(key, value)
 	}
+	stampOutboundRequestID(req, ctx)
 
-	// Perform the request
 	resp, err := clientC.httpClient.Do(req)
 	if err != nil {
+		logOutbound(log, http.MethodPost, requestURL, 0, 0, start, ctx, err)
 		return "", err
 	}
 	defer resp.Body.Close()
 
-	// Check if the response status is not 2xx
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		app.logger.Info("Non-2xx response code", zap.String("status", resp.Status))
-		return "", errors.New("non-2xx response code")
+		err := errors.New("non-2xx response code")
+		logOutbound(log, http.MethodPost, requestURL, resp.StatusCode, 0, start, ctx, err)
+		return "", err
 	}
 
-	// Variable to accumulate the entire response
-	var fullResponse string
-
-	// Read the response stream
+	var fullResponse strings.Builder
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
-
-		// Skip empty lines and headers
 		if line == "" || line == "data: " {
 			continue
 		}
+		// Defensive prefix strip - older code relied on a fixed length
+		// of 6, which would panic on a malformed line shorter than that.
+		line = strings.TrimPrefix(line, "data: ")
 
-		// Remove the "data: " prefix
-		line = line[6:]
-
-		// Parse the chunk as JSON
 		var chunk Chunk
-		err := json.Unmarshal([]byte(line), &chunk)
-		if err != nil {
-			fmt.Println("Error parsing chunk:", err)
+		if err := json.Unmarshal([]byte(line), &chunk); err != nil {
 			continue
 		}
-
-		// Accumulate the content part of the chunk into the fullResponse
 		for _, choice := range chunk.Choices {
 			if choice.Delta.Content != "" {
-				fullResponse += choice.Delta.Content
+				fullResponse.WriteString(choice.Delta.Content)
 			}
 		}
-
-		// Stop reading if we hit the finish reason
+		// finishReason on any choice ends the stream early.
+		done := false
 		for _, choice := range chunk.Choices {
 			if choice.FinishReason != nil {
-				fmt.Println("\nFinished")
+				done = true
 				break
 			}
+		}
+		if done {
+			break
 		}
 	}
 
 	if err := scanner.Err(); err != nil {
+		logOutbound(log, http.MethodPost, requestURL, resp.StatusCode, int64(fullResponse.Len()), start, ctx, err)
 		return "", err
 	}
 
-	return fullResponse, nil
+	logOutbound(log, http.MethodPost, requestURL, resp.StatusCode, int64(fullResponse.Len()), start, ctx, nil)
+	return fullResponse.String(), nil
 }
 
-// scraperGetRSSFeeds() sends our GET request to our RSS Feed URL
-// We recieve an expected XML response and decode it into an RSSFeed struct
-func (app *application) scraperGetRSSFeeds(retryMax, clientTimeout int, url string, sanitizer *bluemonday.Policy) (*data.RSSFeed, error) {
-	// create a retrayable client with our own settings
+// scraperGetRSSFeeds fetches a single feed URL and decodes the (RSS or Atom)
+// XML body. ctx flows from the cron-driven caller so a process shutdown
+// promptly aborts in-flight scrapes. The structured outbound log line lives
+// here directly because the body is XML, not JSON, so this path cannot reuse
+// GETRequest[T any].
+func (app *application) scraperGetRSSFeeds(ctx context.Context, retryMax, clientTimeout int, requestURL string, sanitizer *bluemonday.Policy) (*data.RSSFeed, error) {
+	log := app.loggerFromContext(ctx)
+	start := time.Now()
 	retryClient := NewClient(
 		time.Duration(clientTimeout)*time.Second,
 		retryMax,
+		app.logger,
 	)
-	ResponseContextTimeout := 30 * time.Second
+	const responseContextTimeout = 30 * time.Second
 
-	// Create a new request with context for timeout
-	req, err := retryablehttp.NewRequest("GET", url, nil)
+	req, err := retryablehttp.NewRequest(http.MethodGet, requestURL, nil)
 	if err != nil {
+		logOutbound(log, http.MethodGet, requestURL, 0, 0, start, ctx, err)
 		return nil, err
 	}
-	// Create a context with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), ResponseContextTimeout)
-	defer cancel() // Ensure the context is cancelled to free resources
-	req = req.WithContext(ctx)
+	scraperCtx, cancel := context.WithTimeout(ctx, responseContextTimeout)
+	defer cancel()
+	req = req.WithContext(scraperCtx)
+	stampOutboundRequestID(req, ctx)
 
-	// Perform the request with retries
 	resp, err := retryClient.httpClient.Do(req)
 	if err != nil {
+		logOutbound(log, http.MethodGet, requestURL, 0, 0, start, scraperCtx, err)
 		switch {
 		case strings.Contains(err.Error(), "context deadline exceeded"):
 			return nil, data.ErrContextDeadline
@@ -253,11 +372,11 @@ func (app *application) scraperGetRSSFeeds(retryMax, clientTimeout int, url stri
 		}
 	}
 	defer resp.Body.Close()
-	// Initialize a new RSSFeed struct
+
 	rssFeed := &data.RSSFeed{}
-	// Decode the response using RssFeedDecoder() expecting an RSSFeed struct
-	err = app.RssFeedDecoderDecider(url, rssFeed, sanitizer, resp)
+	err = app.RssFeedDecoderDecider(requestURL, rssFeed, sanitizer, resp)
 	if err != nil {
+		logOutbound(log, http.MethodGet, requestURL, resp.StatusCode, 0, start, scraperCtx, err)
 		switch {
 		case strings.Contains(err.Error(), "context deadline exceeded"):
 			return nil, data.ErrContextDeadline
@@ -268,5 +387,6 @@ func (app *application) scraperGetRSSFeeds(retryMax, clientTimeout int, url stri
 		}
 	}
 
+	logOutbound(log, http.MethodGet, requestURL, resp.StatusCode, 0, start, scraperCtx, nil)
 	return rssFeed, nil
 }

--- a/cmd/api/http_clients_test.go
+++ b/cmd/api/http_clients_test.go
@@ -1,0 +1,336 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// observedClient builds an Optivet_Client wired to an in-memory zap observer
+// so tests can assert on the structured outbound log lines the production
+// code emits. Returns the client and the live log capture handle.
+func observedClient(t *testing.T) (*Optivet_Client, *observer.ObservedLogs) {
+	t.Helper()
+	core, logs := observer.New(zap.InfoLevel)
+	return NewClient(5*time.Second, 0, zap.New(core)), logs
+}
+
+// ctxWithRequestID builds a context populated the same way the requestID
+// middleware populates inbound requests. Used by tests to simulate an
+// outbound call originating from a real HTTP request.
+func ctxWithRequestID(id string) context.Context {
+	return context.WithValue(context.Background(), requestIDContextKey, id)
+}
+
+// echoServer returns an httptest server that captures the inbound request
+// (so tests can assert what the outbound client sent) and replies with a
+// trivial JSON object. The captured request pointer is shared, so tests
+// must not call ServeHTTP concurrently against the same server.
+type echoServer struct {
+	srv      *httptest.Server
+	captured atomic.Pointer[http.Request]
+	status   int
+}
+
+func newEchoServer(status int) *echoServer {
+	es := &echoServer{status: status}
+	es.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Clone so the request stays valid after the handler returns; the
+		// test reads from it on a different goroutine when assertions run
+		// inline.
+		clone := r.Clone(r.Context())
+		es.captured.Store(clone)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(es.status)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	return es
+}
+
+func (es *echoServer) Close() { es.srv.Close() }
+
+// TestGETRequest_StampsRequestIDFromContext is the headline assertion: when
+// the inbound request carries a correlation ID, the outbound call must
+// forward it as X-Request-ID so an upstream service (or a log scraper) can
+// stitch the two sides of the call together by the same key.
+func TestGETRequest_StampsRequestIDFromContext(t *testing.T) {
+	es := newEchoServer(http.StatusOK)
+	defer es.Close()
+
+	c, _ := observedClient(t)
+	ctx := ctxWithRequestID("abc123def456")
+
+	type body struct {
+		Ok bool `json:"ok"`
+	}
+	got, err := GETRequest[body](ctx, c, es.srv.URL+"/v1/foo", nil)
+	if err != nil {
+		t.Fatalf("GETRequest returned error: %v", err)
+	}
+	if !got.Ok {
+		t.Fatalf("decode failed: got %+v", got)
+	}
+	captured := es.captured.Load()
+	if captured == nil {
+		t.Fatal("server never saw a request")
+	}
+	if got := captured.Header.Get("X-Request-ID"); got != "abc123def456" {
+		t.Errorf("X-Request-ID forwarded = %q, want %q", got, "abc123def456")
+	}
+}
+
+// TestGETRequest_DoesNotStampWhenContextHasNoID is the symmetric guard:
+// background work (cron, tests, anything not flowing through the request
+// middleware) must NOT inject an empty X-Request-ID header. An empty header
+// is still a header, and downstream services treating it as "this caller is
+// trying to spoof correlation" would be entirely justified.
+func TestGETRequest_DoesNotStampWhenContextHasNoID(t *testing.T) {
+	es := newEchoServer(http.StatusOK)
+	defer es.Close()
+
+	c, _ := observedClient(t)
+
+	type body struct {
+		Ok bool `json:"ok"`
+	}
+	if _, err := GETRequest[body](context.Background(), c, es.srv.URL+"/health", nil); err != nil {
+		t.Fatalf("GETRequest returned error: %v", err)
+	}
+	captured := es.captured.Load()
+	if captured == nil {
+		t.Fatal("server never saw a request")
+	}
+	if vals := captured.Header.Values("X-Request-ID"); len(vals) != 0 {
+		t.Errorf("X-Request-ID was set despite empty ctx: %v", vals)
+	}
+}
+
+// TestGETRequest_DoesNotClobberCallerProvidedHeader covers the case where a
+// caller has already chosen to set X-Request-ID explicitly (e.g. forwarding
+// an externally-supplied trace ID). The helper must respect that choice.
+func TestGETRequest_DoesNotClobberCallerProvidedHeader(t *testing.T) {
+	es := newEchoServer(http.StatusOK)
+	defer es.Close()
+
+	c, _ := observedClient(t)
+	ctx := ctxWithRequestID("middleware-id")
+
+	type body struct {
+		Ok bool `json:"ok"`
+	}
+	if _, err := GETRequest[body](ctx, c, es.srv.URL+"/x",
+		map[string]string{"X-Request-ID": "caller-supplied-id"}); err != nil {
+		t.Fatalf("GETRequest returned error: %v", err)
+	}
+	captured := es.captured.Load()
+	if got := captured.Header.Get("X-Request-ID"); got != "caller-supplied-id" {
+		t.Errorf("caller-supplied X-Request-ID was overwritten: got %q", got)
+	}
+}
+
+// TestGETRequest_EmitsStructuredLogLine asserts the outbound log shape
+// matches the inbound logRequests middleware (method, host, path, status,
+// bytes, latency_ms, req_id, conn_id, user_id) so a single Loki/Grafana
+// query can stitch inbound and outbound lines by req_id.
+//
+// It also asserts that the log line does NOT contain a "url" field. Several
+// upstream providers carry their API key in the query string (Alpha Vantage,
+// FRED, FMP), and surfacing the full URL would be a credential leak.
+func TestGETRequest_EmitsStructuredLogLine(t *testing.T) {
+	es := newEchoServer(http.StatusOK)
+	defer es.Close()
+
+	c, logs := observedClient(t)
+	ctx := ctxWithRequestID("trace-1")
+
+	type body struct {
+		Ok bool `json:"ok"`
+	}
+	if _, err := GETRequest[body](ctx, c, es.srv.URL+"/v1/timeseries", nil); err != nil {
+		t.Fatalf("GETRequest returned error: %v", err)
+	}
+
+	entries := logs.FilterMessage("http outbound").All()
+	if len(entries) != 1 {
+		t.Fatalf("want exactly 1 'http outbound' log entry, got %d", len(entries))
+	}
+	e := entries[0]
+	got := e.ContextMap()
+
+	for _, key := range []string{"method", "host", "path", "status", "bytes", "latency_ms", "req_id", "conn_id", "user_id"} {
+		if _, ok := got[key]; !ok {
+			t.Errorf("log entry missing field %q", key)
+		}
+	}
+	if got["method"] != "GET" {
+		t.Errorf("method = %v, want GET", got["method"])
+	}
+	if got["path"] != "/v1/timeseries" {
+		t.Errorf("path = %v, want /v1/timeseries", got["path"])
+	}
+	if got["req_id"] != "trace-1" {
+		t.Errorf("req_id = %v, want trace-1", got["req_id"])
+	}
+	if got["status"] != int64(200) {
+		t.Errorf("status = %v, want 200", got["status"])
+	}
+	if _, leaked := got["url"]; leaked {
+		t.Error("log entry leaked full url field; query strings can carry API keys (see SECURITY.md)")
+	}
+}
+
+// TestGETRequest_5xxLogsAtErrorLevel: 5xx responses have to be loud enough
+// for an operator to see them. The outbound log line on a 500 must come out
+// at Error level so it shows up in the alerting query, mirroring the
+// inbound logger's policy.
+func TestGETRequest_5xxLogsAtErrorLevel(t *testing.T) {
+	es := newEchoServer(http.StatusInternalServerError)
+	defer es.Close()
+
+	c, logs := observedClient(t)
+	ctx := ctxWithRequestID("trace-err")
+
+	type body struct {
+		Ok bool `json:"ok"`
+	}
+	_, err := GETRequest[body](ctx, c, es.srv.URL+"/v1/sad", nil)
+	if err == nil {
+		t.Fatal("want error from non-2xx response, got nil")
+	}
+
+	errEntries := logs.FilterLevelExact(zap.ErrorLevel).FilterMessage("http outbound").All()
+	if len(errEntries) != 1 {
+		t.Fatalf("want exactly 1 Error-level outbound log line, got %d (all levels: %d)",
+			len(errEntries), logs.Len())
+	}
+}
+
+// TestGETRequest_ContextCancellation_LogsAtInfoLevel: when the caller's ctx
+// is canceled mid-flight (deliberate disconnect), the outbound log line
+// must NOT show up as Error. Otherwise every browser-tab-close that lands
+// during a slow upstream call generates spurious alert noise. We expect
+// the line at Info level instead.
+func TestGETRequest_ContextCancellation_LogsAtInfoLevel(t *testing.T) {
+	// Slow server: holds the response for longer than the test will wait
+	// for it. The handler observes ctx cancellation through r.Context()
+	// and returns promptly so the test does not leak the goroutine.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(2 * time.Second):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case <-r.Context().Done():
+			return
+		}
+	}))
+	defer server.Close()
+
+	c, logs := observedClient(t)
+	parent := ctxWithRequestID("trace-cancel")
+	ctx, cancel := context.WithCancel(parent)
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	type body struct {
+		Ok bool `json:"ok"`
+	}
+	if _, err := GETRequest[body](ctx, c, server.URL+"/slow", nil); err == nil {
+		t.Fatal("want error from canceled context, got nil")
+	}
+
+	errEntries := logs.FilterLevelExact(zap.ErrorLevel).FilterMessage("http outbound").All()
+	if len(errEntries) != 0 {
+		t.Errorf("ctx cancellation logged at Error level (would create alert noise); want Info")
+	}
+	infoEntries := logs.FilterLevelExact(zap.InfoLevel).FilterMessage("http outbound").All()
+	if len(infoEntries) != 1 {
+		t.Errorf("want exactly 1 Info-level outbound log line on ctx cancel, got %d", len(infoEntries))
+	}
+}
+
+// TestPOSTRequest_StampsRequestIDFromContext mirrors the GET assertion: the
+// POST helper must also forward X-Request-ID so the OCR.Space and predictor
+// micro-service calls participate in the same correlation pipeline.
+func TestPOSTRequest_StampsRequestIDFromContext(t *testing.T) {
+	es := newEchoServer(http.StatusOK)
+	defer es.Close()
+
+	c, _ := observedClient(t)
+	ctx := ctxWithRequestID("post-trace")
+
+	type body struct {
+		Ok bool `json:"ok"`
+	}
+	if _, err := POSTRequest[body](ctx, c, es.srv.URL+"/predict",
+		map[string]string{"Content-Type": "application/json"},
+		map[string]string{"hello": "world"}, false); err != nil {
+		t.Fatalf("POSTRequest returned error: %v", err)
+	}
+	captured := es.captured.Load()
+	if got := captured.Header.Get("X-Request-ID"); got != "post-trace" {
+		t.Errorf("X-Request-ID forwarded = %q, want %q", got, "post-trace")
+	}
+}
+
+// TestSafeHostPath_StripsQueryAndFragment is a direct unit test on the URL
+// sanitiser the outbound logger uses. Anything that survives this function
+// ends up in production logs, so the contract has to be tight.
+func TestSafeHostPath_StripsQueryAndFragment(t *testing.T) {
+	cases := []struct {
+		raw      string
+		wantHost string
+		wantPath string
+	}{
+		{
+			raw:      "https://www.alphavantage.co/query?function=TIME_SERIES_DAILY&symbol=IBM&apikey=DO_NOT_LOG_THIS",
+			wantHost: "www.alphavantage.co",
+			wantPath: "/query",
+		},
+		{
+			raw:      "https://api.fiscaldata.treasury.gov/services/api/v1/series?api_key=secret#frag",
+			wantHost: "api.fiscaldata.treasury.gov",
+			wantPath: "/services/api/v1/series",
+		},
+		{
+			raw:      "not a url at all",
+			wantHost: "",
+			wantPath: "not a url at all",
+		},
+	}
+	for _, tc := range cases {
+		gotHost, gotPath := safeHostPath(tc.raw)
+		if gotHost != tc.wantHost || gotPath != tc.wantPath {
+			t.Errorf("safeHostPath(%q) = (%q, %q), want (%q, %q)",
+				tc.raw, gotHost, gotPath, tc.wantHost, tc.wantPath)
+		}
+		if strings.Contains(gotHost+gotPath, "apikey") || strings.Contains(gotHost+gotPath, "api_key") {
+			t.Errorf("safeHostPath(%q) leaked api key fragment", tc.raw)
+		}
+	}
+}
+
+// TestNewClient_NilLoggerIsHonoured makes sure constructing a client without
+// a logger remains a supported, no-allocation path. Callers that opt out of
+// outbound tracing (background scripts, throwaway tests) should not pay for
+// the structured logger they did not ask for.
+func TestNewClient_NilLoggerIsHonoured(t *testing.T) {
+	es := newEchoServer(http.StatusOK)
+	defer es.Close()
+
+	c := NewClient(5*time.Second, 0, nil)
+	type body struct {
+		Ok bool `json:"ok"`
+	}
+	if _, err := GETRequest[body](context.Background(), c, es.srv.URL+"/", nil); err != nil {
+		t.Fatalf("GETRequest with nil logger returned error: %v", err)
+	}
+}

--- a/cmd/api/investment_operations.go
+++ b/cmd/api/investment_operations.go
@@ -205,7 +205,7 @@ func (app *application) getBondInvestmentDataHandler(ctx context.Context, symbol
 	// bond series) collapse to one FRED call. The leader populates Redis
 	// inside the closure for downstream cache reads.
 	bondTimeSeriesResponse, err := singleflightDoTyped(&app.sf, "fred:bond:"+symbol, func() (data.BondResponse, error) {
-		resp, fetchErr := GETRequest[data.BondResponse](app.http_client, timeSeriesUrl, nil)
+		resp, fetchErr := GETRequest[data.BondResponse](ctx, app.http_client, timeSeriesUrl, nil)
 		if fetchErr != nil {
 			return data.BondResponse{}, fetchErr
 		}
@@ -356,7 +356,7 @@ func (app *application) getStockInvestmentDataHandler(ctx context.Context, symbo
 	app.loggerFromContext(ctx).Info("Time Series URL", zap.String("symbol", symbol))
 
 	timeSeriesResponse, err := singleflightDoTyped(&app.sf, "av:timeseries:"+symbol, func() (data.TimeSeriesDailyResponse, error) {
-		resp, fetchErr := GETRequest[data.TimeSeriesDailyResponse](app.http_client, timeSeriesURL, nil)
+		resp, fetchErr := GETRequest[data.TimeSeriesDailyResponse](ctx, app.http_client, timeSeriesURL, nil)
 		if fetchErr != nil {
 			return data.TimeSeriesDailyResponse{}, fetchErr
 		}
@@ -636,7 +636,7 @@ func (app *application) getSentimentAnalysis(ctx context.Context, symbol string)
 	}
 
 	// if no cache was found, get the data
-	sentimentResponse, err := GETRequest[data.SentimentData](app.http_client, sentimentURL, nil)
+	sentimentResponse, err := GETRequest[data.SentimentData](ctx, app.http_client, sentimentURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -695,7 +695,7 @@ func (app *application) getRiskMetrics(ctx context.Context, timeHorizon string) 
 		return riskFactor, nil
 	}
 	// if no cache was found, get the data
-	treasuryYieldResponse, err := GETRequest[data.TreasuryYieldData](app.http_client, treasuryYieldURL, nil)
+	treasuryYieldResponse, err := GETRequest[data.TreasuryYieldData](ctx, app.http_client, treasuryYieldURL, nil)
 	if err != nil {
 		return decimal.NewFromInt(0), err
 	}
@@ -784,7 +784,7 @@ func (app *application) getSectorPerformance(ctx context.Context, sector string)
 	// to Redis from inside the leader closure so the next miss elsewhere
 	// reads from cache instead of re-firing the upstream call.
 	sectorPerformanceResponse, err := singleflightDoTyped(&app.sf, "fmp:sector-performance", func() (data.SectorAnalysisData, error) {
-		resp, fetchErr := GETRequest[data.SectorAnalysisData](app.http_client, sectorPerformanceURL, nil)
+		resp, fetchErr := GETRequest[data.SectorAnalysisData](ctx, app.http_client, sectorPerformanceURL, nil)
 		if fetchErr != nil {
 			return nil, fetchErr
 		}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -340,8 +340,10 @@ func main() {
 	if err != nil {
 		logger.Fatal(err.Error(), zap.String("dsn", cfg.db.dsn))
 	}
-	// create out http client
-	httpClient := NewClient(cfg.http_client.timeout, cfg.http_client.retrymax)
+	// create out http client. The shared logger flows in so every outbound
+	// call participates in the inbound request-correlation pipeline (see
+	// cmd/api/http_clients.go for the schema).
+	httpClient := NewClient(cfg.http_client.timeout, cfg.http_client.retrymax, logger)
 	// log our connection pool
 	logger.Info("database connection pool established", zap.String("dsn", cfg.db.dsn))
 	// Init our exp metrics variables for server metrics.
@@ -398,7 +400,7 @@ func (app *application) startupFunction() error {
 			// log the error and continue to fetch the data from the API
 			app.logger.Error("Failed to get currency from Redis", zap.String("currency", app.config.api.defaultcurrency))
 			// read and load currencies
-			err = app.getAndSaveAvailableCurrencies()
+			err = app.getAndSaveAvailableCurrencies(app.ctx)
 			if err != nil {
 				return err
 			}

--- a/cmd/api/personal_finance_portfolio.go
+++ b/cmd/api/personal_finance_portfolio.go
@@ -30,7 +30,7 @@ func (app *application) getAllFinanceDetailsForAnalysisByUserIDHandler(w http.Re
 		}
 	}
 	// call the LLM analysis
-	llmPersonalFinanceAnalysis, err := app.buildPersonalFinanceLLMRequest(user, unifiedFinanceAnalysis)
+	llmPersonalFinanceAnalysis, err := app.buildPersonalFinanceLLMRequest(r.Context(), user, unifiedFinanceAnalysis)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -151,6 +151,7 @@ func (app *application) getPersonalFinancePrediction(w http.ResponseWriter, r *h
 	// Send get Post request using our http client
 	// include an "X-API-KEY" using our config
 	response, err := POSTRequest[data.PersonalFinancePredictionResponse](
+		r.Context(),
 		app.http_client,
 		app.config.api.apikeys.optivestmicroservice.url,
 		map[string]string{"X-API-KEY": app.config.api.apikeys.optivestmicroservice.key,
@@ -212,7 +213,7 @@ func (app *application) getOCRDRecieptDataAnalysisHandler(w http.ResponseWriter,
 		return
 	}
 	// process the OCR request
-	ocrResponse, err := app.proces1sOCRRequestHelper(input.URL)
+	ocrResponse, err := app.proces1sOCRRequestHelper(r.Context(), input.URL)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
@@ -224,7 +225,7 @@ func (app *application) getOCRDRecieptDataAnalysisHandler(w http.ResponseWriter,
 		return
 	}
 	// send ocrRespinse to our LLM buildOCRRecieptAnalysisRequest
-	llmOCRRecieptAnalysis, err := app.buildOCRRecieptAnalysisLLMRequest(ocrResponse)
+	llmOCRRecieptAnalysis, err := app.buildOCRRecieptAnalysisLLMRequest(r.Context(), ocrResponse)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return

--- a/cmd/api/scraper.go
+++ b/cmd/api/scraper.go
@@ -27,8 +27,12 @@ func (app *application) rssFeedScraper(feed *data.Feed) {
 			app.logger.Info("An error occurred while marking feed as fetched", zap.String("Feed Name", feed.Name), zap.Int64("Feed ID", feed.ID))
 			return
 		}
-		// call our GetRSSFeeds to return all feeds for each specific URL
+		// call our GetRSSFeeds to return all feeds for each specific URL.
+		// app.ctx is the lifecycle context so a SIGTERM aborts in-flight
+		// scrapes promptly; the inner function further bounds the call
+		// with a 30s response timeout.
 		rssFeeds, err := app.scraperGetRSSFeeds(
+			app.ctx,
 			app.config.scraper.scraperclient.retrymax,
 			app.config.scraper.scraperclient.timeout,
 			feed.URL, app.config.sanitization.sanitizer)


### PR DESCRIPTION
## Why

The inbound request pipeline now stamps every log line with `req_id`,
`conn_id`, and `user_id`, so I can pull a single inbound request out of
the logs and see everything our process did while serving it. The trail
ends at the process boundary though: when the slow part is one of the
upstream calls (Alpha Vantage, FRED, FMP, OCR.Space, the predictor
micro-service, SambaNova, the RSS scraper), the outbound side of the
hop is invisible.

This change closes that gap. Any inbound request can now be traced
through to its specific upstream call, and the upstream call carries
the same `X-Request-ID` we generated on the inbound side so a
log-aware upstream service (or our own RSS feeds) can stitch back to
us by the same key.

## What I changed

**Three helpers in `cmd/api/http_clients.go`** picked up new behaviour:

- They now take a `context.Context` as the first parameter and bind the
  outbound request to it. A client disconnect or our own timeout
  cancels the upstream call promptly instead of waiting for it to
  finish.
- They forward the inbound `X-Request-ID` from the ctx onto the
  outbound request. They never overwrite a header the caller already
  set, and they never inject an empty header when the ctx never
  flowed through the request middleware (cron paths, tests).
- They emit one structured `http outbound` log line per call carrying
  `method`, `host`, `path`, `status`, `bytes`, `latency_ms`, `req_id`,
  `conn_id`, `user_id`. The full URL is deliberately NOT logged
  because several upstream providers carry their API key in the query
  string; surfacing it would be a credential leak. See `SECURITY.md`
  for the rotation runbook if a leak ever happens. Log levels mirror
  the inbound middleware: 5xx and transport errors at `Error`, ctx
  cancel and deadline at `Info` (expected client behaviour, not an
  upstream fault), everything else at `Info`.

**Migration touched ten direct call sites** across `api_manager.go`,
`investment_operations.go` (five sites), `helpers.go` (OCR + currency
cron), `personal_finance_portfolio.go` (predictor POST) and
`ai_operations.go` (SambaNova). Each one already had a `ctx` or an
`*http.Request` in scope, so the call-site change was mechanical.

**Five intermediate helpers** that did not previously carry a context
gained one as a leading parameter: `getAndSaveAvailableCurrencies`,
`proces1sOCRRequestHelper`, `buildLLMRequestHelper`,
`buildPersonalFinanceLLMRequest`, `buildOCRRecieptAnalysisLLMRequest`.

**The RSS scraper** (`scraperGetRSSFeeds`) cannot route through the
generic `GETRequest[T]` because the body is XML, not JSON. I gave it
the same context-binding and structured outbound log line directly.

**`Optivet_Client`** gained an optional `logger` field; `NewClient`
grew a third parameter to accept it. Passing `nil` preserves the old
no-outbound-tracing behaviour for throwaway scripts and tests that
care only about the request mechanics.

## What I did NOT change

I left the SambaNova `LLMRequest` blocking-and-buffering shape alone.
That call still holds an inbound request open for ~10-30 seconds while
streaming chunks server-side and assembling them in-memory. Fixing
that means streaming the chunks back to our own client over SSE, which
is its own slice. This change makes the existing slow call observable;
the next slice can make it actually fast.

## Tests

A new `cmd/api/http_clients_test.go` exercises the helper directly
against an `httptest` server. Nine cases:

- `X-Request-ID` is forwarded from the ctx onto the outbound request
- no header is stamped when the ctx never flowed through the
  request middleware
- a caller-supplied `X-Request-ID` is preserved verbatim
- the outbound log shape contains all nine expected fields and does
  NOT contain a `url` field (the credential-leak guard)
- 5xx responses log at `Error` level
- ctx cancellation logs at `Info`, not `Error`, so a tab-close mid
  upstream call does not generate spurious alert noise
- POST forwards `X-Request-ID` the same way GET does
- the URL sanitiser strips query strings and fragments cleanly
- `NewClient` with a nil logger still works for callers that opt
  out of outbound tracing

Locally:
- `go build ./...` clean
- `go vet ./...` clean
- `go test -race -count=1 -timeout=120s ./...` all green

`staticcheck` and `govulncheck` run via the existing audit workflow on
every PR.

## Follow-ups

- A `/metrics` endpoint emitting the existing expvars in Prometheus
  format (the counters are all there on `/debug/vars` already; this
  is purely a format adapter that unlocks Grafana with no further
  plumbing).
- Streaming the SambaNova response back to the inbound client over
  SSE plus a retry budget tied to user tier so the call no longer
  holds a request open for ~10-30 seconds.
