### PR TITLE
chore(docker): containerize the API and add a one-command local stack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,50 @@
+# Keep the build context tight. Anything not listed here is shipped to the
+# Docker daemon on every `docker build`, which slows builds and leaks files
+# we never want in an image.
+
+# VCS metadata. The build does not use any of it; vcs.Version() reads from
+# the Go module info, not from .git, so dropping the directory is safe.
+.git
+.gitignore
+.gitattributes
+
+# Editor / IDE state
+.vscode
+.idea
+*.swp
+
+# Local tooling caches and outputs
+.tmp
+bin
+*.exe
+api
+api.exe
+
+# Test artefacts and coverage profiles
+*.test
+*.out
+coverage.out
+coverage.html
+
+# OS noise
+.DS_Store
+Thumbs.db
+
+# Documentation that does not need to be in the image. Keep README + SECURITY
+# at runtime so `docker exec ... cat /app/README.md` still works during
+# incident triage if the operator copies them in via a future runtime stage
+# tweak; for now exclude.
+*.md
+!README.md
+!SECURITY.md
+
+# Local environment files. The image must not bake secrets in.
+*.env
+!*.env.example
+
+# Container artefacts of past builds
+docker-compose.override.yml
+.docker
+
+# Test data fixtures that are large and unused by the build
+testdata

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,42 @@
+# =============================================================================
+# OptiVest — docker compose stack credentials
+# =============================================================================
+#
+# This file is loaded by `docker compose` ITSELF (not by the API binary)
+# for ${VAR} interpolation in docker-compose.yml. It is distinct from
+# cmd/api/.env, which carries the binary's runtime config.
+#
+# Quickstart on a fresh checkout:
+#
+#   cp .env.example .env
+#   # edit .env, set POSTGRES_PASSWORD to a value of your choice
+#   make docker/up
+#
+# The actual /.env is gitignored. Never commit it.
+#
+# Production / staging deployments do NOT read this file — they read
+# whatever secret-management system the deployment uses (k8s secrets,
+# AWS Secrets Manager, Doppler, Vault, etc.). The compose file is a
+# local-development convenience only.
+#
+# Why these are required (not defaulted): a default like "optivest_dev"
+# would (a) get copied verbatim into staging or production by someone
+# moving fast, (b) trip secret scanners (GitGuardian, trufflehog) every
+# time the file changes, and (c) embed a credential pattern in git
+# history that we then have to rotate forever. Requiring the operator
+# to set the value once on first checkout costs ~10 seconds and avoids
+# all of the above.
+# =============================================================================
+
+# ----- PostgreSQL -----------------------------------------------------------
+# These three drive the postgres container's bootstrap (POSTGRES_USER /
+# POSTGRES_PASSWORD / POSTGRES_DB env vars, which the official postgres
+# image consumes on first run to create the role and database) AND the
+# DSNs used by the migrate + api services. Single source of truth.
+#
+# Pick whatever values you like for local dev. The most common choice is
+# `optivest` for user and database and a memorable-but-non-trivial
+# password for the password field.
+POSTGRES_USER=optivest
+POSTGRES_PASSWORD=
+POSTGRES_DB=optivest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,130 @@
+# syntax=docker/dockerfile:1.7
+
+# =============================================================================
+# OptiVest API — multi-stage container build
+# =============================================================================
+#
+# Stage 1: builder
+#   - golang:1.25-alpine matches the toolchain pinned in go.mod / CI
+#   - dependencies are downloaded in a dedicated layer so source changes
+#     don't bust the (much slower) go mod download cache
+#   - CGO is explicitly disabled. None of our direct or transitive deps
+#     pull in cgo (verified: pure-go lib/pq, no go-sqlite3 etc.), and a
+#     static binary lets the runtime image be slim alpine (or distroless
+#     in a follow-up) without worrying about glibc / musl symbol drift.
+#   - linker flags strip debug symbols (-s) and the section table (-w);
+#     CI builds locally with -ldflags '-s' for the same reason.
+#
+# Stage 2: runtime
+#   - alpine:3.20 is small (~7 MiB) and ships an interactive shell + curl,
+#     which keeps `docker exec` debugging usable. A future tightening
+#     pass could swap to gcr.io/distroless/static:nonroot to drop another
+#     few MiB and remove the shell, but that comes at the cost of incident-
+#     time tooling.
+#   - we run as a dedicated non-root user (optivest, uid 10001). Even
+#     though the binary listens on 4000 (>1024), having USER set means a
+#     compromised process cannot escalate to root inside the container,
+#     which is the baseline expectation for any container that ships to
+#     a multi-tenant cluster.
+#   - certificates are copied from the builder so outbound TLS to Alpha
+#     Vantage / FRED / FMP / SambaNova / OCR.Space works out of the box;
+#     ca-certificates is a no-op layer on alpine which already ships the
+#     trust bundle, but copying makes the runtime stage portable to a
+#     scratch / distroless base in a future tightening pass.
+#   - HEALTHCHECK polls /healthcheck (mounted on the base router, no auth,
+#     no rate limiting). 5s timeout / 30s interval / 3 retries gives ~95s
+#     before the container is marked unhealthy — long enough to ride out
+#     a single GC pause but short enough to detect a hung process.
+# =============================================================================
+
+# ---------- Stage 1: builder ----------
+FROM golang:1.25-alpine AS builder
+
+WORKDIR /src
+
+# Toolchain extras. git is pulled in implicitly by some go modules during
+# `go mod download` (private replace directives, vcs stamping); without it
+# the download fails with cryptic "exec: git: not found" errors.
+RUN apk add --no-cache git ca-certificates tzdata
+
+# Dependency layer. Copying just go.mod/go.sum first means iterative source
+# edits during local development do not re-trigger `go mod download` — the
+# expensive step is cached as long as the module graph is unchanged.
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Source layer. .dockerignore keeps node_modules / .git / vendored test
+# fixtures out of the build context.
+COPY . .
+
+# Build flags:
+#   CGO_ENABLED=0     -> fully static binary, runtime needs no libc
+#   GOOS/GOARCH       -> default to the build platform; multi-arch is a
+#                        future enhancement using buildx.
+#   -trimpath         -> strip absolute paths so the binary is reproducible
+#                        across machines and so error stacks don't leak
+#                        the build host's filesystem layout.
+#   -ldflags '-s -w'  -> strip the symbol table and DWARF info; reduces
+#                        binary size by ~30% with no debugging cost since
+#                        we collect logs out-of-band via zap.
+ENV CGO_ENABLED=0
+RUN go build -trimpath -ldflags='-s -w' -o /out/api ./cmd/api
+
+# ---------- Stage 2: runtime ----------
+FROM alpine:3.20
+
+# OCI image labels. Registries (GHCR, Harbor, Quay), Docker Desktop, and
+# SBOM tooling (syft, trivy) all key off these to display source links,
+# license, and build metadata. They are pure metadata, no runtime cost.
+# org.opencontainers.image.version is left for CI to overwrite via
+# --label or --build-arg when releasing tagged images.
+LABEL org.opencontainers.image.title="optivest-api" \
+      org.opencontainers.image.description="OptiVest backend API server" \
+      org.opencontainers.image.source="https://github.com/Blue-Davinci/OptiVest" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.vendor="OptiVest"
+
+# Runtime packages:
+#   tini             — see ENTRYPOINT note below
+#   ca-certificates  — needed for outbound TLS to the financial-data vendors
+#                       (Alpha Vantage, FRED, FMP, SambaNova, OCR.Space)
+#   wget             — used by HEALTHCHECK below; busybox wget ships with
+#                       alpine but spelling it out explicitly means a
+#                       future base swap (e.g. to a slimmer scratch /
+#                       distroless image) breaks loudly at build rather
+#                       than silently at runtime
+#   tzdata           — so log timestamps and cron schedules use the
+#                       configured timezone, not UTC-only
+RUN apk add --no-cache tini ca-certificates wget tzdata \
+    && addgroup -S optivest \
+    && adduser -S -u 10001 -G optivest optivest
+
+WORKDIR /app
+COPY --from=builder /out/api /app/api
+
+# Drop privileges. UID 10001 matches a number of cloud-provider non-root
+# presets so a downstream k8s manifest can use runAsUser: 10001 with no
+# coordination; the choice is otherwise arbitrary as long as it is not 0.
+USER optivest
+
+EXPOSE 4000 4001
+
+# tini gives us a real PID 1: it forwards SIGTERM/SIGINT to the Go binary
+# (PID 1 in Linux has special signal semantics — default handlers are
+# ignored unless explicitly registered, which can stall graceful shutdown)
+# and reaps zombie children if any are ever spawned. Today the binary
+# does no os/exec work so the zombie-reaper aspect is forward-looking,
+# but tini is ~30 KB and zero runtime overhead, so the insurance is free.
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["/app/api"]
+
+# k8s probes typically replace this with their own liveness/readiness
+# definitions, but for plain `docker run` and docker compose the
+# HEALTHCHECK is what `docker ps` reports as healthy/unhealthy.
+# Note on the wget invocation: busybox wget (the variant alpine ships) has
+# subtly different exit-code semantics from GNU wget. In particular
+# `wget --spider` returns non-zero on a perfectly successful HEAD response,
+# which silently breaks the probe. Doing a tiny GET and discarding the body
+# avoids that footgun and works on both flavours.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget -q -O /dev/null --tries=1 http://127.0.0.1:4000/healthcheck || exit 1

--- a/Dockerfile.migrate
+++ b/Dockerfile.migrate
@@ -1,0 +1,54 @@
+# syntax=docker/dockerfile:1.7
+
+# =============================================================================
+# Goose migration runner — one-shot container.
+# =============================================================================
+#
+# Pressly publishes the goose Go module but does not maintain an official
+# CLI Docker image, and the community-mirrored variants drift in version
+# pinning and trust. Building our own from the same golang:1.25-alpine
+# base used by the API image keeps us off third-party registries entirely
+# and pins to the exact goose version the codebase was tested with.
+#
+# The container is intentionally a single binary on alpine — no /app, no
+# user account, no shell session expected. It runs once per
+# `docker compose up`, applies the migrations from /migrations (mounted by
+# compose), and exits with status 0 on success or non-zero on failure.
+# Compose's depends_on -> service_completed_successfully is what gates the
+# api service from starting before this one finishes.
+# =============================================================================
+
+# ---------- Stage 1: install goose ----------
+FROM golang:1.25-alpine AS builder
+
+# Pin the goose version explicitly. Bumping it is a one-line change and a
+# new image tag, so operators can roll forward without surprise.
+ARG GOOSE_VERSION=v3.21.1
+
+RUN apk add --no-cache git \
+    && go install github.com/pressly/goose/v3/cmd/goose@${GOOSE_VERSION}
+
+# ---------- Stage 2: minimal runtime ----------
+FROM alpine:3.20
+
+# postgresql-client is convenient for ad-hoc inspection during migration
+# debugging (`docker compose exec migrate psql ...`); strip if you want
+# the smallest possible image.
+#
+# We add a dedicated non-root user even though this container exits in
+# under a second on a normal run. Defense-in-depth: a malformed migration
+# that triggers, say, a goose CVE should not be running with root inside
+# the container. The migrations are read-only-mounted at /migrations from
+# the host, so the only privilege the migrator needs is "open a TCP
+# connection to postgres", which any user has.
+RUN apk add --no-cache ca-certificates postgresql-client \
+    && addgroup -S goose \
+    && adduser -S -u 10001 -G goose goose
+
+COPY --from=builder /go/bin/goose /usr/local/bin/goose
+
+WORKDIR /migrations
+USER goose
+
+ENTRYPOINT ["goose"]
+CMD ["up"]

--- a/README.md
+++ b/README.md
@@ -161,6 +161,82 @@ db/psql            -  connect to the db using psql
 build/api          -  build the cmd/api application
 ```
 
+### Local stack with Docker / Podman
+
+If you don't want to install Postgres + Redis on your host, the repo ships
+a `docker-compose.yml` that brings up the entire stack (Postgres 17, Redis 7,
+a one-shot `goose` migration runner, and the API itself) with a single
+command. The same compose file works on Docker Desktop and on rootless
+Podman with the docker-compatibility shim.
+
+Prerequisites:
+- A container runtime (Docker Engine, Docker Desktop, or rootless Podman 5+)
+- Two populated `.env` files (templates committed, real files gitignored):
+  - `cmd/api/.env` for the API binary's runtime config (smtp, vendor API
+    keys, encryption key, etc) — copy `cmd/api/.env.example`
+  - `/.env` at the repo root for the docker stack's database credentials
+    (`POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB`) — copy
+    `/.env.example`
+
+The two files are deliberately separate: `cmd/api/.env` is loaded by
+the binary via `godotenv`, `/.env` is loaded by `docker compose` itself
+for `${VAR}` interpolation in the compose file. Compose `${VAR:?...}`
+syntax fails fast if anything in `/.env` is unset, so a missing variable
+shows up as a clear error at `make docker/up` time rather than as a
+"password authentication failed" deep in a migration.
+
+Bring everything up:
+
+```bash
+cp .env.example .env                     # first time only — set POSTGRES_PASSWORD
+cp cmd/api/.env.example cmd/api/.env     # first time only — fill the keys you have
+make docker/up
+```
+
+That builds the API image (multi-stage: `golang:1.25-alpine` builder →
+`alpine:3.20` runtime, non-root `optivest` user, static binary), pulls
+`postgres:17-alpine` + `redis:7-alpine`, runs every migration in
+`internal/sql/schema/` against the fresh database, and then starts the
+API. The API container is wired to a `HEALTHCHECK` that polls
+`/healthcheck` every 30s, so `docker compose ps` reflects healthy /
+unhealthy state. The first run takes 1-3 minutes (image pulls + Go module
+download); subsequent runs are layer-cached and start in seconds.
+
+Once it's up, the same observability surface that's exposed locally is
+available from the host:
+
+```bash
+curl http://localhost:4000/healthcheck     # JSON liveness payload
+curl http://localhost:4000/metrics         # Prometheus exposition
+curl http://localhost:4000/debug/vars      # raw JSON expvars
+psql "$OPTIVEST_DB_DSN"                    # interactive DB shell
+```
+
+Other useful targets:
+
+| Command                  | Effect                                                              |
+|--------------------------|---------------------------------------------------------------------|
+| `make docker/logs`       | tail just the API container logs                                    |
+| `make docker/ps`         | list the running compose services                                   |
+| `make docker/migrate`    | re-run `goose up` against the running Postgres                      |
+| `make docker/build`      | rebuild the API image without restarting the stack                  |
+| `make docker/down`       | stop and remove containers, **preserving** the Postgres data volume |
+| `make docker/down/clean` | same as above but **drops** the Postgres volume too                 |
+
+How the API in the container finds its config: docker-compose loads
+`cmd/api/.env` via `env_file`, then overrides the DSN host (`localhost`
+→ `postgres`) and the Redis password (empty in dev) via an explicit
+`environment:` block on the api service. The DSN itself is built from
+the `${POSTGRES_USER}` / `${POSTGRES_PASSWORD}` / `${POSTGRES_DB}` values
+that compose interpolates from the root `/.env`, so there is exactly one
+source of truth for the database credential. The binary itself was
+already tolerant of a missing `.env` file at runtime (it falls back to
+the process environment), which is what makes the same image work in
+cluster deployments where config comes from a Kubernetes Secret rather
+than a file. CLI flags overriding `-redis-addr=redis:6379` are passed
+via the service `command:` so the binary connects to the in-network
+service name rather than the localhost default.
+
 ### Description
 
 The application accepts command-line flags for configuration, establishes a connection pool to a database, and publishes variables for monitoring the application. The published variables include the application version, the number of active goroutines and the current Unix timestamp.

--- a/cmd/api/healthcheck.go
+++ b/cmd/api/healthcheck.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// ---------------------------------------------------------------------------
+// Liveness probe.
+//
+// /healthcheck is mounted on the BASE router (alongside /metrics and
+// /debug/vars), deliberately outside the global middleware chain. Load
+// balancers, k8s liveness probes, and Docker HEALTHCHECK directives all
+// poll this endpoint at high frequency (every 1-30s); putting it through
+// logRequests + the per-IP rate limiter would generate thousands of log
+// lines per day per probe source and could plausibly trip the limiter on
+// a misconfigured cluster.
+//
+// The handler is intentionally minimal:
+//   - no DB ping. A liveness probe answers "is the process running?" not
+//     "is every dependency healthy?"; readiness is the right place for
+//     deeper checks but we do not have a separate readiness endpoint yet.
+//     If you need one, copy this file and add the ping; do not bolt it
+//     onto liveness.
+//   - constant-time JSON output. No allocation in the hot path beyond what
+//     writeJSON does.
+//   - exported uptime measured from a package-level start timestamp set in
+//     init(), not from request time. Operators routinely correlate uptime
+//     with deployment events, so a monotonic value tied to process start
+//     is what they want.
+// ---------------------------------------------------------------------------
+
+// processStart records the wall-clock instant at which this binary became
+// ready to serve. It is set once at package init time and never mutated.
+// Reading it via UnixNano + atomic.LoadInt64 keeps the read lock-free.
+var processStart atomic.Int64
+
+func init() {
+	processStart.Store(time.Now().UnixNano())
+}
+
+// healthcheckHandler answers a 200 OK with a small JSON payload describing
+// the running build. Returns the same shape regardless of state because
+// the only failure mode for liveness should be "the HTTP server stopped
+// answering at all" — a 200 with payload is the unambiguous "I'm alive"
+// signal.
+func (app *application) healthcheckHandler(w http.ResponseWriter, r *http.Request) {
+	uptimeNs := time.Now().UnixNano() - processStart.Load()
+	body := envelope{
+		"status":     "ok",
+		"version":    version,
+		"env":        app.config.env,
+		"uptime_sec": int64(time.Duration(uptimeNs) / time.Second),
+	}
+	if err := app.writeJSON(w, http.StatusOK, body, nil); err != nil {
+		// At this point most of the response is already on the wire; we
+		// cannot upgrade to a 5xx. Log once on the request-correlated
+		// logger so the operator notices.
+		app.loggerFromRequest(r).Error("healthcheck: writeJSON failed", zap.Error(err))
+	}
+}

--- a/cmd/api/healthcheck_test.go
+++ b/cmd/api/healthcheck_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// TestHealthcheck_Shape covers the contract a load balancer or k8s
+// liveness probe expects: 200 status, JSON body with a `status` field set
+// to "ok", and the version + env tags so a multi-cluster operator can tell
+// at a glance which build is answering.
+func TestHealthcheck_Shape(t *testing.T) {
+	app := &application{
+		logger: zap.NewNop(),
+		config: config{env: "development"},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/healthcheck", nil)
+	app.healthcheckHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("response body is not valid JSON: %v\nbody: %s", err, rec.Body.String())
+	}
+
+	if got, ok := body["status"].(string); !ok || got != "ok" {
+		t.Errorf("body.status = %v, want \"ok\"", body["status"])
+	}
+	if _, ok := body["version"]; !ok {
+		t.Error("body missing required field: version")
+	}
+	if got, ok := body["env"].(string); !ok || got != "development" {
+		t.Errorf("body.env = %v, want \"development\"", body["env"])
+	}
+	if _, ok := body["uptime_sec"]; !ok {
+		t.Error("body missing required field: uptime_sec")
+	}
+}
+
+// TestHealthcheck_NoAuthRequired confirms that the handler is callable
+// without a request context that has been through the auth middleware.
+// It would be surprising for an LB probe to need an API key, and any
+// future refactor that accidentally adds an auth dependency should fail
+// here.
+func TestHealthcheck_NoAuthRequired(t *testing.T) {
+	app := &application{
+		logger: zap.NewNop(),
+		config: config{env: "production"},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/healthcheck", nil)
+	app.healthcheckHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (no auth should be required)", rec.Code)
+	}
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -372,10 +372,23 @@ func main() {
 		ListeningUsers:    make(map[int64]bool),
 		ClientCancelFuncs: make(map[int64]context.CancelFunc),
 	}
-	err = app.startupFunction()
-	if err != nil {
-		logger.Fatal("Error while starting up application", zap.String("error", err.Error()))
-		return
+	if err := app.startupFunction(); err != nil {
+		// startupFunction's main job is seeding the default-currency cache
+		// from the Exchange Rate API. In a fresh environment the upstream
+		// call can legitimately fail (no API key in development, vendor
+		// outage, network egress restricted, etc.). validateConfig already
+		// treats missing required secrets as warn-in-dev / fatal-in-prod;
+		// the startup hook should follow the same policy so a developer
+		// without every vendor key can still bring the binary up.
+		// Currency-aware code paths will fail at first use with a clear
+		// per-request error, which is the right tradeoff vs. crash-looping
+		// at boot.
+		if cfg.env == "development" {
+			logger.Warn("startup: currency seeding failed (allowed in development)", zap.String("error", err.Error()))
+		} else {
+			logger.Fatal("Error while starting up application", zap.String("error", err.Error()))
+			return
+		}
 	}
 	// start schedulers
 	app.startSchedulers()
@@ -444,18 +457,31 @@ func publishMetrics() {
 	}))
 }
 
-// getCurrentPath invokes getEnvPath to get the path to the .env file based on the current working directory.
-// After that it loads the .env file using godotenv.Load to be used by the initFlags() function
+// getCurrentPath invokes getEnvPath to get the path to the .env file based on
+// the current working directory and asks godotenv to load it into the
+// process environment.
+//
+// Failure to load the file is intentionally a WARN, not a FATAL: when the
+// binary runs inside a container, k8s pod, or CI job, configuration is
+// usually injected via real environment variables and a .env file is
+// neither expected nor present. The downstream validateConfig() call is the
+// single source of truth for "do we have what we need to start"; it will
+// fatal cleanly with a list of every missing variable in non-development
+// environments and warn-only in development. Forcing a fatal here on top of
+// that just made the binary unrunnable in containers without a sentinel
+// file mounted at the right path.
 func getCurrentPath(logger *zap.Logger) string {
 	currentpath := getEnvPath(logger)
-	if currentpath != "" {
-		err := godotenv.Load(currentpath)
-		if err != nil {
-			logger.Fatal(err.Error(), zap.String("path", currentpath))
-		}
-	} else {
-
-		logger.Error("Path Error", zap.String("path", currentpath), zap.String("error", "unable to load .env file"))
+	if currentpath == "" {
+		logger.Warn("env loader: could not determine .env path; proceeding with process environment only")
+		return currentpath
+	}
+	if err := godotenv.Load(currentpath); err != nil {
+		logger.Warn("env loader: could not load .env; proceeding with process environment only",
+			zap.String("path", currentpath),
+			zap.String("error", err.Error()),
+		)
+		return currentpath
 	}
 	logger.Info("Loading Environment Variables", zap.String("path", currentpath))
 	return currentpath

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -85,6 +85,7 @@ func (app *application) routes() http.Handler {
 	// The endpoints are intentionally unauthenticated; deployments are
 	// expected to scope reachability to the internal scrape network. See
 	// SECURITY.md for the reasoning.
+	router.Get("/healthcheck", app.healthcheckHandler)
 	router.Get("/metrics", app.prometheusMetricsHandler)
 	router.Handle("/debug/vars", expvar.Handler())
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,207 @@
+# =============================================================================
+# OptiVest local development stack
+# =============================================================================
+#
+# Brings up the full stack a fresh contributor needs to run the API:
+#
+#   - postgres   PostgreSQL 17, primary data store
+#   - redis      Redis 7, cache + rate-limiter bucket store
+#   - migrate    one-shot goose runner that applies internal/sql/schema/*.sql
+#                against postgres, then exits with status 0
+#   - api        the Go binary built from ./Dockerfile
+#
+# Use:
+#
+#   docker compose up --build              # bring up the full stack
+#   docker compose down                    # stop and remove containers
+#   docker compose down -v                 # also wipe the postgres volume
+#   docker compose logs -f api             # tail just the API logs
+#   docker compose run --rm migrate up     # re-apply migrations manually
+#
+# The Makefile wraps these as `make docker/up`, `make docker/down`,
+# `make docker/logs`, and `make docker/migrate` for convenience.
+#
+# Networking: every service joins the default compose network and is
+# reachable from the others by service name (postgres, redis). The API
+# container therefore uses postgres:5432 / redis:6379, NOT localhost.
+# Host-side tooling (psql, redis-cli, an HTTP client) reaches the same
+# services on localhost via the published port mappings below.
+#
+# Two distinct .env files are in play here. They are NOT the same thing:
+#
+#   1. /.env (project root)        loaded by docker compose ITSELF for
+#                                  ${VAR} interpolation in this YAML —
+#                                  carries POSTGRES_USER /
+#                                  POSTGRES_PASSWORD / POSTGRES_DB so
+#                                  there is no hardcoded credential in
+#                                  the file. Template at /.env.example,
+#                                  gitignored otherwise.
+#
+#   2. cmd/api/.env                loaded by the API container via
+#                                  `env_file:` below — carries the
+#                                  binary's runtime config (smtp,
+#                                  exchange-rate keys, encryption key,
+#                                  etc). Template at cmd/api/.env.example,
+#                                  gitignored otherwise.
+#
+# Variables that need to differ between the host-run binary and the
+# in-container binary — namely the DSN host (localhost vs postgres) —
+# are overridden via the explicit `environment:` block on the api
+# service, which takes precedence over env_file entries.
+#
+# The `${VAR:?message}` syntax fails compose with a clear error if the
+# variable is unset, instead of silently substituting an empty string —
+# which would otherwise produce an unhelpful "password authentication
+# failed" failure deep in the migration step.
+# =============================================================================
+
+services:
+  # ---------------------------------------------------------------------------
+  # PostgreSQL 17 — primary data store
+  # ---------------------------------------------------------------------------
+  # The healthcheck uses pg_isready against the application user, so the
+  # `migrate` and `api` services do not start until postgres is ACTUALLY
+  # accepting connections (not just "the process is up"). 5s interval / 30s
+  # start_period covers a cold-start volume rebuild.
+  postgres:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER is required - copy .env.example to .env and fill it}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required - copy .env.example to .env and fill it}
+      POSTGRES_DB: ${POSTGRES_DB:?POSTGRES_DB is required - copy .env.example to .env and fill it}
+      # Without this, pg defaults to scram-sha-256 which is fine but worth
+      # being explicit about for the dev image; matches what production
+      # should be running.
+      POSTGRES_HOST_AUTH_METHOD: scram-sha-256
+    # Bind to the host loopback only (127.0.0.1) rather than 0.0.0.0. With
+    # 0.0.0.0, the dev DB would be reachable from anyone on the same LAN /
+    # cafe wifi / coworking VLAN — combined with whatever credential the
+    # operator has in /.env, that is a credible risk even for a dev box.
+    # Loopback binding keeps the port reachable from the host (psql, sqlc,
+    # debugger) and from sibling containers (via the internal compose
+    # network on `postgres:5432`), but invisible from everything else.
+    ports:
+      - "127.0.0.1:5432:5432"
+    volumes:
+      - optivest-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      # The $$ escapes compose interpolation so the shell inside the
+      # container expands the env vars at runtime — the postgres image
+      # already exports POSTGRES_USER / POSTGRES_DB.
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 30s
+
+  # ---------------------------------------------------------------------------
+  # Redis 7 — cache + rate-limiter bucket store
+  # ---------------------------------------------------------------------------
+  # AOF disabled and persistence kept on the default RDB snapshot policy:
+  # this is a dev cache, not a system of record. If a pod is killed we lose
+  # the cache and that's the correct behaviour. --maxmemory + LRU prevent a
+  # runaway test scenario from filling the host disk.
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--maxmemory", "256mb", "--maxmemory-policy", "allkeys-lru"]
+    # Same loopback-only binding rationale as postgres above. Redis 7's
+    # default config has no auth in dev (we run with an empty password),
+    # so a 0.0.0.0 binding would trivially leak the cache to anyone on
+    # the network.
+    ports:
+      - "127.0.0.1:6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  # ---------------------------------------------------------------------------
+  # goose migrations — one-shot
+  # ---------------------------------------------------------------------------
+  # Runs `goose up` against postgres on every `compose up`, then exits.
+  # `restart: no` keeps it from looping. depends_on with condition
+  # service_healthy means the migrate container blocks on postgres being
+  # ready before it tries to connect; without that we'd see a string of
+  # "connection refused" failures while postgres is still booting.
+  #
+  # We build a tiny in-house image (Dockerfile.migrate) that pins the goose
+  # version explicitly. There is no official pressly Docker image and
+  # community mirrors drift, so building from source keeps the supply
+  # chain narrow and reproducible.
+  #
+  # The schema directory is mounted read-only so adding a new migration
+  # does not require an image rebuild; just `make docker/migrate` re-runs
+  # against the existing image.
+  migrate:
+    build:
+      context: .
+      dockerfile: Dockerfile.migrate
+    restart: "no"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      GOOSE_DRIVER: postgres
+      GOOSE_DBSTRING: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable
+      GOOSE_MIGRATION_DIR: /migrations
+    volumes:
+      - ./internal/sql/schema:/migrations:ro
+    command: ["up"]
+
+  # ---------------------------------------------------------------------------
+  # OptiVest API — the binary built from ./Dockerfile
+  # ---------------------------------------------------------------------------
+  # The container's HEALTHCHECK polls /healthcheck (registered on the base
+  # router, no auth, no rate limiting). depends_on with service_completed_
+  # successfully on `migrate` means the API does not start until schema is
+  # in place; without that, the first request that touches a missing table
+  # would fail at runtime instead of at boot.
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    env_file:
+      - cmd/api/.env
+    environment:
+      # Override the host-targeted DSN with the in-network one. env_file
+      # is loaded first; explicit `environment:` entries below win. The
+      # POSTGRES_* values come from /.env via compose interpolation, so
+      # there is one source of truth for the credential.
+      OPTIVEST_DB_DSN: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable
+      # No password on the dev redis; an empty string is valid.
+      OPTIVEST_REDIS_PASSWORD: ""
+    # Unlike postgres / redis, the api ports stay on 0.0.0.0 so a phone or
+    # second laptop on the same LAN can hit the dev API for frontend
+    # integration testing. The binary itself enforces auth (bearer tokens)
+    # and rate limiting, so this is a less stark exposure than the bare
+    # databases — but if a contributor wants stricter isolation they can
+    # change these to "127.0.0.1:4000:4000" / "127.0.0.1:4001:4001". The
+    # observability endpoints (/healthcheck, /metrics, /debug/vars) on
+    # the base router are unauthenticated; SECURITY.md documents the
+    # assumption that a public-internet-facing deploy gates them at the
+    # ingress.
+    ports:
+      - "4000:4000"   # API
+      - "4001:4001"   # WebSocket
+    # Override the binary's CLI flags so it reaches redis by service name
+    # rather than the localhost default. Everything else (port, env name,
+    # rate-limiter knobs) keeps its in-code default.
+    command:
+      - "/app/api"
+      - "-redis-addr=redis:6379"
+
+volumes:
+  # Named volume so `docker compose down` does not wipe the database. Use
+  # `docker compose down -v` to drop it intentionally.
+  optivest-postgres-data:

--- a/internal/sql/schema/029_create_award_triggers.sql
+++ b/internal/sql/schema/029_create_award_triggers.sql
@@ -80,6 +80,7 @@ BEGIN
             FROM awards a
             WHERE a.code = 'first_budget';
         END IF;
+    END IF;
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;

--- a/makefile
+++ b/makefile
@@ -8,6 +8,13 @@ help:
 	@echo "  audit               - Run vet, staticcheck, govulncheck, and the test suite (matches CI)"
 	@echo "  tidy                - Format code and tidy go.mod/go.sum"
 	@echo "  test                - Run the full test suite with -race"
+	@echo "  docker/up           - Build images and bring up the local stack (postgres, redis, migrations, api)"
+	@echo "  docker/down         - Stop and remove the local stack (volumes preserved)"
+	@echo "  docker/down/clean   - Stop the stack AND drop the postgres data volume"
+	@echo "  docker/logs         - Tail the api service logs"
+	@echo "  docker/migrate      - Re-run the goose up migrations against the running postgres"
+	@echo "  docker/build        - Build the api image without starting anything"
+	@echo "  docker/ps           - Show the running compose services"
 
 .PHONY: run/api
 run/api:
@@ -58,3 +65,42 @@ audit:
 	govulncheck ./...
 	@echo 'Running tests with race detector...'
 	go test -race -count=1 -timeout=120s ./...
+
+## docker/up: build images and bring up the full local stack in detached mode
+.PHONY: docker/up
+docker/up:
+	@echo 'Bringing up postgres, redis, migrate, api...'
+	docker compose up --build -d
+
+## docker/down: stop the stack but preserve the postgres data volume
+.PHONY: docker/down
+docker/down:
+	@echo 'Stopping stack (volumes preserved)...'
+	docker compose down
+
+## docker/down/clean: stop the stack AND wipe the postgres data volume
+.PHONY: docker/down/clean
+docker/down/clean:
+	@echo 'Stopping stack and dropping the postgres volume...'
+	docker compose down -v
+
+## docker/logs: tail the api service logs (Ctrl-C to stop)
+.PHONY: docker/logs
+docker/logs:
+	docker compose logs -f api
+
+## docker/migrate: re-run goose up against the running postgres
+.PHONY: docker/migrate
+docker/migrate:
+	@echo 'Re-running migrations...'
+	docker compose run --rm migrate up
+
+## docker/build: build the api image without bringing the stack up
+.PHONY: docker/build
+docker/build:
+	docker compose build api
+
+## docker/ps: list the running compose services
+.PHONY: docker/ps
+docker/ps:
+	docker compose ps


### PR DESCRIPTION
## Summary

I packaged the API as a multi-stage container and wrote a docker-compose
file that brings up the entire local stack — Postgres 17, Redis 7, a
one-shot goose migration runner, and the API itself — with `make docker/up`.

End-to-end verified on rootless Podman 5.8.2 with the docker-compatibility
shim: every service comes up healthy, all 38 migrations apply cleanly from
scratch, and `/healthcheck`, `/metrics`, `/debug/vars` are reachable from
the host on port 4000.

## What changed

### Dockerfile (multi-stage)

- `golang:1.25-alpine` builder produces a CGO-disabled, `-trimpath`,
  `-ldflags='-s -w'` static binary
- `alpine:3.20` runtime adds `tini` as PID 1 (so SIGTERM forwarding works)
  and `ca-certificates` for outbound TLS to the financial-data vendors
- Drops privileges to a dedicated non-root `optivest` user (uid 10001;
  matches a number of cloud-provider non-root presets so a downstream k8s
  manifest can use `runAsUser: 10001` with no coordination)
- `HEALTHCHECK` polls the new `/healthcheck` endpoint via busybox-compatible
  `wget` (busybox's `--spider` exit codes are subtly broken — using
  `-O /dev/null` avoids the trap)
- OCI image labels (`org.opencontainers.image.{title,description,source,
  licenses,vendor}`) so registries and SBOM tooling pick them up

### Dockerfile.migrate

Pressly publishes the goose Go module but not an official CLI image;
`ghcr.io/pressly/goose` returns 403. I build a tiny in-house image that
pins `goose v3.21.1` explicitly, runs as a dedicated non-root `goose` user,
and removes the third-party-registry dependency.

### docker-compose.yml

Four services with healthcheck-based ordering:

- `postgres` (with `pg_isready` healthcheck) — bound to `127.0.0.1` only on
  the host
- `redis` — bound to `127.0.0.1` only on the host
- `migrate` — depends on `postgres` healthy, exits 0 when migrations are
  applied
- `api` — depends on `migrate` completing successfully + `postgres` and
  `redis` healthy

The DSN host gets overridden from `localhost` to `postgres` via an
explicit `environment:` block on the api service so the same
`cmd/api/.env` works for both `make run/api` and `make docker/up`.

The api ports stay on `0.0.0.0` for cross-device LAN testing;
postgres/redis stay loopback-only because they carry the dev credentials
and Redis runs without auth.

### .dockerignore

Drops `.git`, `*.md` (except README/SECURITY), `*.env` (except example),
IDE state, build artefacts, test fixtures.

### makefile

`docker/{up,down,down/clean,logs,migrate,build,ps}` — all wrap `docker
compose`, nothing reaches into podman/docker directly so the same
targets work on Docker Desktop and rootless Podman with the
docker-compatibility shim.

## Adjacent fixes the Docker work surfaced

Three real pre-existing issues — fixing them was unavoidable to get the
stack to come up cleanly, and each is worth fixing regardless of
containerization.

### `internal/sql/schema/029_create_award_triggers.sql`

The `award_first_budget` PL/pgSQL function was missing its outer
`END IF;` — `IF (...) THEN IF (...) THEN INSERT ...; END IF; RETURN NEW;
END;` has only one `END IF` for two opening `IF`s. Postgres reports
`syntax error at or near ";"` on the trailing semicolon because the
outer `IF` block is still open when `END` is reached.

Migrations 1-28 ran fine; 029 failed in goose every time it ran from
scratch. The other three trigger functions in the same file
(`award_first_expense`, `award_first_goal`, `award_first_income`) are
correct and were the reference for the fix. Fresh databases now apply
cleanly through to migration 38.

> [!NOTE]
> Existing databases that applied 029 partially will need
> `goose down 029 && goose up` or a manual cleanup of the
> `award_first_budget` function before redeploying.

### `cmd/api/main.go` — `getCurrentPath`

Missing or unparsable `.env` was previously `logger.Fatal`. That makes
the binary unrunnable in any environment where configuration comes from
real env vars (k8s, CI, bare `docker run`) without a sentinel file
mounted at the right path. Demoted to `logger.Warn`.

The downstream `validateConfig()` is already the single source of truth
for *do we have what we need to start?* — and it already does the right
thing (warn in dev / fatal in non-dev).

### `cmd/api/main.go` — `startupFunction`

`startupFunction` tries to seed the default-currency cache from the
Exchange Rate API and was unconditionally fatal on failure. In dev with
no API key (or behind a corp egress filter, or during a vendor outage)
that crash-loops the container.

Now follows the same warn-in-dev / fatal-in-non-dev policy as
`validateConfig`: currency-aware code paths fail at first use with a
clear per-request error in dev rather than at boot, which is the right
tradeoff.

## New `/healthcheck` endpoint

- Mounted on the **base router** alongside `/metrics` and `/debug/vars`,
  so LB probes do not flow through `logRequests`, the metrics middleware,
  or the per-IP rate limiter — same reasoning as the prior metrics work
- Returns `200` + JSON `{status, version, env, uptime_sec}`
- `uptime_sec` is measured from a package-init timestamp via
  `atomic.Int64`, lock-free. The atomic is defensive — it documents
  intent, costs nothing on 64-bit, prevents torn reads on 32-bit, and
  survives any later refactor that introduces concurrent writes
- **Liveness only — no DB ping.** A liveness probe answers *is the
  process running?*, not *is every dependency healthy?*; readiness with
  a DB ping is the right place for deeper checks but is out of scope here
- Two tests cover the response shape and that the handler works without
  an authenticated request context

## README

New *Local stack with Docker / Podman* section under Getting Started:
prerequisites, the `make docker/up` quickstart, a one-table summary of
the `make docker/*` targets, and a short note on how the in-container
DSN override works.

## Test plan

- [x] `go test ./...` passes
- [x] `go test -race ./cmd/api` passes
- [x] `go vet ./...` clean
- [x] `make docker/up` brings the full stack up, all four services
      report `healthy` / migrate reports `Exited 0`
- [x] `make docker/down/clean && make docker/up` from a wiped volume
      applies all 38 migrations cleanly (regression check on the 029 fix)
- [x] `curl http://localhost:4000/healthcheck` returns
      `{"env":"development","status":"ok","uptime_sec":N,"version":"development version"}`
- [x] `curl http://localhost:4000/metrics` returns Prometheus exposition
      with the curated metric set, content type `text/plain`
- [x] `ss -tln` confirms postgres + redis listen on `127.0.0.1` only,
      api on `0.0.0.0:4000`
- [x] `docker inspect optivest-api:latest` shows OCI labels populated
- [x] `docker inspect optivest-migrate:latest --format '{{.Config.User}}'`
      returns `goose` (non-root)
- [x] CI passes