### PR TITLE
Add committed .env.example template and tighten .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
+# Local environment files. .env*.example is whitelisted so the committed
+# templates stay tracked; everything else (.env, .env.local, .env.production,
+# cmd/api/.env, etc.) is ignored to keep real secrets out of git.
 *.env
+!.env.example
+!.env*.example

--- a/README.md
+++ b/README.md
@@ -112,36 +112,25 @@ goose postgres postgres://aggregate:password@localhost/aggregate  up
 
 5. **Download and Setup the MIcroService:** Follow the instructions highlighted [here](https://github.com/Blue-Davinci/OptiVest_Finance_Predictor_Micro_Service_V1) to get the micro-service up and running.
 
-6. **Environment Variable Setups:** OptiVest uses a few external APIs. You will need to set them up and make an `.env` containing the following templates:
-```bash
-# DSN Link to our Postgres database
-OPTIVEST_DB_DSN=postgres://optivest:yourpassword@localhost/optivest?sslmode=disable
-# For deployment: , comment the above and uncomment the below DSN
-#OPTIVEST_DB_DSN=postgres://optivest:yourpassword@host.docker.internal/optivest?sslmode=disable
-OPTIVEST_DATA_ENCRYPTION_KEY=xxxxxxx
+6. **Environment variables:** Copy the committed template into the location
+   the API loads at boot, then fill in real values:
 
-# Mailer configuration
-OPTIVEST_SMTP_HOST=xxxxx
-OPTIVEST_SMTP_USERNAME=xxxxxx
-OPTIVEST_SMTP_PASSWORD=xxxxxxx
-OPTIVEST_SMTP_SENDER=Optivest <no-reply@optivest.tech>
+   ```bash
+   cp cmd/api/.env.example cmd/api/.env
+   # then edit cmd/api/.env
+   ```
 
-# Exchange Rate API
-OPTIVEST_EXCHANGERATE_API_KEY=xxxxxxxxx
-# Alpha Vantage API
-OPTIVEST_ALPHAVANTAGE_API_KEY=xxxxxx
-# Fred API
-OPTIVEST_FRED_API_KEY=xxx
-# Financial Modeling Prep API
-OPTIVEST_FINANCIALMODELINGPREP_API_KEY=xxxxx
-# Samba Nova LLM API
-OPTIVEST_SAMBA_NOVA_LLM_API_KEY=xxxx
-# Optivest Predictor Microservice
-OPTIVEST_PREDICTOR_API_KEY=xxx
-# OCR.Space API
-OPTIVEST_OCRSPACE_API_KEY=xxxx
-```
-**The above .env is self explanatory for each API needed**
+   `cmd/api/.env.example` documents every variable, marks each one as
+   `[REQUIRED]` or `[OPTIONAL]`, calls out which ones are tolerated as
+   warnings in `-env=development` and fatal in non-development, and
+   includes a one-liner for generating the AES encryption key with
+   `openssl rand -hex 32`. The actual `cmd/api/.env` you create is
+   gitignored, so real secrets never enter the repo.
+
+   `godotenv.Load` runs against `cmd/api/.env` (or `.env` if your CWD is
+   already `cmd/api/`); environment variables exported in your shell take
+   precedence over the file, so per-shell overrides work without editing
+   it.
 
 5. **Build the project:** You can build the project using the makefile's command:
 

--- a/cmd/api/.env.example
+++ b/cmd/api/.env.example
@@ -1,0 +1,95 @@
+# =============================================================================
+# OptiVest API - environment variable template
+# =============================================================================
+#
+# Copy this file to cmd/api/.env (loaded automatically by godotenv at boot)
+# and fill in real values. Anything blank below is either optional or has a
+# safe in-code default.
+#
+# Loading mechanism: cmd/api/main.go calls godotenv.Load() against
+# cmd/api/.env (or .env when CWD is cmd/api). Values from a real environment
+# (export FOO=bar before `make run/api`) take precedence over the file, so
+# you can override any of these per-shell without editing the file.
+#
+# Required vs optional: every variable below is marked [REQUIRED] or
+# [OPTIONAL]. In `-env=development` (the default) missing required values
+# only emit a WARN log and the server still boots far enough to do partial
+# integration work, but most code paths that touch DB / Redis / outbound
+# vendors will fail at first use. In `-env=staging` or `-env=production`
+# the same gaps are FATAL and the server refuses to start. Validation logic
+# lives in validateConfig() in cmd/api/main.go.
+
+# -----------------------------------------------------------------------------
+# Database
+# -----------------------------------------------------------------------------
+# [REQUIRED] PostgreSQL DSN. Format:
+#   postgres://USER:PASSWORD@HOST:PORT/DATABASE?sslmode=disable
+# Local default for the docker-compose stack:
+#   postgres://optivest:optivest@localhost:5432/optivest?sslmode=disable
+OPTIVEST_DB_DSN=
+
+# -----------------------------------------------------------------------------
+# Redis
+# -----------------------------------------------------------------------------
+# [OPTIONAL] Redis password. Address (-redis-addr, default localhost:6379)
+# and DB index (-redis-db, default 0) are CLI flags, not env vars; set them
+# via flags if your local Redis is somewhere else. Leave this empty for an
+# auth-disabled local Redis.
+OPTIVEST_REDIS_PASSWORD=
+
+# -----------------------------------------------------------------------------
+# Encryption - used by internal/data for AES-GCM at-rest encryption
+# -----------------------------------------------------------------------------
+# [REQUIRED] Hex-encoded AES key. The decoded value MUST be 16, 24, or 32
+# bytes (AES-128 / AES-192 / AES-256). Generate one for local dev with:
+#   openssl rand -hex 32
+# Anything else is rejected at startup so the first encrypt/decrypt call
+# does not panic. Treat this like a database password: do NOT commit and
+# rotate per the runbook in SECURITY.md if it leaks.
+OPTIVEST_DATA_ENCRYPTION_KEY=
+
+# -----------------------------------------------------------------------------
+# External API keys - financial data + LLM + OCR
+# -----------------------------------------------------------------------------
+# Each provider's URL is a CLI flag with a sensible default; only the keys
+# come from env. Rotation procedures for every key live in SECURITY.md.
+
+# [REQUIRED] Alpha Vantage - equity time series, fundamentals
+# Free tier: 5 req/min. Premium: 75 req/min. Premium Plus: 600 req/min.
+# Tune -portfolio-worker-limit to your tier (default 6 = Premium).
+OPTIVEST_ALPHAVANTAGE_API_KEY=
+
+# [REQUIRED] ExchangeRate-API - FX rates for the multi-currency layer
+OPTIVEST_EXCHANGERATE_API_KEY=
+
+# [REQUIRED] FRED - macro series (rates, inflation, etc.)
+OPTIVEST_FRED_API_KEY=
+
+# [REQUIRED] Financial Modeling Prep - sector snapshots, fundamentals
+OPTIVEST_FINANCIALMODELINGPREP_API_KEY=
+
+# [REQUIRED] SambaNova - LLM completions for portfolio + personal-finance
+# analysis. Held open for 10-30s per request, so make sure your account
+# has streaming enabled.
+OPTIVEST_SAMBA_NOVA_LLM_API_KEY=
+
+# [REQUIRED] OptiVest predictor microservice - the in-house ML predictor
+# at -api-url-optivestmicroservice (default http://127.0.0.1:8000/v1/predict).
+# Use a shared bearer token between the two services in non-dev envs.
+OPTIVEST_PREDICTOR_API_KEY=
+
+# [REQUIRED] OCR.Space - receipt analysis pipeline
+OPTIVEST_OCRSPACE_API_KEY=
+
+# -----------------------------------------------------------------------------
+# SMTP - outbound mail (account activation, password reset, etc.)
+# -----------------------------------------------------------------------------
+# [REQUIRED in non-dev] Mailtrap is the convenient default for local
+# development; production typically uses SES, Postmark, or similar.
+OPTIVEST_SMTP_HOST=sandbox.smtp.mailtrap.io
+OPTIVEST_SMTP_USERNAME=
+OPTIVEST_SMTP_PASSWORD=
+OPTIVEST_SMTP_SENDER="OptiVest <no-reply@optivest.local>"
+# Note: -smtp-port is a CLI flag, default 587. Override at run time
+# (e.g. `make run/api -- -smtp-port 2525`) if your provider uses a
+# non-default port.


### PR DESCRIPTION
## Summary

I added a committed env-var template at `cmd/api/.env.example` so a fresh contributor can copy it to `cmd/api/.env`, fill in real values, and have the API boot. Every variable is marked `[REQUIRED]` or `[OPTIONAL]` and explicitly notes which ones are tolerated as warnings in `-env=development` versus fatal in non-development. This mirrors the actual logic in `validateConfig` in `cmd/api/main.go`, so the template and the runtime stay in sync.

`.gitignore` now whitelists `*.env.example` while keeping every other `*.env` file ignored, so the template stays tracked and real secrets never enter the repo:

```
*.env
!.env.example
!.env*.example
```

Verified locally:
- `cmd/api/.env` → ignored (`*.env`)
- `cmd/api/.env.example` → tracked (`!.env*.example`)

## What's in the template

- Database DSN (with the local docker-compose default for the upcoming Docker stack)
- Redis password (optional; address/db are CLI flags)
- AES-GCM encryption key with a one-liner for generating one (`openssl rand -hex 32`) and a note that it must decode to 16/24/32 bytes
- Every external vendor key (Alpha Vantage, ExchangeRate-API, FRED, FMP, SambaNova, the OptiVest predictor microservice, OCR.Space) with a brief reminder of what each one is for
- SMTP block with a Mailtrap default for local development

## README

Step 6 of the Getting Started section used to inline a copy of the variable list. I replaced that block with a `cp` instruction pointing at the template, plus a short note about the `godotenv` load order (file is loaded from `cmd/api/.env`; shell-exported env vars take precedence). The duplicate inline list went away because keeping it in sync with the real validation rules was already drifting.

## Boot check

Running `go run ./cmd/api` against a populated `cmd/api/.env`:

1. `Loading Environment Variables path=cmd/api/.env` — godotenv loaded the file.
2. Flag parsing succeeded.
3. `validateConfig` in development mode emitted warnings for the missing vendor keys (per the design) and the server kept going.
4. The encryption key passed the hex/length check.
5. The DSN was loaded (no missing-DSN error).
6. Boot stopped at the Redis dial step — fully expected without infrastructure, and exactly what the follow-up Docker PR will address.

So the env-loading path is verified end-to-end; the next step is the local Docker stack so the boot can actually complete.

## Test plan

- [x] `git check-ignore -v cmd/api/.env` returns the ignore rule
- [x] `git check-ignore -v cmd/api/.env.example` returns nothing (tracked)
- [x] `go run ./cmd/api` loads `cmd/api/.env` and proceeds past `validateConfig`
- [x] CI green