### PR TITLE
feat(ops): add /readyz readiness probe with postgres + redis pings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,6 +425,23 @@ jobs:
           echo "$body" | jq -e '.uptime_sec | type == "number"' >/dev/null
           echo "healthcheck OK: $body"
 
+      # /readyz is the readiness probe; with the full compose stack up
+      # (postgres + redis + migrate done), it must return 200 and report
+      # both deps as ok. A regression that bypasses pgs or redis pings or
+      # collapses the per-dep map will fail here.
+      - name: Assert /readyz reports ready with all deps up
+        run: |
+          status=$(curl -sS -o /tmp/readyz.body -w '%{http_code}' http://127.0.0.1:4000/readyz)
+          body=$(cat /tmp/readyz.body)
+          if [ "$status" != "200" ]; then
+            echo "expected 200, got $status; body=$body"
+            exit 1
+          fi
+          echo "$body" | jq -e '.status == "ready"' >/dev/null
+          echo "$body" | jq -e '.checks.postgres == "ok"' >/dev/null
+          echo "$body" | jq -e '.checks.redis == "ok"' >/dev/null
+          echo "readyz OK: $body"
+
       - name: Assert /metrics is Prometheus-format
         run: |
           body=$(curl -fsS http://127.0.0.1:4000/metrics)

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ available from the host:
 
 ```bash
 curl http://localhost:4000/healthcheck     # JSON liveness payload
+curl http://localhost:4000/readyz          # JSON readiness payload (postgres + redis)
 curl http://localhost:4000/metrics         # Prometheus exposition
 curl http://localhost:4000/debug/vars      # raw JSON expvars
 psql "$OPTIVEST_DB_DSN"                    # interactive DB shell
@@ -468,16 +469,18 @@ the available commands for a quick lookup (INCOMPLETE, use help for full list).
 > - `optivest_build_info{version="..."} 1` — canonical Prom info-pattern
 >   for build identity
 >
-> The `/metrics` and `/debug/vars` endpoints are mounted on the **base
-> router**, deliberately outside the global middleware chain that wraps
-> `/v1`. Scrape traffic therefore does not flow through `logRequests` (no
-> log-line-per-scrape noise), is not counted by the `metrics` middleware
-> (no circular self-incrementing of the very counters being read), and is
-> not subject to the per-IP rate limiter (a fast or misconfigured scraper
-> cannot lock itself out of the diagnosis endpoint). Both endpoints are
-> unauthenticated; the deployment is expected to scope reachability to the
-> internal scrape network — see `SECURITY.md` for the operator-side
-> assumptions.
+> The `/metrics`, `/debug/vars`, `/healthcheck`, and `/readyz` endpoints
+> are all mounted on the **base router**, deliberately outside the global
+> middleware chain that wraps `/v1`. Probe and scrape traffic therefore
+> does not flow through `logRequests` (no log-line-per-scrape noise), is
+> not counted by the `metrics` middleware (no circular self-incrementing
+> of the very counters being read), and is not subject to the per-IP
+> rate limiter (a fast or misconfigured scraper cannot lock itself out
+> of the diagnosis endpoint, and a load balancer probing `/readyz` more
+> aggressively during a degradation cannot be told the instance is
+> unready by the limiter). All four endpoints are unauthenticated; the
+> deployment is expected to scope reachability to the internal scrape /
+> probe network — see `SECURITY.md` for the operator-side assumptions.
 >
 > Adding a new metric to the `/metrics` surface is one line in
 > `cmd/api/metrics.go` (the `knownMetrics` allow-list); the friction is
@@ -523,7 +526,8 @@ Auth tokens are obtained via `POST /v1/api/authentication` and sent as `Authoriz
 
 | Method | Path | Purpose |
 |---|---|---|
-| GET | `/healthcheck` | Liveness probe; returns `{status, version, env, uptime_sec}` |
+| GET | `/healthcheck` | Liveness probe; returns `{status, version, env, uptime_sec}`. Always 200 unless the process itself is unable to answer. Wire to k8s `livenessProbe` or Docker `HEALTHCHECK`. Failure causes a container restart. |
+| GET | `/readyz` | Readiness probe; pings Postgres and Redis in parallel, returns `200 {status: "ready", checks: {...}}` when both are reachable, `503 {status: "not_ready", checks: {...}}` when any required dep is down. Wire to k8s `readinessProbe` or load-balancer health checks. Failure pulls the instance out of rotation without restarting it. |
 | GET | `/metrics` | Prometheus text exposition of the curated metric set |
 | GET | `/debug/vars` | Raw `expvar` JSON dump for ad-hoc inspection |
 
@@ -823,7 +827,7 @@ makes branch-protection wiring trivial:
 | `docker-build` | buildx + GHA cache | Builds both images, exports tarballs as artifacts |
 | `image-scan` | trivy | HIGH/CRITICAL CVEs and Dockerfile misconfig; SARIF uploaded to the Security tab |
 | `sbom` | syft | SPDX-JSON SBOM per image, retained 30 days |
-| `e2e` | docker compose | Brings the full stack up in CI, probes `/healthcheck`, `/metrics`, `/debug/vars`, tears down |
+| `e2e` | docker compose | Brings the full stack up in CI, probes `/healthcheck`, `/readyz`, `/metrics`, `/debug/vars`, tears down |
 
 A new commit on the same PR auto-cancels the in-flight run via the
 workflow's `concurrency` block, so the canonical "ready to merge"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -97,16 +97,34 @@ boot for sanity-checking config rollouts; it is published on
 
 ### Operational endpoint exposure
 
-`/metrics` and `/debug/vars` are mounted on the base router and bypass
-the global middleware chain on purpose: they are not authenticated, not
-rate-limited, and not counted by the request-log middleware. The
-deployment is responsible for **scoping reachability to the internal
-scrape network** (cluster-local Prometheus, an IP allow-list at the load
-balancer, or an mTLS sidecar). `/debug/vars` exposes runtime memstats
-and goroutine counts that are not strictly secret but should not be
-publicly browsable; `/metrics` carries the curated subset documented in
-`README.md`. If a deployment must expose these endpoints publicly, gate
-them at the ingress rather than weakening the bypass semantics here.
+`/metrics`, `/debug/vars`, `/healthcheck`, and `/readyz` are all mounted
+on the base router and bypass the global middleware chain on purpose:
+they are not authenticated, not rate-limited, and not counted by the
+request-log middleware. The deployment is responsible for **scoping
+reachability to the internal scrape / probe network** (cluster-local
+Prometheus and the kubelet, an IP allow-list at the load balancer, or
+an mTLS sidecar).
+
+What each endpoint discloses, by design:
+
+- `/healthcheck` — version, env name, process uptime in seconds. Wired
+  to the container `livenessProbe`; failure causes a restart.
+- `/readyz` — version, env, uptime, plus a `checks` map naming the
+  required dependencies (`postgres`, `redis`) and reporting each as
+  `ok` or `down`. The body deliberately does **not** include driver
+  error strings, which can leak hostnames, ports, and version banners;
+  operators read the structured logs for the "why". Wired to the load
+  balancer / `readinessProbe`; failure pulls the instance from rotation
+  without restart.
+- `/debug/vars` — raw runtime memstats and goroutine counts. Not
+  strictly secret but should not be publicly browsable.
+- `/metrics` — the curated subset documented in `README.md`.
+
+If a deployment must expose these endpoints publicly, gate them at the
+ingress rather than weakening the bypass semantics here. In particular,
+do NOT add authentication to `/healthcheck` or `/readyz`: orchestrators
+do not carry tokens on probe requests, and an authenticated probe
+endpoint will report the instance as failing for the wrong reason.
 
 ### Latency budget
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -159,6 +159,11 @@ type application struct {
 	mailer      mailer.Mailer
 	wg          sync.WaitGroup
 	RedisDB     *redis.Client
+	// db is the raw connection pool. Held alongside models (sqlc-generated
+	// Queries) so operational endpoints — specifically /readyz — can call
+	// PingContext on it without going through the typed query layer, which
+	// hides *sql.DB behind an unexported DBTX field.
+	db *sql.DB
 	// ctx is the application's lifecycle context. It is canceled when the
 	// process receives SIGINT/SIGTERM (see main()). HTTP servers wire it into
 	// BaseContext so in-flight requests get cancellation propagation, and
@@ -336,8 +341,10 @@ func main() {
 		logger.Fatal("Error while connecting to REDIS.", zap.String("error", err.Error()))
 	}
 	logger.Info("Redis connection established", zap.String("addr", cfg.redis.addr))
-	// create our connection pull
-	db, err := openDB(cfg)
+	// create our connection pull. openDB returns both the raw *sql.DB pool
+	// (used by /readyz for liveness pings) and the sqlc-generated Queries
+	// wrapper (used by the data layer).
+	rawDB, queries, err := openDB(cfg)
 	if err != nil {
 		logger.Fatal(err.Error(), zap.String("dsn", cfg.db.dsn))
 	}
@@ -360,10 +367,11 @@ func main() {
 	app := &application{
 		config:      cfg,
 		logger:      logger,
-		models:      data.NewModels(db),
+		models:      data.NewModels(queries),
 		http_client: httpClient,
 		mailer:      mailer.New(cfg.smtp.host, cfg.smtp.port, cfg.smtp.username, cfg.smtp.password, cfg.smtp.sender),
 		RedisDB:     rdb,
+		db:          rawDB,
 		ctx:         appCtx,
 		WebSocketUpgrader: websocket.Upgrader{
 			ReadBufferSize:  1024,
@@ -501,27 +509,29 @@ func getEnvPath(logger *zap.Logger) string {
 	return filepath.Join("cmd", "api", ".env")
 }
 
-// openDB() opens a new database connection using the provided configuration.
-// It returns a pointer to the sql.DB connection pool and an error value.
-func openDB(cfg config) (*database.Queries, error) {
+// openDB opens the Postgres connection pool and wraps it with the sqlc
+// Queries layer. Both handles are returned: the raw *sql.DB so operational
+// endpoints (e.g. /readyz) can ping it directly, and *database.Queries so
+// the data layer can issue typed queries.
+func openDB(cfg config) (*sql.DB, *database.Queries, error) {
 	db, err := sql.Open("postgres", cfg.db.dsn)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	db.SetMaxOpenConns(cfg.db.maxOpenConns)
 	db.SetMaxIdleConns(cfg.db.maxIdleConns)
 	duration, err := time.ParseDuration(cfg.db.maxIdleTime)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	db.SetConnMaxIdleTime(duration)
 	// Use ping to establish new conncetions
 	err = db.Ping()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	queries := database.New(db)
-	return queries, nil
+	return db, queries, nil
 }
 
 // validateConfig returns a list of human-readable errors describing required

--- a/cmd/api/readyz.go
+++ b/cmd/api/readyz.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+)
+
+// ---------------------------------------------------------------------------
+// Readiness probe.
+//
+// /readyz is mounted on the BASE router (alongside /healthcheck, /metrics,
+// /debug/vars), deliberately outside the global middleware chain. The same
+// reasoning that applies to /healthcheck applies here, doubly so:
+//
+//   - high-frequency probe traffic (k8s readinessProbe / AWS target group
+//     health check, both at single-digit-second intervals) would drown the
+//     real request log if it went through logRequests.
+//   - per-IP rate limiting on the readiness endpoint is exactly the wrong
+//     thing: the LB would be told the instance is unready precisely when
+//     the LB starts probing harder, the classic feedback loop.
+//
+// What /readyz answers vs /healthcheck:
+//
+//   /healthcheck — liveness. "Is the process running?" Always 200 unless the
+//                  HTTP server itself stopped serving. Wired to k8s
+//                  livenessProbe / Docker HEALTHCHECK; failure causes a
+//                  container RESTART.
+//   /readyz      — readiness. "Can this instance serve real traffic right
+//                  now?" 200 when Postgres + Redis are reachable, 503 when
+//                  any required dependency is down. Wired to k8s
+//                  readinessProbe / load-balancer health checks; failure
+//                  causes the instance to be REMOVED FROM ROTATION (no
+//                  restart, no traffic routed in).
+//
+// The split is the orchestrator-pattern that prevents a brief Postgres
+// hiccup from triggering a global restart cascade across every API pod.
+//
+// Scope is intentionally narrow: only the dependencies the request path
+// actually needs to succeed.
+//
+//   - Postgres pool: every authenticated handler hits it.
+//   - Redis: rate limiter, cache layer, notification pubsub.
+//
+// We deliberately do NOT check upstream third-party APIs (Alpha Vantage,
+// FRED, FMP, SambaNova). Their availability is asynchronous to ours;
+// reflecting their state in /readyz would let a vendor outage drain the
+// pool and cause a self-inflicted outage. The application falls back
+// gracefully on those vendors at the per-request layer.
+//
+// Body shape is intentionally minimal. /readyz is unauthenticated by
+// design — k8s and load balancers do not carry tokens. We disclose dep
+// *names* (postgres, redis) which are inferable from any job description,
+// but we do NOT expose error strings on the wire because Go network errors
+// routinely leak internal hostnames, ports, and driver-level details.
+// Operators read the structured logs for the "why"; the probe just tells
+// the orchestrator the "what".
+// ---------------------------------------------------------------------------
+
+// readinessTimeout bounds each per-dependency check. A hung Postgres or
+// Redis must not be able to make /readyz hang past this; the LB needs a
+// definitive answer. 1.5s is comfortably above realistic ping latency
+// (single-digit ms on a healthy stack) and well under any sensible LB
+// probe timeout (typically 5-10s).
+const readinessTimeout = 1500 * time.Millisecond
+
+// readyStatus is the per-dep verdict reported in the response body.
+type readyStatus string
+
+const (
+	readyStatusOK   readyStatus = "ok"
+	readyStatusDown readyStatus = "down"
+)
+
+// readyzHandler runs Postgres and Redis pings in parallel, each with an
+// independent deadline, and returns 200 if both succeed or 503 if either
+// fails. Failures are logged on the request-correlated logger so operators
+// can correlate a 503 here with the underlying driver error.
+func (app *application) readyzHandler(w http.ResponseWriter, r *http.Request) {
+	checks := app.runReadinessChecks(r.Context())
+
+	allOK := true
+	for _, status := range checks {
+		if status != readyStatusOK {
+			allOK = false
+			break
+		}
+	}
+
+	uptimeNs := time.Now().UnixNano() - processStart.Load()
+	body := envelope{
+		"status":     readinessSummary(allOK),
+		"version":    version,
+		"env":        app.config.env,
+		"uptime_sec": int64(time.Duration(uptimeNs) / time.Second),
+		"checks":     checks,
+	}
+
+	statusCode := http.StatusOK
+	if !allOK {
+		statusCode = http.StatusServiceUnavailable
+	}
+
+	if err := app.writeJSON(w, statusCode, body, nil); err != nil {
+		app.loggerFromRequest(r).Error("readyz: writeJSON failed", zap.Error(err))
+	}
+}
+
+// readinessSummary returns the user-facing status string. Kept as a tiny
+// helper so the two call sites (handler + tests) stay in lockstep.
+func readinessSummary(allOK bool) string {
+	if allOK {
+		return "ready"
+	}
+	return "not_ready"
+}
+
+// runReadinessChecks fires the dependency checks concurrently, each with
+// its own bounded context, and returns a stable map keyed by dep name. The
+// parent context is honored: a client that cancels mid-probe (rare, but it
+// happens with aggressive LB timeouts) propagates the cancel into the
+// driver-level pings.
+func (app *application) runReadinessChecks(parent context.Context) map[string]readyStatus {
+	checks := map[string]readyStatus{
+		"postgres": readyStatusDown,
+		"redis":    readyStatusDown,
+	}
+
+	var (
+		mu sync.Mutex
+		wg sync.WaitGroup
+	)
+	record := func(name string, err error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if err != nil {
+			checks[name] = readyStatusDown
+			app.logger.Warn("readyz: dependency unhealthy",
+				zap.String("dependency", name),
+				zap.Error(err),
+			)
+			return
+		}
+		checks[name] = readyStatusOK
+	}
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(parent, readinessTimeout)
+		defer cancel()
+		record("postgres", pingPostgres(ctx, app.db))
+	}()
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(parent, readinessTimeout)
+		defer cancel()
+		record("redis", pingRedis(ctx, app.RedisDB))
+	}()
+	wg.Wait()
+
+	return checks
+}
+
+// pingPostgres is a thin wrapper so tests can exercise the nil-safety
+// branch without spinning up a real *sql.DB. In production the field is
+// always non-nil (main() exits on openDB error), but defending against nil
+// here turns a would-be panic into a clean 503 if the pool is somehow
+// torn down.
+func pingPostgres(ctx context.Context, db *sql.DB) error {
+	if db == nil {
+		return errReadinessNoPool
+	}
+	return db.PingContext(ctx)
+}
+
+// pingRedis mirrors pingPostgres for the Redis client.
+func pingRedis(ctx context.Context, rdb *redis.Client) error {
+	if rdb == nil {
+		return errReadinessNoPool
+	}
+	return rdb.Ping(ctx).Err()
+}
+
+// errReadinessNoPool is returned when the dependency handle is nil, which
+// in practice can only happen in tests or in a half-initialized
+// application. Treating it as "down" rather than panicking keeps the probe
+// honest.
+var errReadinessNoPool = readinessError("dependency handle is nil")
+
+type readinessError string
+
+func (e readinessError) Error() string { return string(e) }

--- a/cmd/api/readyz_test.go
+++ b/cmd/api/readyz_test.go
@@ -1,0 +1,324 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	_ "github.com/lib/pq"
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+)
+
+// readyzTestApp wires a minimal *application against the supplied
+// dependencies. Either may be nil to simulate a torn-down pool. The miniredis
+// instance and *sql.DB lifecycles stay owned by the caller.
+func readyzTestApp(t *testing.T, db *sql.DB, rdb *redis.Client) *application {
+	t.Helper()
+	return &application{
+		logger:  zap.NewNop(),
+		ctx:     context.Background(),
+		db:      db,
+		RedisDB: rdb,
+		config:  config{env: "development"},
+	}
+}
+
+// healthyPostgres returns an *sql.DB that is wired to a real Postgres only
+// if one is reachable on the standard local port; otherwise the test is
+// skipped. Unit tests that require a "Postgres is up" signal without
+// actually exercising the schema use this — the underlying integration
+// e2e job in CI is what proves the path against a real cluster.
+//
+// We do not embed a Postgres test container in unit tests because it is
+// expensive and the production path we care about (db.PingContext) is
+// trivially exercised by the e2e job. The unit tests instead focus on the
+// failure paths, which are the interesting ones for a readiness probe.
+func healthyPostgres(t *testing.T) *sql.DB {
+	t.Helper()
+	dsn := "postgres://optivest:optivest@127.0.0.1:5432/optivest?sslmode=disable&connect_timeout=1"
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		t.Skipf("skip: sql.Open postgres: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 750*time.Millisecond)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		t.Skipf("skip: no local postgres reachable for happy-path test: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// downPostgres returns an *sql.DB wired to a guaranteed-closed port so
+// PingContext fails fast. lib/pq honors the DSN connect_timeout, but we
+// also belt-and-brace with a 1s context deadline at the call site so the
+// failure mode is bounded regardless of driver behavior.
+func downPostgres(t *testing.T) *sql.DB {
+	t.Helper()
+	dsn := "postgres://x:x@127.0.0.1:1/x?sslmode=disable&connect_timeout=1"
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// healthyRedis spins up an in-process miniredis and returns a real
+// go-redis client pointed at it. Cleaning up is automatic via t.Cleanup.
+func healthyRedis(t *testing.T) *redis.Client {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	return redis.NewClient(&redis.Options{Addr: mr.Addr()})
+}
+
+// downRedis returns a go-redis client pointed at a port that is reserved
+// by an immediately-closed listener. Any Ping against it fails inside the
+// dial timeout. We deliberately do not use 127.0.0.1:1 verbatim because
+// the kernel rejects connect(2) before the dial timeout fires on Linux,
+// which is fine for "down" but not great for "we exercised the timeout
+// path"; the explicit closed-listener gives us a TCP RST without
+// involving privileged ports.
+func downRedis(t *testing.T) *redis.Client {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close() // free the port immediately so subsequent dials fail
+	return redis.NewClient(&redis.Options{
+		Addr:        addr,
+		DialTimeout: 100 * time.Millisecond,
+		MaxRetries:  -1,
+	})
+}
+
+// fire issues a GET to /readyz and returns the recorded response. We invoke
+// the handler directly rather than through the router because the router
+// wiring is exercised in TestReadyz_RouteRegistered separately, and a
+// direct call gives the test a deterministic ctx.
+func fire(t *testing.T, app *application) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil).
+		WithContext(context.Background())
+	app.readyzHandler(rec, req)
+	return rec
+}
+
+// decodeReadyz parses the response body and returns its checks map and
+// top-level status field. Any malformed response fails the test
+// immediately because /readyz is a contract endpoint with downstream
+// consumers (k8s, LBs).
+func decodeReadyz(t *testing.T, rec *httptest.ResponseRecorder) (string, map[string]string) {
+	t.Helper()
+	var raw struct {
+		Status string            `json:"status"`
+		Checks map[string]string `json:"checks"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode body: %v\nbody: %s", err, rec.Body.String())
+	}
+	return raw.Status, raw.Checks
+}
+
+// TestReadyz_HappyPath asserts the 200/ready contract when both deps are
+// reachable. Postgres-availability skips if no local cluster is up, so the
+// test is non-flaky in cold environments while still asserting the path
+// when the developer has the docker stack running.
+func TestReadyz_HappyPath(t *testing.T) {
+	app := readyzTestApp(t, healthyPostgres(t), healthyRedis(t))
+
+	rec := fire(t, app)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+	status, checks := decodeReadyz(t, rec)
+	if status != "ready" {
+		t.Errorf("status = %q, want %q", status, "ready")
+	}
+	if checks["postgres"] != string(readyStatusOK) {
+		t.Errorf("checks.postgres = %q, want %q", checks["postgres"], readyStatusOK)
+	}
+	if checks["redis"] != string(readyStatusOK) {
+		t.Errorf("checks.redis = %q, want %q", checks["redis"], readyStatusOK)
+	}
+}
+
+// TestReadyz_PostgresDown is the "Postgres is unreachable, Redis is fine"
+// failure mode. The orchestrator should pull this instance out of
+// rotation; we assert the 503 and the per-dep status disclosure.
+func TestReadyz_PostgresDown(t *testing.T) {
+	app := readyzTestApp(t, downPostgres(t), healthyRedis(t))
+
+	rec := fire(t, app)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body=%s", rec.Code, rec.Body.String())
+	}
+	status, checks := decodeReadyz(t, rec)
+	if status != "not_ready" {
+		t.Errorf("status = %q, want %q", status, "not_ready")
+	}
+	if checks["postgres"] != string(readyStatusDown) {
+		t.Errorf("checks.postgres = %q, want %q", checks["postgres"], readyStatusDown)
+	}
+	if checks["redis"] != string(readyStatusOK) {
+		t.Errorf("checks.redis = %q, want %q", checks["redis"], readyStatusOK)
+	}
+}
+
+// TestReadyz_RedisDown mirrors the Postgres-down case for Redis. The
+// dependency-isolation property of /readyz means a single failing dep
+// must produce a single failing check, never a cascade. Skips silently
+// when no local Postgres is reachable (the same behavior as the happy
+// path test); CI's e2e job covers this path against a real cluster.
+func TestReadyz_RedisDown(t *testing.T) {
+	t.Parallel()
+	app := readyzTestApp(t, healthyPostgres(t), downRedis(t))
+
+	rec := fire(t, app)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body=%s", rec.Code, rec.Body.String())
+	}
+	status, checks := decodeReadyz(t, rec)
+	if status != "not_ready" {
+		t.Errorf("status = %q, want %q", status, "not_ready")
+	}
+	if checks["postgres"] != string(readyStatusOK) {
+		t.Errorf("checks.postgres = %q, want %q", checks["postgres"], readyStatusOK)
+	}
+	if checks["redis"] != string(readyStatusDown) {
+		t.Errorf("checks.redis = %q, want %q", checks["redis"], readyStatusDown)
+	}
+}
+
+// TestReadyz_BothDown exercises the cascading-failure case. Both pings
+// fail, both report down, and the overall verdict is not_ready. This is
+// the test that catches regressions in the per-dep aggregation logic
+// (e.g. someone short-circuiting after the first failure and never
+// running the second probe).
+func TestReadyz_BothDown(t *testing.T) {
+	t.Parallel()
+	app := readyzTestApp(t, downPostgres(t), downRedis(t))
+
+	rec := fire(t, app)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+	_, checks := decodeReadyz(t, rec)
+	if checks["postgres"] != string(readyStatusDown) {
+		t.Errorf("checks.postgres = %q, want %q", checks["postgres"], readyStatusDown)
+	}
+	if checks["redis"] != string(readyStatusDown) {
+		t.Errorf("checks.redis = %q, want %q", checks["redis"], readyStatusDown)
+	}
+}
+
+// TestReadyz_NilHandlesProduceDown covers the defense-in-depth nil-pool
+// branch. In production the handles are always non-nil (main exits on
+// openDB error), but a future refactor that drops the assignment must
+// not be allowed to turn a probe call into a nil-pointer panic.
+func TestReadyz_NilHandlesProduceDown(t *testing.T) {
+	t.Parallel()
+	app := readyzTestApp(t, nil, nil)
+
+	rec := fire(t, app)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+	status, checks := decodeReadyz(t, rec)
+	if status != "not_ready" {
+		t.Errorf("status = %q, want %q", status, "not_ready")
+	}
+	if checks["postgres"] != string(readyStatusDown) {
+		t.Errorf("checks.postgres = %q, want %q", checks["postgres"], readyStatusDown)
+	}
+	if checks["redis"] != string(readyStatusDown) {
+		t.Errorf("checks.redis = %q, want %q", checks["redis"], readyStatusDown)
+	}
+}
+
+// TestReadyz_BodyShape pins down the exposed JSON contract so any future
+// edit that drops a top-level field fails loudly. Downstream consumers
+// (operator dashboards, k8s readiness logs) parse this shape.
+func TestReadyz_BodyShape(t *testing.T) {
+	t.Parallel()
+	app := readyzTestApp(t, downPostgres(t), downRedis(t))
+
+	rec := fire(t, app)
+	var body map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	required := []string{"status", "version", "env", "uptime_sec", "checks"}
+	for _, k := range required {
+		if _, ok := body[k]; !ok {
+			t.Errorf("body missing required field: %q", k)
+		}
+	}
+	if got, ok := body["env"].(string); !ok || got != "development" {
+		t.Errorf("body.env = %v, want \"development\"", body["env"])
+	}
+}
+
+// TestReadyz_DoesNotLeakDriverErrors guards the don't-disclose-internals
+// invariant. The body must report a coarse "down" verdict and must not
+// inline raw driver error strings, which can leak hostnames and ports.
+// This test is intentionally pessimistic: it checks for substrings that
+// commonly appear in lib/pq and go-redis errors.
+func TestReadyz_DoesNotLeakDriverErrors(t *testing.T) {
+	t.Parallel()
+	app := readyzTestApp(t, downPostgres(t), downRedis(t))
+
+	rec := fire(t, app)
+	body := rec.Body.String()
+	for _, leaked := range []string{
+		"127.0.0.1",
+		"connection refused",
+		"dial tcp",
+		"i/o timeout",
+		"sql:",
+		"pq:",
+	} {
+		if strings.Contains(body, leaked) {
+			t.Errorf("response body should not contain driver-level detail %q\nbody=%s", leaked, body)
+		}
+	}
+}
+
+// TestReadyz_RouteRegistered verifies /readyz is wired into the base
+// router and reachable without auth, rate limiting, or logRequests in
+// front of it. We do not stand up real deps here — the failure path is
+// fine for confirming the route wiring; the response code only matters in
+// that it is one of {200, 503}, both of which prove the handler ran.
+func TestReadyz_RouteRegistered(t *testing.T) {
+	t.Parallel()
+	app := readyzTestApp(t, downPostgres(t), downRedis(t))
+	app.config.cors.trustedOrigins = []string{}
+
+	server := httptest.NewServer(app.routes())
+	t.Cleanup(server.Close)
+
+	resp, err := http.Get(server.URL + "/readyz")
+	if err != nil {
+		t.Fatalf("GET /readyz: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 200 or 503", resp.StatusCode)
+	}
+}

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -86,6 +86,7 @@ func (app *application) routes() http.Handler {
 	// expected to scope reachability to the internal scrape network. See
 	// SECURITY.md for the reasoning.
 	router.Get("/healthcheck", app.healthcheckHandler)
+	router.Get("/readyz", app.readyzHandler)
 	router.Get("/metrics", app.prometheusMetricsHandler)
 	router.Handle("/debug/vars", expvar.Handler())
 


### PR DESCRIPTION
## Why this PR

We have had `/healthcheck` for a while as the liveness probe. Liveness
only answers \"is the process running?\" — it cannot distinguish \"process
up but cannot serve traffic because Postgres is unreachable\". Mixing
both checks behind a single endpoint is the classic operational hazard:
a brief Postgres hiccup fails liveness, the orchestrator restarts every
API pod, and the outage gets worse rather than recovering.

This PR splits the concerns properly:

- `/healthcheck` stays as **liveness** — no I/O, always 200, wired to
  k8s `livenessProbe` and the Docker `HEALTHCHECK`. Failure restarts
  the container.
- `/readyz` is the new **readiness** endpoint — pings Postgres and
  Redis in parallel, each with an independent 1.5s deadline, and
  returns `200 {status: \"ready\", checks: {postgres: \"ok\", redis: \"ok\"}}`
  when both are reachable or `503 {status: \"not_ready\", checks: {...}}`
  when any required dep is down. Wired to the load balancer and
  `readinessProbe`. Failure pulls the instance out of rotation
  **without** restarting it.

## Design decisions and the reasoning

- **Scope: narrow.** Only Postgres and Redis. I deliberately did not
  include upstream third-party APIs (Alpha Vantage, FRED, FMP,
  SambaNova). Their availability is asynchronous to ours; reflecting
  their state in `/readyz` would let a vendor outage drain the pool.
  Encryption-key validation and migration state are boot concerns —
  `validateConfig` already FATALs at startup on a missing key, and
  compose's `depends_on: service_completed_successfully` already gates
  the API on `migrate` finishing.
- **Body shape: minimal.** Per-dep `ok` / `down` only. No driver error
  strings on the wire. `/readyz` is unauthenticated by design
  (orchestrators do not carry tokens on probes) and Go network errors
  routinely leak internal hostnames, ports, and driver-level details.
  Operators get the \"why\" from the structured logs.
- **Routing: base router.** `/readyz` is mounted alongside
  `/healthcheck`, `/metrics`, `/debug/vars` — outside the global
  middleware chain. No auth, no rate limit, no `logRequests`. The
  rate-limit bypass is especially important: a load balancer probing
  more aggressively during a degradation must not be told the instance
  is unready by the limiter itself.

## Plumbing

`openDB` now returns both the raw `*sql.DB` (for the readiness ping)
and the sqlc-generated `*database.Queries` (for the data layer).
`application` gained a `db *sql.DB` field. The data layer is unchanged.

## Tests

`cmd/api/readyz_test.go` covers:

- happy path (skips silently if no local Postgres; CI's e2e covers it)
- postgres-down → 503, postgres reports `down`, redis reports `ok`
- redis-down → 503, mirrored case (skips on no local Postgres)
- both-down → 503, both report `down`
- nil-handle defense-in-depth → 503 (no panic)
- JSON body shape (`status`, `version`, `env`, `uptime_sec`, `checks`)
- no-driver-error-leakage invariant (`127.0.0.1`, `dial tcp`,
  `connection refused`, `pq:`, `sql:` must not appear in the body)
- route registration through the real `routes()` chain

## CI

The `e2e` compose smoke test now also asserts `/readyz`:

- 200 from the endpoint
- `status == \"ready\"`
- `checks.postgres == \"ok\"`
- `checks.redis == \"ok\"`

So a regression that wires `/readyz` to the wrong pool, returns the
wrong status code on success, or drops the per-dep map will fail at the
e2e gate.

## Test plan for the reviewer

- [x] `go test ./...` clean locally
- [x] `golangci-lint run` clean (0 issues)
- [x] e2e job assertion exercises real Postgres + real Redis
- [ ] Confirm the new CI pipeline goes green on this PR