### PR TITLE
Stream the SambaNova LLM call with a wallclock + idle budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,12 @@ the available commands for a quick lookup (INCOMPLETE, use help for full list).
         Enable rate limiter (default true)
   -limiter-rps float
         Rate limiter maximum requests per second (default 5)
+  -llm-idle-timeout duration
+        Abort the LLM stream if no chunk arrives within this window (default 15s)
+  -llm-max-retries int
+        Max retries for the LLM call before the first SSE chunk; mid-stream errors never retry (default 2)
+  -llm-total-budget duration
+        Wallclock cap for an LLM streaming call across retries (default 1m30s)
   -portfolio-worker-limit int
         Max concurrent per-asset workers in portfolio analysis (1 = serial; tune to upstream API rate limits) (default 6)
 ```
@@ -485,6 +491,33 @@ the available commands for a quick lookup (INCOMPLETE, use help for full list).
 > Adding a new metric to the `/metrics` surface is one line in
 > `cmd/api/metrics.go` (the `knownMetrics` allow-list); the friction is
 > intentional, since this is an operator-facing surface, not a debug dump.
+
+> **SambaNova streaming + retry budget (P4.A):** The SambaNova chat-completions
+> path is special-cased away from the generic `Optivet_Client` because every
+> call holds a connection slot open for 10–30s while the model emits SSE
+> chunks. `LLMStream` in `cmd/api/http_clients.go` provides three guarantees
+> the generic path cannot:
+>
+> - A **wallclock budget context** (`-llm-total-budget`, default `90s`) caps
+>   the entire call across pre-first-byte retries plus the streaming read.
+>   The retry layer's backoff sleeps inherit this deadline, so a tight
+>   budget naturally compresses the effective retry window.
+> - An **idle deadline** (`-llm-idle-timeout`, default `15s`) aborts the
+>   stream when no chunk has arrived within the window. Protects connection
+>   slots from a stalled upstream that has sent headers but no body, and
+>   caps the impact of a slowloris-style upstream.
+> - **Bounded pre-first-byte retries** (`-llm-max-retries`, default `2`).
+>   Retries fire only on dial / TLS / non-2xx errors that happen *before*
+>   the response body is streamed. Once a chunk has been read, mid-stream
+>   errors return verbatim — replaying a 30s prompt for a transient blip
+>   would double user-visible latency and the token bill, with no
+>   reliability gain because SambaNova's API is not resumable.
+>
+> `LLMRequest` is preserved as a thin back-compat wrapper for callers that
+> only need the joined string (`buildLLMRequestHelper` and friends in
+> `cmd/api/ai_operations.go`). Future Server-Sent Events handlers should
+> call `LLMStream` directly with a non-nil `onChunk` callback to forward
+> partial deltas to the browser as they arrive.
 
 Using `make run`, will run the API with a default connection string located 
 in `cmd\api\.env`. If you're using `powershell`, you need to load the values otherwise you will get

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -156,6 +156,30 @@ upstream fetches (e.g. two stocks of the same symbol), so even under
 fan-out we never N-multiply duplicate vendor calls. Watch
 `portfolio_singleflight_collapsed_total` to confirm dedup is firing.
 
+## SambaNova streaming budget (P4.A)
+
+The SambaNova chat-completions client (`LLMStream` in
+`cmd/api/http_clients.go`) holds a TCP connection open for 10–30s while
+the model emits SSE chunks. Three knobs gate that exposure:
+
+| Flag                   | Default | Role                                                                                                                  |
+| ---------------------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
+| `-llm-total-budget`    | `90s`   | Wallclock cap across pre-first-byte retries plus the streaming read. Bounds the worst-case slot-hold per call.        |
+| `-llm-idle-timeout`    | `15s`   | Aborts the call when no chunk arrives within the window. Slowloris-style mitigation against a stalled or hostile API. |
+| `-llm-max-retries`     | `2`     | Pre-first-byte retry cap. Mid-stream errors **never** retry, regardless of this value.                                |
+
+The mid-stream no-retry rule is a deliberate trade-off: SambaNova's API
+is non-resumable, so replaying a partially-streamed prompt costs the
+full prompt evaluation again (latency + tokens) for no reliability
+gain. Operators wanting tighter blast-radius control should lower
+`-llm-total-budget` rather than raise `-llm-max-retries`.
+
+The idle timeout doubles as the primary defence against a hostile or
+compromised LLM upstream holding our connection slots indefinitely.
+Lowering it past 5s is not recommended - the model's first-token
+latency is genuinely variable, and false-positive aborts manifest as
+user-visible 5xxs.
+
 ## CI security scanning
 
 Every push and PR to `main` runs:

--- a/cmd/api/ai_operations.go
+++ b/cmd/api/ai_operations.go
@@ -23,11 +23,12 @@ type UserPersonalFinanceProfile struct {
 	PersonalFinanceAnalysis data.UnifiedFinanceAnalysis    `json:"personal_finance_analysis"`
 }
 type Chunk struct {
-	ID                string   `json:"id"`
-	Object            string   `json:"object"`
-	Model             string   `json:"model"`
-	SystemFingerprint string   `json:"system_fingerprint"`
-	Choices           []Choice `json:"choices"`
+	ID                string    `json:"id"`
+	Object            string    `json:"object"`
+	Model             string    `json:"model"`
+	SystemFingerprint string    `json:"system_fingerprint"`
+	Choices           []Choice  `json:"choices"`
+	Usage             *LLMUsage `json:"usage,omitempty"`
 }
 
 type Choice struct {
@@ -38,6 +39,17 @@ type Choice struct {
 
 type Delta struct {
 	Content string `json:"content"`
+}
+
+// LLMUsage captures the SambaNova/OpenAI-style token-usage block. It only
+// arrives in the final SSE chunk when the request was made with
+// stream_options.include_usage = true (which all the buildLLM* templates
+// in this file set), and is exposed on LLMStreamResult so future callers
+// can record per-call cost or rate-limit budgets.
+type LLMUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
 }
 
 // buildLLMRequest sends a request to the LLM API with the user's profile and

--- a/cmd/api/http_clients.go
+++ b/cmd/api/http_clients.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -254,87 +255,261 @@ func POSTRequest[T any](ctx context.Context, c *Optivet_Client, requestURL strin
 	return result, nil
 }
 
-// LLMRequest sends a context-bound POST to the SambaNova chat-completions
-// endpoint and reads the streaming response, accumulating chunk content into
-// a single string. ctx propagates so a client disconnect cancels the
-// long-running upstream stream promptly. The same outbound-correlation
-// behavior as GETRequest/POSTRequest applies: X-Request-ID is forwarded
-// when present, and one structured log line summarizes the call.
+// LLMStreamResult is the structured outcome of an LLMStream call.
 //
-// The streaming reader uses a 1 MiB scanner buffer because SambaNova chunks
-// can exceed bufio.Scanner's default 64 KiB limit on long responses.
-func (app *application) LLMRequest(ctx context.Context, requestURL string, headers map[string]string, body string) (string, error) {
+//   - Text holds the concatenation of every content delta the upstream
+//     emitted. Even when an error is returned, Text contains whatever did
+//     stream successfully — partial-progress callers may want to log it
+//     or surface it to the user before falling back.
+//   - Usage carries the final-chunk token-usage block when the upstream
+//     emitted one (stream_options.include_usage = true on the request).
+//     Nil otherwise.
+//   - FinishReason holds the terminal finish_reason from the last choice
+//     ("stop", "length", "content_filter", ...). Empty string when the
+//     stream ended without one (EOF, idle timeout, ctx cancel).
+type LLMStreamResult struct {
+	Text         string
+	Usage        *LLMUsage
+	FinishReason string
+}
+
+// errLLMIdleTimeout is returned by LLMStream when no SSE chunk arrived
+// within the configured idle window. The underlying transport error is
+// always context.Canceled (we cancel the stream ctx from the idle timer);
+// translating it to this sentinel lets operators distinguish "upstream
+// stalled" from "user disconnected" without having to inspect log fields.
+var errLLMIdleTimeout = errors.New("llm: idle timeout exceeded waiting for next chunk")
+
+// idleTimeoutReader wraps an io.Reader with a per-Read inactivity deadline.
+// When no Read returns bytes within timeout, onIdle is invoked exactly once
+// (typically a context cancel func that unblocks the consumer). The reader
+// is single-goroutine; SSE consumers always read sequentially, which is
+// the only call site here.
+type idleTimeoutReader struct {
+	r       io.Reader
+	timer   *time.Timer
+	timeout time.Duration
+	fired   atomic.Bool
+}
+
+func newIdleTimeoutReader(r io.Reader, timeout time.Duration, onIdle func()) *idleTimeoutReader {
+	itr := &idleTimeoutReader{r: r, timeout: timeout}
+	if timeout <= 0 {
+		return itr
+	}
+	itr.timer = time.AfterFunc(timeout, func() {
+		itr.fired.Store(true)
+		if onIdle != nil {
+			onIdle()
+		}
+	})
+	return itr
+}
+
+func (i *idleTimeoutReader) Read(p []byte) (int, error) {
+	n, err := i.r.Read(p)
+	// Re-arm only when bytes arrived and the timer has not already fired.
+	// Once fired, the cancel signal is in flight and we must not "rescue"
+	// the request by extending the deadline — even if more bytes raced
+	// in before the cancel propagated.
+	if i.timer != nil && n > 0 && !i.fired.Load() {
+		i.timer.Reset(i.timeout)
+	}
+	return n, err
+}
+
+func (i *idleTimeoutReader) Stop() {
+	if i.timer != nil {
+		i.timer.Stop()
+	}
+}
+
+func (i *idleTimeoutReader) FiredIdle() bool { return i.fired.Load() }
+
+// llmStreamingDefaults returns the per-call streaming knobs, falling back
+// to safe values when cfg.llm is unset (e.g. zero-valued application{} in
+// tests). Production wiring is in main.go via the -llm-* flags.
+func (app *application) llmStreamingDefaults() (totalBudget, idleTimeout time.Duration, retries int) {
+	totalBudget = app.config.llm.totalBudget
+	if totalBudget <= 0 {
+		totalBudget = 90 * time.Second
+	}
+	idleTimeout = app.config.llm.idleTimeout
+	if idleTimeout <= 0 {
+		idleTimeout = 15 * time.Second
+	}
+	retries = app.config.llm.maxRetriesBeforeFirstByte
+	if retries < 0 {
+		retries = 2
+	}
+	return
+}
+
+// LLMStream sends a context-bound POST to the SambaNova chat-completions
+// endpoint and consumes the SSE response chunk-by-chunk. Three behavioral
+// guarantees on top of the basic POST path:
+//
+//  1. A wallclock budget context (cfg.llm.totalBudget, default 90s) caps
+//     total time across pre-first-byte retries plus the streaming read.
+//     The retry layer's backoff sleeps inherit this deadline, so a tight
+//     budget naturally compresses the retry window.
+//  2. An idle deadline (cfg.llm.idleTimeout, default 15s) aborts the call
+//     when no chunk has arrived within the window. Protects connection
+//     slots from a stalled upstream that has sent headers but no body,
+//     and caps the impact of a slowloris-style upstream.
+//  3. retryablehttp.RetryMax is bounded to cfg.llm.maxRetriesBeforeFirstByte
+//     (default 2). Retries fire only on dial / TLS / non-2xx errors that
+//     happen *before* the response body is streamed; mid-stream errors
+//     are surfaced verbatim because replaying a 30s prompt for a transient
+//     blip costs more (latency + tokens) than failing fast.
+//
+// onChunk, when non-nil, is invoked synchronously for every non-empty
+// content delta the upstream emits — wire it through to a Server-Sent
+// Events handler to stream tokens to the browser, or pass nil to
+// collect-only and read the joined Text from the returned LLMStreamResult.
+// Returning a non-nil error from onChunk aborts the stream with that error
+// and preserves the partial Text accumulated so far.
+//
+// X-Request-ID forwarding and the structured outbound log line behave
+// identically to GETRequest / POSTRequest.
+func (app *application) LLMStream(
+	ctx context.Context,
+	requestURL string,
+	headers map[string]string,
+	body string,
+	onChunk func(delta string) error,
+) (LLMStreamResult, error) {
 	log := app.loggerFromContext(ctx)
 	start := time.Now()
-	jsonBody := []byte(body)
-	clientC := NewClient(60*time.Second, 3, app.logger)
+	var result LLMStreamResult
 
-	req, err := retryablehttp.NewRequest(http.MethodPost, requestURL, bytes.NewBuffer(jsonBody))
+	totalBudget, idleTimeout, retries := app.llmStreamingDefaults()
+
+	streamCtx, cancel := context.WithTimeout(ctx, totalBudget)
+	defer cancel()
+
+	// A streaming-tuned client. No per-request HTTPClient.Timeout — the
+	// budget ctx is the cap, and a stdlib timeout would also kill healthy
+	// long reads. Constructed fresh per call so a future per-tenant
+	// CheckRetry / rate-limiter hook can be stamped without affecting the
+	// shared Optivet_Client used by every other outbound path.
+	retryClient := retryablehttp.NewClient()
+	retryClient.RetryMax = retries
+	retryClient.HTTPClient.Timeout = 0
+	retryClient.Backoff = retryablehttp.LinearJitterBackoff
+	retryClient.ErrorHandler = retryablehttp.PassthroughErrorHandler
+	retryClient.Logger = nil
+	// Tighten the retry-wait bounds vs. retryablehttp's library defaults
+	// (1s / 30s). The LLM call already runs under a wallclock budget, so
+	// long backoffs only burn that budget; with RetryMax=2 the hard cap
+	// here is 100ms + 200ms = 300ms of cumulative sleep which is plenty
+	// to recover from a flapping upstream while staying invisible to the
+	// p95 user-visible latency.
+	retryClient.RetryWaitMin = 100 * time.Millisecond
+	retryClient.RetryWaitMax = 2 * time.Second
+
+	req, err := retryablehttp.NewRequest(http.MethodPost, requestURL, bytes.NewBufferString(body))
 	if err != nil {
 		logOutbound(log, http.MethodPost, requestURL, 0, 0, start, ctx, err)
-		return "", err
+		return result, err
 	}
-	req = req.WithContext(ctx)
+	req = req.WithContext(streamCtx)
 	req.Header.Set("Content-Type", "application/json")
 	for key, value := range headers {
 		req.Header.Set(key, value)
 	}
 	stampOutboundRequestID(req, ctx)
 
-	resp, err := clientC.httpClient.Do(req)
+	resp, err := retryClient.Do(req)
 	if err != nil {
+		// Pass the parent ctx (not streamCtx) so logOutbound classifies
+		// wallclock-budget exhaustion as Error rather than Info: a budget
+		// blow-out is operator-visible, only a true parent-ctx cancel
+		// (user disconnect) should land at Info.
 		logOutbound(log, http.MethodPost, requestURL, 0, 0, start, ctx, err)
-		return "", err
+		return result, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		err := errors.New("non-2xx response code")
+		err := fmt.Errorf("llm: non-2xx response: %d", resp.StatusCode)
 		logOutbound(log, http.MethodPost, requestURL, resp.StatusCode, 0, start, ctx, err)
-		return "", err
+		return result, err
 	}
 
+	// Idle timer wraps the body. The cancel func belongs to streamCtx, so
+	// firing it propagates through the http transport and unblocks the
+	// next scanner.Scan with context.Canceled — which we then translate
+	// to errLLMIdleTimeout for clarity.
+	idleR := newIdleTimeoutReader(resp.Body, idleTimeout, cancel)
+	defer idleR.Stop()
+
 	var fullResponse strings.Builder
-	scanner := bufio.NewScanner(resp.Body)
+	scanner := bufio.NewScanner(idleR)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
 	for scanner.Scan() {
 		line := scanner.Text()
 		if line == "" || line == "data: " {
 			continue
 		}
-		// Defensive prefix strip - older code relied on a fixed length
-		// of 6, which would panic on a malformed line shorter than that.
 		line = strings.TrimPrefix(line, "data: ")
+		if line == "[DONE]" {
+			break
+		}
 
 		var chunk Chunk
 		if err := json.Unmarshal([]byte(line), &chunk); err != nil {
+			// Non-JSON keepalive or transient malformed line; ignore
+			// rather than failing the whole stream over one byte.
 			continue
 		}
+		if chunk.Usage != nil {
+			result.Usage = chunk.Usage
+		}
+
 		for _, choice := range chunk.Choices {
 			if choice.Delta.Content != "" {
 				fullResponse.WriteString(choice.Delta.Content)
+				if onChunk != nil {
+					if cbErr := onChunk(choice.Delta.Content); cbErr != nil {
+						result.Text = fullResponse.String()
+						logOutbound(log, http.MethodPost, requestURL, resp.StatusCode, int64(fullResponse.Len()), start, ctx, cbErr)
+						return result, cbErr
+					}
+				}
 			}
-		}
-		// finishReason on any choice ends the stream early.
-		done := false
-		for _, choice := range chunk.Choices {
 			if choice.FinishReason != nil {
-				done = true
-				break
+				result.FinishReason = *choice.FinishReason
 			}
 		}
-		if done {
+		if result.FinishReason != "" {
 			break
 		}
 	}
 
-	if err := scanner.Err(); err != nil {
-		logOutbound(log, http.MethodPost, requestURL, resp.StatusCode, int64(fullResponse.Len()), start, ctx, err)
-		return "", err
+	if scanErr := scanner.Err(); scanErr != nil {
+		result.Text = fullResponse.String()
+		out := scanErr
+		if idleR.FiredIdle() {
+			out = errLLMIdleTimeout
+		}
+		logOutbound(log, http.MethodPost, requestURL, resp.StatusCode, int64(fullResponse.Len()), start, ctx, out)
+		return result, out
 	}
 
+	result.Text = fullResponse.String()
 	logOutbound(log, http.MethodPost, requestURL, resp.StatusCode, int64(fullResponse.Len()), start, ctx, nil)
-	return fullResponse.String(), nil
+	return result, nil
+}
+
+// LLMRequest is preserved as a thin back-compat wrapper around LLMStream.
+// Existing callers (buildLLMRequestHelper) only need the joined string;
+// future SSE handlers should call LLMStream directly with a non-nil
+// onChunk to forward partial deltas.
+func (app *application) LLMRequest(ctx context.Context, requestURL string, headers map[string]string, body string) (string, error) {
+	res, err := app.LLMStream(ctx, requestURL, headers, body, nil)
+	return res.Text, err
 }
 
 // scraperGetRSSFeeds fetches a single feed URL and decodes the (RSS or Atom)

--- a/cmd/api/http_clients_llm_test.go
+++ b/cmd/api/http_clients_llm_test.go
@@ -1,0 +1,408 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// newLLMTestApp builds a minimal *application wired with an in-memory zap
+// observer plus the three LLM streaming knobs the test wants to exercise.
+// All other application fields are intentionally zero — LLMStream only
+// reads cfg.llm and app.logger, so anything else would just be noise.
+func newLLMTestApp(t *testing.T, totalBudget, idleTimeout time.Duration, retries int) (*application, *observer.ObservedLogs) {
+	t.Helper()
+	core, logs := observer.New(zap.InfoLevel)
+	app := &application{logger: zap.New(core)}
+	app.config.llm.totalBudget = totalBudget
+	app.config.llm.idleTimeout = idleTimeout
+	app.config.llm.maxRetriesBeforeFirstByte = retries
+	return app, logs
+}
+
+// writeSSEChunk emits one OpenAI/SambaNova-style SSE line and flushes the
+// response writer so the body chunk is on the wire before the next call.
+// Test handlers use this to drip-feed chunks instead of buffering the
+// whole response, which is what makes the streaming assertions meaningful.
+func writeSSEChunk(t *testing.T, w http.ResponseWriter, payload string) {
+	t.Helper()
+	fl, ok := w.(http.Flusher)
+	if !ok {
+		t.Fatal("http.ResponseWriter does not implement http.Flusher; cannot stream")
+	}
+	if _, err := fmt.Fprintf(w, "data: %s\n\n", payload); err != nil {
+		// Mid-stream client disconnects produce write errors here, which
+		// some tests deliberately trigger; ignore so the handler can
+		// finish and let the client-side assertion be the source of truth.
+		return
+	}
+	fl.Flush()
+}
+
+// TestLLMStream_HappyPath_StreamsAndAccumulates is the headline case: the
+// stream must (a) accumulate every content delta into LLMStreamResult.Text,
+// (b) fire onChunk synchronously per delta in arrival order, (c) capture
+// the final-chunk Usage block, and (d) record the terminal FinishReason.
+// Any of those failing would invalidate the future SSE handler's contract.
+func TestLLMStream_HappyPath_StreamsAndAccumulates(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		writeSSEChunk(t, w, `{"choices":[{"index":0,"delta":{"content":"Hello, "},"finish_reason":null}]}`)
+		writeSSEChunk(t, w, `{"choices":[{"index":0,"delta":{"content":"world"},"finish_reason":null}]}`)
+		writeSSEChunk(t, w, `{"choices":[{"index":0,"delta":{"content":"!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":3,"total_tokens":13}}`)
+	}))
+	defer srv.Close()
+
+	app, _ := newLLMTestApp(t, 5*time.Second, 1*time.Second, 0)
+	var deltas []string
+	res, err := app.LLMStream(context.Background(), srv.URL, nil, `{}`,
+		func(d string) error {
+			deltas = append(deltas, d)
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("LLMStream returned error: %v", err)
+	}
+	if got, want := res.Text, "Hello, world!"; got != want {
+		t.Errorf("Text = %q, want %q", got, want)
+	}
+	if !reflect.DeepEqual(deltas, []string{"Hello, ", "world", "!"}) {
+		t.Errorf("onChunk deltas = %v, want [\"Hello, \", \"world\", \"!\"]", deltas)
+	}
+	if res.FinishReason != "stop" {
+		t.Errorf("FinishReason = %q, want %q", res.FinishReason, "stop")
+	}
+	if res.Usage == nil {
+		t.Fatal("Usage = nil; want token usage from final chunk")
+	}
+	if res.Usage.TotalTokens != 13 {
+		t.Errorf("Usage.TotalTokens = %d, want 13", res.Usage.TotalTokens)
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Errorf("server saw %d attempts, want exactly 1", got)
+	}
+}
+
+// TestLLMStream_StampsRequestIDFromContext is the correlation guard: a
+// request originating from an inbound HTTP request must forward its
+// X-Request-ID so a Loki query can stitch the inbound and LLM-call lines
+// by the same key. Same contract as TestGETRequest_StampsRequestIDFromContext.
+func TestLLMStream_StampsRequestIDFromContext(t *testing.T) {
+	var captured atomic.Pointer[http.Request]
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.Store(r.Clone(r.Context()))
+		writeSSEChunk(t, w, `{"choices":[{"index":0,"delta":{"content":"x"},"finish_reason":"stop"}]}`)
+	}))
+	defer srv.Close()
+
+	app, _ := newLLMTestApp(t, 5*time.Second, 1*time.Second, 0)
+	ctx := ctxWithRequestID("llm-trace-1")
+	if _, err := app.LLMStream(ctx, srv.URL, nil, `{}`, nil); err != nil {
+		t.Fatalf("LLMStream: %v", err)
+	}
+	gotReq := captured.Load()
+	if gotReq == nil {
+		t.Fatal("server never saw a request")
+	}
+	if got := gotReq.Header.Get("X-Request-ID"); got != "llm-trace-1" {
+		t.Errorf("X-Request-ID forwarded = %q, want %q", got, "llm-trace-1")
+	}
+}
+
+// TestLLMStream_HandlesDoneSentinel asserts that "data: [DONE]" terminates
+// the loop. To make the assertion strong, the handler writes a phantom
+// chunk *after* [DONE] which must NOT appear in Text. If the sentinel is
+// ignored the test catches it; if the sentinel works, Text == "hi".
+func TestLLMStream_HandlesDoneSentinel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeSSEChunk(t, w, `{"choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}`)
+		writeSSEChunk(t, w, `[DONE]`)
+		writeSSEChunk(t, w, `{"choices":[{"index":0,"delta":{"content":"PHANTOM_SHOULD_NOT_APPEAR"},"finish_reason":null}]}`)
+	}))
+	defer srv.Close()
+
+	app, _ := newLLMTestApp(t, 1*time.Second, 500*time.Millisecond, 0)
+	res, err := app.LLMStream(context.Background(), srv.URL, nil, `{}`, nil)
+	if err != nil {
+		t.Fatalf("LLMStream: %v", err)
+	}
+	if res.Text != "hi" {
+		t.Errorf("Text = %q, want %q (phantom chunk after [DONE] leaked)", res.Text, "hi")
+	}
+}
+
+// TestLLMStream_IgnoresMalformedLines proves that a non-JSON keepalive or
+// transient garbage line in the middle of a stream does NOT fail the
+// whole call. Real upstream providers periodically send blank pings or
+// recover from bad bytes; the consumer has to be tolerant.
+func TestLLMStream_IgnoresMalformedLines(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeSSEChunk(t, w, `{"choices":[{"index":0,"delta":{"content":"a"},"finish_reason":null}]}`)
+		writeSSEChunk(t, w, `not-json-at-all`)
+		writeSSEChunk(t, w, `{"choices":[{"index":0,"delta":{"content":"b"},"finish_reason":"stop"}]}`)
+	}))
+	defer srv.Close()
+
+	app, _ := newLLMTestApp(t, 1*time.Second, 500*time.Millisecond, 0)
+	res, err := app.LLMStream(context.Background(), srv.URL, nil, `{}`, nil)
+	if err != nil {
+		t.Fatalf("LLMStream: %v", err)
+	}
+	if res.Text != "ab" {
+		t.Errorf("Text = %q, want %q", res.Text, "ab")
+	}
+}
+
+// TestLLMStream_IdleTimeoutFires is the operational protection guarantee:
+// when the upstream sends headers and one chunk, then goes silent, the
+// call must abort within idle+epsilon (NOT the full wallclock budget).
+// We assert both the sentinel error and the elapsed wall time so a
+// regression that swaps the idle timer for a budget-only path fails loudly.
+func TestLLMStream_IdleTimeoutFires(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeSSEChunk(t, w, `{"choices":[{"index":0,"delta":{"content":"first"},"finish_reason":null}]}`)
+		// Stall longer than the test's idle timeout but well within the
+		// wallclock budget. The handler exits when the client cancels.
+		select {
+		case <-time.After(2 * time.Second):
+		case <-r.Context().Done():
+		}
+	}))
+	defer srv.Close()
+
+	const idle = 200 * time.Millisecond
+	app, _ := newLLMTestApp(t, 5*time.Second, idle, 0)
+
+	start := time.Now()
+	res, err := app.LLMStream(context.Background(), srv.URL, nil, `{}`, nil)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, errLLMIdleTimeout) {
+		t.Fatalf("err = %v, want errLLMIdleTimeout", err)
+	}
+	if res.Text != "first" {
+		t.Errorf("Text = %q, want partial %q (bytes that did stream must be preserved)", res.Text, "first")
+	}
+	// Generous bound: idle timer + scheduling + network noise + ctx
+	// propagation should resolve well inside 1s for a 200ms idle window.
+	if elapsed > 1*time.Second {
+		t.Errorf("idle timeout took %v; want < 1s for idle=%v", elapsed, idle)
+	}
+}
+
+// TestLLMStream_NoRetryAfterFirstByte is the retry-budget guarantee: once
+// any chunk has streamed, a mid-stream connection drop must NOT re-send
+// the prompt. Replaying a 30s prompt evaluation for a transient TCP blip
+// would double user-visible latency and double our token bill. The retry
+// budget is intentionally generous (3) to prove the rule, not the count.
+func TestLLMStream_NoRetryAfterFirstByte(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeSSEChunk(t, w, `{"choices":[{"index":0,"delta":{"content":"partial"},"finish_reason":null}]}`)
+		// Hijack and close to simulate a mid-stream TCP drop. We can't use
+		// a normal handler return here because that would emit a clean EOF
+		// which the client's scanner treats as "stream finished cleanly".
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Errorf("server does not support hijack; cannot simulate mid-stream drop")
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+	}))
+	defer srv.Close()
+
+	app, _ := newLLMTestApp(t, 5*time.Second, 1*time.Second, 3 /*retries; intentionally generous to prove they don't fire*/)
+	res, err := app.LLMStream(context.Background(), srv.URL, nil, `{}`, nil)
+	if err == nil {
+		t.Fatal("want error from mid-stream drop, got nil")
+	}
+	if res.Text != "partial" {
+		t.Errorf("Text = %q, want %q (bytes that did stream must be preserved)", res.Text, "partial")
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Errorf("attempts = %d, want exactly 1 (no retry permitted after first byte)", got)
+	}
+}
+
+// TestLLMStream_BoundedPreFirstByteRetries is the symmetric guarantee:
+// pre-first-byte errors (5xx, dial fail) DO get retried, but bounded
+// strictly to cfg.llm.maxRetriesBeforeFirstByte. The handler returns 503
+// every time so retryablehttp will exhaust its budget; we assert exactly
+// retries+1 attempts.
+func TestLLMStream_BoundedPreFirstByteRetries(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	const wantRetries = 2
+	app, _ := newLLMTestApp(t, 30*time.Second, 5*time.Second, wantRetries)
+	if _, err := app.LLMStream(context.Background(), srv.URL, nil, `{}`, nil); err == nil {
+		t.Fatal("want error from exhausted retries, got nil")
+	}
+	if got := int(attempts.Load()); got != wantRetries+1 {
+		t.Errorf("attempts = %d, want %d (retries=%d + 1 initial)", got, wantRetries+1, wantRetries)
+	}
+}
+
+// TestLLMStream_WallclockBudgetCap proves the budget context actually caps
+// the call. The handler holds the response open well beyond the budget;
+// the call must return within the budget plus a small scheduling margin,
+// not eight seconds later.
+func TestLLMStream_WallclockBudgetCap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(8 * time.Second):
+			w.WriteHeader(http.StatusOK)
+		case <-r.Context().Done():
+		}
+	}))
+	defer srv.Close()
+
+	const budget = 250 * time.Millisecond
+	app, _ := newLLMTestApp(t, budget, 5*time.Second, 0)
+
+	start := time.Now()
+	_, err := app.LLMStream(context.Background(), srv.URL, nil, `{}`, nil)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("want error from budget exhaustion, got nil")
+	}
+	if elapsed > 1*time.Second {
+		t.Errorf("budget enforcement took %v; want < 1s for budget=%v", elapsed, budget)
+	}
+}
+
+// TestLLMStream_OnChunkErrorAborts asserts that a non-nil return from the
+// onChunk callback short-circuits the stream and surfaces that error to
+// the caller, while preserving the partial Text. This is the contract the
+// future SSE handler relies on: a browser that disconnects mid-stream
+// should let the handler return cleanly without forcing the LLM call to
+// run to completion.
+func TestLLMStream_OnChunkErrorAborts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeSSEChunk(t, w, `{"choices":[{"index":0,"delta":{"content":"a"},"finish_reason":null}]}`)
+		writeSSEChunk(t, w, `{"choices":[{"index":0,"delta":{"content":"b"},"finish_reason":null}]}`)
+		writeSSEChunk(t, w, `{"choices":[{"index":0,"delta":{"content":"c"},"finish_reason":"stop"}]}`)
+	}))
+	defer srv.Close()
+
+	app, _ := newLLMTestApp(t, 5*time.Second, 1*time.Second, 0)
+	sentinel := errors.New("client lost")
+	var deltas []string
+	res, err := app.LLMStream(context.Background(), srv.URL, nil, `{}`,
+		func(d string) error {
+			deltas = append(deltas, d)
+			if d == "b" {
+				return sentinel
+			}
+			return nil
+		})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want %v", err, sentinel)
+	}
+	if res.Text != "ab" {
+		t.Errorf("Text = %q, want %q (stream stopped after delta 'b')", res.Text, "ab")
+	}
+	if len(deltas) != 2 {
+		t.Errorf("onChunk fired %d times, want exactly 2 (chunk after abort must not fire)", len(deltas))
+	}
+}
+
+// TestLLMStream_5xxLogsAtErrorLevel: a non-2xx response from the upstream
+// is operator-actionable, so the outbound log line must come out at Error
+// level. retryablehttp will retry internally, but LLMStream emits exactly
+// one log line per call (the final outcome), so this assertion holds
+// regardless of internal retries.
+func TestLLMStream_5xxLogsAtErrorLevel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	app, logs := newLLMTestApp(t, 30*time.Second, 5*time.Second, 0)
+	if _, err := app.LLMStream(context.Background(), srv.URL, nil, `{}`, nil); err == nil {
+		t.Fatal("want error from 500 response, got nil")
+	}
+	errEntries := logs.FilterLevelExact(zap.ErrorLevel).FilterMessage("http outbound").All()
+	if len(errEntries) != 1 {
+		t.Errorf("want 1 Error-level outbound log entry, got %d", len(errEntries))
+	}
+}
+
+// TestLLMStream_ContextCancellationLogsAtInfoLevel: when the inbound
+// caller's ctx is canceled mid-stream (browser tab closed), the outbound
+// log line must NOT be Error. Otherwise every drive-by user disconnect
+// generates spurious alert noise. Same policy as the GETRequest sibling test.
+func TestLLMStream_ContextCancellationLogsAtInfoLevel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Drip-feed chunks slowly so the client has time to cancel.
+		for i := 0; i < 50; i++ {
+			select {
+			case <-r.Context().Done():
+				return
+			default:
+			}
+			writeSSEChunk(t, w, `{"choices":[{"index":0,"delta":{"content":"x"},"finish_reason":null}]}`)
+			time.Sleep(50 * time.Millisecond)
+		}
+	}))
+	defer srv.Close()
+
+	app, logs := newLLMTestApp(t, 30*time.Second, 5*time.Second, 0)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		cancel()
+	}()
+	if _, err := app.LLMStream(ctx, srv.URL, nil, `{}`, nil); err == nil {
+		t.Fatal("want error from canceled ctx, got nil")
+	}
+
+	if got := len(logs.FilterLevelExact(zap.ErrorLevel).FilterMessage("http outbound").All()); got != 0 {
+		t.Errorf("ctx cancellation logged at Error level (would create alert noise); want 0, got %d", got)
+	}
+	if got := len(logs.FilterLevelExact(zap.InfoLevel).FilterMessage("http outbound").All()); got != 1 {
+		t.Errorf("want exactly 1 Info-level outbound log line on ctx cancel, got %d", got)
+	}
+}
+
+// TestLLMRequest_BackCompatWrapper is the smoke check that the legacy
+// signature still works. Existing buildLLMRequestHelper callers in
+// ai_operations.go go through this wrapper, so a regression here would
+// silently break the portfolio analysis path.
+func TestLLMRequest_BackCompatWrapper(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeSSEChunk(t, w, `{"choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":"stop"}]}`)
+	}))
+	defer srv.Close()
+
+	app, _ := newLLMTestApp(t, 5*time.Second, 1*time.Second, 0)
+	got, err := app.LLMRequest(context.Background(), srv.URL, nil, `{}`)
+	if err != nil {
+		t.Fatalf("LLMRequest: %v", err)
+	}
+	if got != "hello" {
+		t.Errorf("LLMRequest result = %q, want %q", got, "hello")
+	}
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -79,6 +79,31 @@ type config struct {
 		timeout  time.Duration
 		retrymax int
 	}
+	// llm holds runtime knobs for the streaming SambaNova client. The
+	// LLM path is special-cased away from the generic http_client tunables
+	// because chat-completions calls keep a connection slot open for
+	// 10-30s while the model emits SSE chunks; the generic 10s client
+	// timeout would just kill them mid-stream, and the generic 3-retry
+	// policy would replay a 30s prompt on a transient 5xx and double
+	// user-visible latency.
+	llm struct {
+		// totalBudget is a wallclock cap that supersedes any per-attempt
+		// timeout. It governs the entire call including pre-first-byte
+		// retries plus the streaming read. A value of 0 falls back to a
+		// safe internal default (see llmStreamingDefaults).
+		totalBudget time.Duration
+		// idleTimeout aborts the stream when no chunk has arrived within
+		// the window. Protects connection slots from a stalled upstream
+		// that has sent headers but no body, and also acts as a coarse
+		// DoS mitigation.
+		idleTimeout time.Duration
+		// maxRetriesBeforeFirstByte caps how many times the retryablehttp
+		// layer may replay the request on dial / TLS / 5xx errors *before*
+		// the first SSE chunk arrives. Mid-stream errors are never
+		// retried regardless of this value (see CheckRetry override in
+		// LLMStream).
+		maxRetriesBeforeFirstByte int
+	}
 	sanitization struct {
 		sanitizer *bluemonday.Policy
 		usestrict bool
@@ -244,6 +269,14 @@ func main() {
 	// HTTP client configuration
 	flag.DurationVar(&cfg.http_client.timeout, "http-client-timeout", 10*time.Second, "HTTP client timeout")
 	flag.IntVar(&cfg.http_client.retrymax, "http-client-retrymax", 3, "HTTP client maximum retries")
+	// LLM streaming client tunables (SambaNova chat-completions). See the
+	// type definition in the config struct for the rationale; defaults are
+	// chosen to match the observed p95 latency of the 405B model plus a
+	// margin, with retry budget tight enough to keep tail latency below
+	// 2x of a healthy single-attempt call.
+	flag.DurationVar(&cfg.llm.totalBudget, "llm-total-budget", 90*time.Second, "Wallclock cap for an LLM streaming call across retries")
+	flag.DurationVar(&cfg.llm.idleTimeout, "llm-idle-timeout", 15*time.Second, "Abort the LLM stream if no chunk arrives within this window")
+	flag.IntVar(&cfg.llm.maxRetriesBeforeFirstByte, "llm-max-retries", 2, "Max retries for the LLM call before the first SSE chunk; mid-stream errors never retry")
 	// Sanitization
 	flag.BoolVar(&cfg.sanitization.usestrict, "sanitization-strict", false, "Use strict sanitization")
 	// Encryption key


### PR DESCRIPTION
## What I changed

I rewrote the SambaNova chat-completions path so the inbound HTTP request is no longer pinned for the full 10–30s the model takes to type. The new `LLMStream` primitive in `cmd/api/http_clients.go` consumes the SSE response chunk-by-chunk and exposes an `onChunk` callback so a future Server-Sent-Events handler can forward partial deltas to the browser. `LLMRequest` is preserved as a five-line wrapper, so every existing caller in `cmd/api/ai_operations.go` inherits the new behaviour without a signature change.

## Three guarantees the generic `Optivet_Client` could not give the LLM path

- **Wallclock budget context** (`-llm-total-budget`, default `90s`) caps the entire call across pre-first-byte retries plus the streaming read. Backoff sleeps inherit the deadline, so a tight budget naturally compresses the retry window.
- **Idle deadline** (`-llm-idle-timeout`, default `15s`) aborts when no chunk arrives within the window. Protects connection slots from a stalled upstream that has sent headers but no body, and is the primary slowloris mitigation against a hostile or compromised LLM provider.
- **Bounded pre-first-byte retries** (`-llm-max-retries`, default `2`). Mid-stream errors never retry: SambaNova's API is non-resumable, so replaying a partial 30s prompt costs the full prompt evaluation again for no reliability gain. I also tightened the retry-wait bounds to `100ms..2s` vs `retryablehttp`'s library defaults of `1s..30s`, so a healthy single-attempt call's tail latency is dominated by the model itself.

## Implementation notes

- The idle timer is an `io.Reader` wrapper that resets a `time.AfterFunc` on every successful `Read`. Once it fires we translate the resulting `ctx.Canceled` into a clear `errLLMIdleTimeout` sentinel so operators can tell *upstream stalled* apart from *user disconnected* without grepping log fields.
- The mid-stream no-retry rule comes for free: `retryablehttp`'s `CheckRetry` hook only sees errors that happen before `Do` returns, and SSE consumption happens after, so any mid-stream drop is surfaced verbatim without ever touching the retry layer.
- Outbound `logOutbound` calls are passed the **parent** ctx (not the budget child) so wallclock-exhaustion and idle-timeout still log at Error level — only a real user-disconnect lands at Info.

## Tests (`cmd/api/http_clients_llm_test.go`, 12 cases)

- Happy-path accumulation + `onChunk` ordering + `Usage` capture + `FinishReason`.
- `X-Request-ID` forwarding from inbound ctx.
- `[DONE]` sentinel handling, with a phantom chunk after `[DONE]` that must NOT appear in `Text`.
- Malformed SSE line tolerance (non-JSON keepalives don't fail the stream).
- Idle timeout fires with elapsed-time assertion (proves it fires on idle, not budget).
- No retry after first byte (httptest hijack to drop the conn mid-stream; retries=3 set generously to prove the rule, not the count).
- Bounded pre-first-byte retries (handler returns 503 N times; assert exactly `retries+1` attempts).
- Wallclock budget cap (handler holds 8s; call must return inside the configured 250ms budget + scheduling slack).
- `onChunk` error aborts the stream and preserves partial `Text`.
- 5xx logs at Error level; ctx-cancel logs at Info (no alert noise from drive-by user disconnects).
- `LLMRequest` back-compat smoke test.

## Local verification

- `go build ./...` clean.
- `go vet ./...` clean.
- `go test -count=1 ./cmd/api/... ./internal/...` clean (~14s).
- `golangci-lint run --timeout=3m ./cmd/api/...` 0 issues.

## Docs

- `README.md`: added a SambaNova streaming + retry-budget subsection alongside the existing operational subsections, plus the three new flags in the `make help` block.
- `SECURITY.md`: added a "SambaNova streaming budget (P4.A)" section framing the idle timeout as the slowloris-defence knob it is, and explaining why I lean on lowering `-llm-total-budget` rather than raising `-llm-max-retries` for tighter blast-radius control.

## Out of scope (deliberate)

- The actual SSE inbound handler that forwards `onChunk` to the browser. The primitive lands first; the `/v1/streaming/...` endpoint is its own PR with its own UX/error-shape decisions.
- Replacing `retryablehttp` for non-LLM calls. The new behaviour is scoped to the LLM path; the shared `Optivet_Client` keeps its existing retry policy.

## Test plan

- [x] All new tests pass locally.
- [x] Full existing test suite still passes.
- [x] golangci-lint 0 issues.
- [ ] CI pipeline green on this branch.
- [ ] Smoke-check against a real SambaNova endpoint after merge (the e2e job uses no real LLM key, so this is a deploy-time verification).