### PR TITLE
Stream the portfolio analysis to clients over Server-Sent Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,9 +515,37 @@ the available commands for a quick lookup (INCOMPLETE, use help for full list).
 >
 > `LLMRequest` is preserved as a thin back-compat wrapper for callers that
 > only need the joined string (`buildLLMRequestHelper` and friends in
-> `cmd/api/ai_operations.go`). Future Server-Sent Events handlers should
-> call `LLMStream` directly with a non-nil `onChunk` callback to forward
-> partial deltas to the browser as they arrive.
+> `cmd/api/ai_operations.go`).
+
+> **Streaming portfolio analysis (P4.B):**
+> `GET /v1/investments/analysis/stream` is the user-facing payoff for the
+> streaming client. It runs the same DB pre-checks as the synchronous
+> `/v1/investments/analysis` endpoint (goals + non-empty portfolio), and
+> only switches into `text/event-stream` mode once those 4xx-eligible
+> validations pass — so client-side error handling for "no goals set"
+> stays a normal JSON envelope, not a malformed SSE frame.
+>
+> Wire format (all events are JSON-encoded so the client always parses
+> `JSON.parse(event.data)`, regardless of which event name fires):
+>
+> ```text
+> data: {"delta": "<token text>"}             // one per LLM chunk, default event
+> event: done
+> data: {"finish_reason":"stop","usage":{...},"analyzed":{...}}
+>
+> event: error
+> data: {"error":"upstream stalled"}          // terminal failure
+> ```
+>
+> The handler reuses one prompt template across the streaming and
+> non-streaming paths via `renderInvestmentPortfolioPrompt` in
+> `ai_operations.go`, so a user gets the same analysis regardless of
+> which endpoint they hit. On stream completion the analyzed portfolio
+> is persisted to the same table read by `/v1/investments/analysis/summary`;
+> a persist failure logs but does not abort the user's stream, since
+> the result is already in the browser by then. Mid-stream errors are
+> reported via a single `event: error` event because by that point the
+> response status code is already on the wire and unchangeable.
 
 Using `make run`, will run the API with a default connection string located 
 in `cmd\api\.env`. If you're using `powershell`, you need to load the values otherwise you will get
@@ -731,6 +759,7 @@ Auth tokens are obtained via `POST /v1/api/authentication` and sent as `Authoriz
 | POST   | `/v1/investments/transactions` | Record an investment transaction |
 | DELETE | `/v1/investments/transactions/{transactionID}` | Delete an investment transaction |
 | GET    | `/v1/investments/analysis` | Run a portfolio analysis (LLM-backed) |
+| GET    | `/v1/investments/analysis/stream` | Stream a portfolio analysis as Server-Sent Events |
 | GET    | `/v1/investments/analysis/summary` | Latest LLM analysis snapshot |
 
 </details>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -180,6 +180,43 @@ Lowering it past 5s is not recommended - the model's first-token
 latency is genuinely variable, and false-positive aborts manifest as
 user-visible 5xxs.
 
+## Streaming portfolio analysis endpoint (P4.B)
+
+`GET /v1/investments/analysis/stream` is the inbound counterpart to the
+SambaNova streaming client. It is mounted on the regular `/v1` router
+(not the long-lived `sseRoutes` server), so it inherits the full
+middleware chain: per-IP rate limiting, bearer-token auth + activated-user
+check, structured request logging, and X-Request-ID correlation. This is
+deliberate — each call is bounded by `-llm-total-budget` (default 90s)
+and behaves much more like a slow HTTP request than a persistent push
+channel, so the same controls that protect `/v1/investments/analysis`
+must apply here.
+
+Two wire-level rules limit information leakage on the SSE error path:
+
+- **No raw upstream errors hit the wire.** `classifyLLMStreamError`
+  collapses transport / dial / TLS errors to a fixed phrase (`internal
+  stream error`) and only surfaces messages we author ourselves
+  (`upstream stalled`, `upstream timed out`, `request canceled`,
+  `llm: non-2xx response: <code>`). Hostnames, retry counts, and
+  socket-level diagnostics stay in the structured server logs.
+- **No partial deltas after a failure.** `streamLLMToSSE` returns the
+  underlying error to the handler rather than emitting a synthetic
+  empty delta. The handler writes a single `event: error` and the
+  connection ends. Clients can therefore treat any received delta as
+  authoritative, with no need to reconcile partial frames.
+
+A persist failure on stream completion (writing the analyzed portfolio
+to the table read by `/v1/investments/analysis/summary`) is logged at
+Error level and surfaced via the standard request log line, but does
+not turn a successful stream into a visible error — the user already
+has the result in their browser. Operators see this as a
+`portfolio analysis stream persist failed` log entry, the metric
+counters are unchanged, and the user has to re-run the analysis to
+see it in their history view. We accept that trade-off because
+emitting a failure event for a *successful* stream would mislead the
+client into discarding a valid analysis.
+
 ## CI security scanning
 
 Every push and PR to `main` runs:

--- a/TODO.md
+++ b/TODO.md
@@ -47,9 +47,16 @@
    - **User Preferences**: Allow users to customize their notification preferences.
    - **Event Triggers**: Set up notifications for different events such as new comments, likes, subscription renewals, and monthly report availability.
 
-8. **Enhance Investment Portfolio Flow**
-   - **Include Concurrency on per API Request:** Use concurrency to decrease the time duration of the AI financial analysis. Currrently
-                                                 it takes around 30-40s for complete processing. We should get it down to < 10-20s
+8. ~~**Enhance Investment Portfolio Flow**~~
+   - ~~**Include Concurrency on per API Request:** Use concurrency to decrease the time duration of the AI financial analysis. Currrently
+                                                 it takes around 30-40s for complete processing. We should get it down to < 10-20s~~
+   - Delivered. The portfolio analysis pipeline now fans out per-asset workers
+     (stocks + bonds) via a bounded `errgroup` capped at `-portfolio-worker-limit`,
+     plus a process-wide `singleflight` to collapse duplicate upstream calls.
+     Cache-cold runs dropped from ~25-30s to ~3-5s on Premium Alpha Vantage tiers.
+     The follow-on SambaNova streaming work (`-llm-total-budget`, idle deadline,
+     bounded retries) frees the inbound HTTP request from being pinned for the
+     whole 10-30s LLM tail.
 
 ## Additional Notes
 

--- a/cmd/api/ai_operations.go
+++ b/cmd/api/ai_operations.go
@@ -52,19 +52,14 @@ type LLMUsage struct {
 	TotalTokens      int `json:"total_tokens"`
 }
 
-// buildLLMRequest sends a request to the LLM API with the user's profile and
-// investment analysis data and returns the analyzed portfolio data. ctx flows
-// from the originating HTTP request so the downstream INSERT into
-// CreateLLMAnalysisResponse aborts when the client disconnects.
-func (app *application) buildInvestmentPortfolioLLMRequest(ctx context.Context, user *data.User, goals *data.InvestmentGoal, investmentAnalysis *data.InvestmentAnalysis) (*data.LLMAnalyzedPortfolio, error) {
-	// Create a profile
-	profile := UserPortfolioProfile{
-		UserTimeHorizon:    user.TimeHorizon,
-		UserRiskTolerance:  user.RiskTolerance,
-		InvestmentGoals:    goals,
-		InvestmentAnalysis: *investmentAnalysis,
-	}
-	instructions := `{
+// investmentPortfolioInstructionsTemplate is the chat-completions request body
+// sent to SambaNova for portfolio analysis, with a single %s slot where the
+// per-user UserPortfolioProfile is interpolated as JSON. It is package-level
+// so both the synchronous (buildInvestmentPortfolioLLMRequest) and streaming
+// (streamInvestmentPortfolioAnalysisHandler) paths share one prompt source —
+// drift between the two would silently produce different analyses for the
+// same user depending on which endpoint they hit.
+const investmentPortfolioInstructionsTemplate = `{
     "messages": [
 	{
 	  "role": "system",
@@ -88,18 +83,54 @@ func (app *application) buildInvestmentPortfolioLLMRequest(ctx context.Context, 
         "include_usage": true
     }
 }`
-	// get the analyzed portfolio
-	analyzedPortfolio, err := app.buildLLMRequestHelper(ctx, profile, instructions)
+
+// renderInvestmentPortfolioPrompt marshals the user profile and slots it into
+// the chat-completions template. Returns the final JSON body string that gets
+// POSTed to the LLM endpoint.
+func renderInvestmentPortfolioPrompt(profile UserPortfolioProfile) (string, error) {
+	profileData, err := json.Marshal(profile)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(investmentPortfolioInstructionsTemplate, string(profileData)), nil
+}
+
+// buildLLMRequest sends a request to the LLM API with the user's profile and
+// investment analysis data and returns the analyzed portfolio data. ctx flows
+// from the originating HTTP request so the downstream INSERT into
+// CreateLLMAnalysisResponse aborts when the client disconnects.
+func (app *application) buildInvestmentPortfolioLLMRequest(ctx context.Context, user *data.User, goals *data.InvestmentGoal, investmentAnalysis *data.InvestmentAnalysis) (*data.LLMAnalyzedPortfolio, error) {
+	profile := UserPortfolioProfile{
+		UserTimeHorizon:    user.TimeHorizon,
+		UserRiskTolerance:  user.RiskTolerance,
+		InvestmentGoals:    goals,
+		InvestmentAnalysis: *investmentAnalysis,
+	}
+	body, err := renderInvestmentPortfolioPrompt(profile)
 	if err != nil {
 		return nil, err
+	}
+	url := app.config.api.apikeys.sambanova.url
+	apiKey := app.config.api.apikeys.sambanova.key
+	fullResponse, err := app.LLMRequest(ctx, url, map[string]string{
+		"Authorization": "Bearer " + apiKey,
+	}, body)
+	if err != nil {
+		return nil, err
+	}
+	header, llmAnalysis, footer, err := parseLLMResponse(fullResponse)
+	if err != nil {
+		return nil, err
+	}
+	analyzedPortfolio := &data.LLMAnalyzedPortfolio{
+		Header:   header,
+		Analysis: llmAnalysis,
+		Footer:   footer,
 	}
 	app.loggerFromContext(ctx).Info("Done building LLM request for investment portfolio")
-	// save the analyzed portfolio to the database using CreateLLMAnalysisResponse
-	err = app.models.InvestmentPortfolioManager.CreateLLMAnalysisResponse(ctx, user.ID, analyzedPortfolio)
-	if err != nil {
+	if err := app.models.InvestmentPortfolioManager.CreateLLMAnalysisResponse(ctx, user.ID, analyzedPortfolio); err != nil {
 		return nil, err
 	}
-	// return the analyzed portfolio
 	return analyzedPortfolio, nil
 }
 

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -276,6 +276,7 @@ func (app *application) investmentPortfolioRoutes() chi.Router {
 
 	// Analysis
 	investmentPortfolioRoutes.Get("/analysis", app.investmentPrtfolioAnalysisHandler)
+	investmentPortfolioRoutes.Get("/analysis/stream", app.streamInvestmentPortfolioAnalysisHandler)
 	investmentPortfolioRoutes.Get("/analysis/summary", app.getLatestLLMAnalysisResponseByUserIDHandler)
 	return investmentPortfolioRoutes
 }

--- a/cmd/api/streaming.go
+++ b/cmd/api/streaming.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"go.uber.org/zap"
+
+	"github.com/Blue-Davinci/OptiVest/internal/data"
+)
+
+// SSE protocol notes:
+//
+// We use Server-Sent Events for the streaming portfolio-analysis endpoint
+// because the browser's EventSource API speaks it natively (no extra
+// client library, automatic reconnect, automatic UTF-8 framing). The
+// endpoint sits inside the regular /v1 router (not the dedicated long-
+// lived sseRoutes server) because each call is bounded by the LLM
+// streaming budget — typically 10-30s, capped at -llm-total-budget=90s
+// — so it behaves much more like a slow HTTP request than a persistent
+// push channel. Going through the normal middleware chain means it
+// inherits per-IP rate limiting (you do not want a user spamming
+// expensive LLM calls), authentication, and the one-line-per-request
+// log entry, all of which are correct here.
+//
+// All events are JSON-wrapped, even per-token deltas, so the wire shape
+// stays parseable from a single `JSON.parse(event.data)` on the client
+// regardless of whether new fields are added later. Three event names
+// are produced:
+//
+//   default ("message")  - {"delta": "<text>"}             one per LLM chunk
+//   "done"               - {"finish_reason", "usage", "analyzed"}
+//   "error"              - {"error": "<reason>"}            terminal failure
+//
+// The default event is anonymous (no `event:` line) so EventSource's
+// `onmessage` handler picks it up by default; named events route to
+// `addEventListener("done", ...)` / `addEventListener("error", ...)`
+// on the client side.
+
+// setSSEHeaders writes the canonical Server-Sent Events response headers.
+// Must be called before the first body byte. X-Accel-Buffering disables
+// nginx response buffering when this server is behind an nginx ingress —
+// without it nginx waits to fill its 4 KiB buffer before flushing, which
+// defeats the whole point of streaming.
+func setSSEHeaders(h http.Header) {
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-cache")
+	h.Set("Connection", "keep-alive")
+	h.Set("X-Accel-Buffering", "no")
+}
+
+// writeSSEEvent emits one SSE event. event="" omits the `event:` line so
+// the message arrives on EventSource's default `onmessage` handler. data
+// is split on '\n' and each line is prefixed with `data: ` per the SSE
+// spec, which keeps multi-line payloads (e.g. JSON-encoded errors with
+// newlines from the upstream) parseable without hand-escaping.
+//
+// The flush is unconditional so the client sees the event as soon as
+// it arrives, not whenever the response writer's buffer happens to fill.
+// A write error short-circuits and is returned: callers (the handler
+// loop, the per-delta callback) use that as the disconnect signal and
+// abort the upstream stream cleanly.
+func writeSSEEvent(w io.Writer, fl http.Flusher, event, data string) error {
+	var buf strings.Builder
+	if event != "" {
+		buf.WriteString("event: ")
+		buf.WriteString(event)
+		buf.WriteByte('\n')
+	}
+	for _, line := range strings.Split(data, "\n") {
+		buf.WriteString("data: ")
+		buf.WriteString(line)
+		buf.WriteByte('\n')
+	}
+	buf.WriteByte('\n')
+	if _, err := io.WriteString(w, buf.String()); err != nil {
+		return err
+	}
+	fl.Flush()
+	return nil
+}
+
+// writeSSEEventJSON marshals payload to JSON and writes it as a single
+// SSE event with the given name. Convenience wrapper for the structured
+// `done` and `error` events. Returns the write error verbatim so the
+// caller can short-circuit on client disconnect.
+func writeSSEEventJSON(w io.Writer, fl http.Flusher, event string, payload any) error {
+	blob, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	return writeSSEEvent(w, fl, event, string(blob))
+}
+
+// classifyLLMStreamError translates an internal LLMStream error into a
+// short, user-safe phrase fit for the SSE `error` event. The full
+// underlying error stays in the structured server logs (one line per
+// outbound call from logOutbound, plus a handler-side log on the error
+// path); the wire-level message is deliberately coarse so we never leak
+// transport details, hostnames, or anything an attacker could turn into
+// a fingerprinting signal.
+func classifyLLMStreamError(err error) string {
+	switch {
+	case errors.Is(err, errLLMIdleTimeout):
+		return "upstream stalled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "upstream timed out"
+	case errors.Is(err, context.Canceled):
+		return "request canceled"
+	default:
+		// Surface only the prefix-stripped sentinel-style messages we
+		// emit ourselves (e.g. "llm: non-2xx response: 503"). Anything
+		// else collapses to a generic phrase.
+		msg := err.Error()
+		if strings.HasPrefix(msg, "llm: ") {
+			return msg
+		}
+		return "internal stream error"
+	}
+}
+
+// streamLLMToSSE drives one SambaNova streaming call and forwards each
+// SSE chunk's content delta to the client as a JSON-wrapped event. It
+// is intentionally a single-purpose helper rather than inlined into the
+// portfolio handler so the wire-format glue (LLMStream → JSON event →
+// flush) is unit-testable against a fake LLM upstream without dragging
+// the full DB / auth surface into the test.
+//
+// Return semantics mirror LLMStream itself: the result is returned in
+// all paths (zero-value on early failure), and any non-nil error came
+// from either the upstream LLM or the per-delta SSE write. On the
+// error path streamLLMToSSE does NOT emit an SSE error event itself —
+// the caller has more context (which logical operation was streaming,
+// which user, etc.) and is better placed to write the final framed
+// error and any persistence-bypass logging.
+func (app *application) streamLLMToSSE(
+	ctx context.Context,
+	w io.Writer,
+	fl http.Flusher,
+	url string,
+	headers map[string]string,
+	body string,
+) (LLMStreamResult, error) {
+	return app.LLMStream(ctx, url, headers, body, func(delta string) error {
+		return writeSSEEventJSON(w, fl, "", map[string]string{"delta": delta})
+	})
+}
+
+// streamInvestmentPortfolioAnalysisHandler serves the streaming variant
+// of the existing /investments/analysis endpoint. It runs the same DB
+// pre-checks as the non-streaming handler (goals, investment analysis,
+// non-empty portfolio), and only switches into SSE mode once those
+// 4xx-eligible checks have passed — that way validation failures still
+// produce the standard JSON error envelopes clients are used to, and we
+// only commit to text/event-stream framing when there is real work to
+// stream.
+//
+// Once streaming starts, content deltas are forwarded to the client as
+// fast as SambaNova produces them (one anonymous event per delta with
+// `{"delta": "..."}`), the joined text is then parsed via the same
+// parseLLMResponse used by the synchronous path, the analyzed portfolio
+// is persisted via CreateLLMAnalysisResponse (best-effort: a persist
+// failure logs but does not abort the user's stream), and a final
+// `done` event carries the structured result alongside the LLM's
+// finish_reason and token usage.
+//
+// Errors after stream start surface as `event: error` rather than a
+// 4xx/5xx status, because by that point the response headers are
+// already on the wire — the client is now reading SSE and would not
+// see a status-code change.
+func (app *application) streamInvestmentPortfolioAnalysisHandler(w http.ResponseWriter, r *http.Request) {
+	user := app.contextGetUser(r)
+	log := app.loggerFromRequest(r)
+
+	fl, ok := w.(http.Flusher)
+	if !ok {
+		app.serverErrorResponse(w, r, errors.New("streaming response writer does not implement http.Flusher"))
+		return
+	}
+
+	goals, err := app.models.FinancialManager.GetGoalsForUserInvestmentHelper(r.Context(), user.ID)
+	if err != nil && !errors.Is(err, data.ErrGeneralRecordNotFound) {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+	if goals == nil || len(goals.Goals) == 0 {
+		app.failedValidationResponse(w, r, map[string]string{"goals": "no goals set for user"})
+		return
+	}
+
+	investmentAnalysis, err := app.models.InvestmentPortfolioManager.GetAllInvestmentsByUserID(r.Context(), user.ID)
+	if err != nil && !errors.Is(err, data.ErrGeneralRecordNotFound) {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+	if err := app.performInvestmentPortfolioAnalysis(r.Context(), investmentAnalysis, user); err != nil &&
+		!errors.Is(err, data.ErrFailedToGetBondData) {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+	if investmentAnalysis == nil ||
+		(len(investmentAnalysis.StockAnalysis) == 0 && len(investmentAnalysis.BondAnalysis) == 0) {
+		app.failedValidationResponse(w, r, map[string]string{"investment_analysis": "no investments to analyze"})
+		return
+	}
+
+	profile := UserPortfolioProfile{
+		UserTimeHorizon:    user.TimeHorizon,
+		UserRiskTolerance:  user.RiskTolerance,
+		InvestmentGoals:    goals,
+		InvestmentAnalysis: *investmentAnalysis,
+	}
+	body, err := renderInvestmentPortfolioPrompt(profile)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	setSSEHeaders(w.Header())
+	w.WriteHeader(http.StatusOK)
+	fl.Flush()
+
+	res, err := app.streamLLMToSSE(
+		r.Context(),
+		w, fl,
+		app.config.api.apikeys.sambanova.url,
+		map[string]string{"Authorization": "Bearer " + app.config.api.apikeys.sambanova.key},
+		body,
+	)
+	if err != nil {
+		log.Error("portfolio analysis stream failed",
+			zap.Error(err),
+			zap.Int("partial_bytes", len(res.Text)),
+		)
+		_ = writeSSEEventJSON(w, fl, "error", map[string]string{
+			"error": classifyLLMStreamError(err),
+		})
+		return
+	}
+
+	header, llmAnalysis, footer, parseErr := parseLLMResponse(res.Text)
+	if parseErr != nil {
+		log.Error("portfolio analysis stream parse failed",
+			zap.Error(parseErr),
+			zap.Int("response_bytes", len(res.Text)),
+		)
+		_ = writeSSEEventJSON(w, fl, "error", map[string]string{
+			"error": "failed to parse model output",
+		})
+		return
+	}
+
+	analyzed := &data.LLMAnalyzedPortfolio{
+		Header:   header,
+		Analysis: llmAnalysis,
+		Footer:   footer,
+	}
+
+	// Persistence is best-effort. The user already has the streamed
+	// answer in their browser; a DB write failure should not turn a
+	// successful analysis into a visible error. The downstream
+	// /analysis/summary endpoint reads from this same table, so a
+	// missed persist means the user has to re-run the analysis to
+	// see it in their history — surface it loudly in logs but keep
+	// the stream completion clean.
+	if err := app.models.InvestmentPortfolioManager.CreateLLMAnalysisResponse(r.Context(), user.ID, analyzed); err != nil {
+		log.Error("portfolio analysis stream persist failed", zap.Error(err))
+	}
+
+	_ = writeSSEEventJSON(w, fl, "done", struct {
+		FinishReason string                     `json:"finish_reason,omitempty"`
+		Usage        *LLMUsage                  `json:"usage,omitempty"`
+		Analyzed     *data.LLMAnalyzedPortfolio `json:"analyzed"`
+	}{
+		FinishReason: res.FinishReason,
+		Usage:        res.Usage,
+		Analyzed:     analyzed,
+	})
+
+	log.Info("portfolio analysis stream completed",
+		zap.Int("response_bytes", len(res.Text)),
+		zap.String("finish_reason", res.FinishReason),
+	)
+}

--- a/cmd/api/streaming_test.go
+++ b/cmd/api/streaming_test.go
@@ -1,0 +1,278 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeFlusher counts Flush invocations so tests can assert that the SSE
+// writer flushes exactly once per event. Standalone struct rather than
+// piggybacking on http.Flusher's interface so it works against a plain
+// io.Writer in the same test, not just an http.ResponseWriter.
+type fakeFlusher struct{ calls atomic.Int32 }
+
+func (f *fakeFlusher) Flush() { f.calls.Add(1) }
+
+// errWriter always returns errBoom; used to verify writeSSEEvent
+// surfaces the underlying transport error rather than swallowing it.
+type errWriter struct{ err error }
+
+func (e *errWriter) Write(_ []byte) (int, error) { return 0, e.err }
+
+// TestSetSSEHeaders pins the four header values the SSE protocol +
+// nginx ingress depend on. Adding/removing a header here is a wire
+// contract change.
+func TestSetSSEHeaders(t *testing.T) {
+	rec := httptest.NewRecorder()
+	setSSEHeaders(rec.Header())
+
+	cases := map[string]string{
+		"Content-Type":      "text/event-stream",
+		"Cache-Control":     "no-cache",
+		"Connection":        "keep-alive",
+		"X-Accel-Buffering": "no",
+	}
+	for name, want := range cases {
+		if got := rec.Header().Get(name); got != want {
+			t.Errorf("header %q = %q, want %q", name, got, want)
+		}
+	}
+}
+
+// TestWriteSSEEvent_DefaultEvent: the default ("message") event must
+// omit the `event:` line so EventSource's onmessage handler picks it
+// up. Any leading `event: ` would route it to addEventListener("",..)
+// instead and the client would silently drop it.
+func TestWriteSSEEvent_DefaultEvent(t *testing.T) {
+	var out strings.Builder
+	fl := &fakeFlusher{}
+
+	if err := writeSSEEvent(&out, fl, "", "hello"); err != nil {
+		t.Fatalf("writeSSEEvent: %v", err)
+	}
+	if got, want := out.String(), "data: hello\n\n"; got != want {
+		t.Errorf("frame = %q, want %q", got, want)
+	}
+	if fl.calls.Load() != 1 {
+		t.Errorf("flush called %d times, want 1", fl.calls.Load())
+	}
+}
+
+// TestWriteSSEEvent_NamedEvent: named events must prepend the
+// `event: <name>\n` line. The client's addEventListener("done",..) is
+// the only thing that fires on the structured terminal payload, so a
+// missing event name would silently drop the analyzed-portfolio block.
+func TestWriteSSEEvent_NamedEvent(t *testing.T) {
+	var out strings.Builder
+	fl := &fakeFlusher{}
+
+	if err := writeSSEEvent(&out, fl, "done", "{}"); err != nil {
+		t.Fatalf("writeSSEEvent: %v", err)
+	}
+	if got, want := out.String(), "event: done\ndata: {}\n\n"; got != want {
+		t.Errorf("frame = %q, want %q", got, want)
+	}
+}
+
+// TestWriteSSEEvent_MultilineData: the SSE spec says multi-line data
+// must be split into one `data:` line per source line. If we instead
+// write a literal newline inside the value, the client treats the
+// blank line that follows as the event terminator and the second half
+// arrives as part of the *next* event — so this is a correctness
+// guarantee, not a style preference.
+func TestWriteSSEEvent_MultilineData(t *testing.T) {
+	var out strings.Builder
+	fl := &fakeFlusher{}
+
+	if err := writeSSEEvent(&out, fl, "", "line one\nline two"); err != nil {
+		t.Fatalf("writeSSEEvent: %v", err)
+	}
+	if got, want := out.String(), "data: line one\ndata: line two\n\n"; got != want {
+		t.Errorf("frame = %q, want %q", got, want)
+	}
+}
+
+// TestWriteSSEEvent_PropagatesWriteError: a client disconnect surfaces
+// as a write error here, and the per-delta callback uses that as its
+// "stop streaming" signal. If we swallowed it, LLMStream would keep
+// pulling chunks from SambaNova long after the client was gone.
+func TestWriteSSEEvent_PropagatesWriteError(t *testing.T) {
+	want := errors.New("client gone")
+	if err := writeSSEEvent(&errWriter{err: want}, &fakeFlusher{}, "", "x"); !errors.Is(err, want) {
+		t.Errorf("err = %v, want %v", err, want)
+	}
+}
+
+// TestWriteSSEEventJSON_MarshalsPayload: the structured `done` and
+// `error` events go through this path. Asserts both the framing (event
+// line, JSON body, blank line) and that the JSON itself round-trips so
+// future field additions stay parseable.
+func TestWriteSSEEventJSON_MarshalsPayload(t *testing.T) {
+	var out strings.Builder
+	fl := &fakeFlusher{}
+	payload := map[string]any{"finish_reason": "stop", "usage": map[string]int{"total_tokens": 42}}
+
+	if err := writeSSEEventJSON(&out, fl, "done", payload); err != nil {
+		t.Fatalf("writeSSEEventJSON: %v", err)
+	}
+	frame := out.String()
+	if !strings.HasPrefix(frame, "event: done\ndata: ") {
+		t.Errorf("frame missing event line, got %q", frame)
+	}
+	if !strings.HasSuffix(frame, "\n\n") {
+		t.Errorf("frame missing terminal blank line, got %q", frame)
+	}
+	body := strings.TrimSuffix(strings.TrimPrefix(frame, "event: done\ndata: "), "\n\n")
+	var got map[string]any
+	if err := json.Unmarshal([]byte(body), &got); err != nil {
+		t.Fatalf("payload not JSON: %v\n%s", err, body)
+	}
+	if got["finish_reason"] != "stop" {
+		t.Errorf("finish_reason = %v, want stop", got["finish_reason"])
+	}
+}
+
+// TestClassifyLLMStreamError table: the wire-level error message is
+// part of the public contract — clients display it. Any change to the
+// strings is a UX-visible change. The defaults branch must NEVER leak
+// raw transport errors (they can carry hostnames, retry counts, etc.)
+// so the unknown-error case has a fixed phrase.
+func TestClassifyLLMStreamError(t *testing.T) {
+	cases := []struct {
+		name string
+		in   error
+		want string
+	}{
+		{"idle timeout", errLLMIdleTimeout, "upstream stalled"},
+		{"deadline exceeded", context.DeadlineExceeded, "upstream timed out"},
+		{"canceled", context.Canceled, "request canceled"},
+		{"non-2xx (llm: prefix)", errors.New("llm: non-2xx response: 503"), "llm: non-2xx response: 503"},
+		{"random transport err", errors.New("dial tcp 10.0.0.5:443: connection refused"), "internal stream error"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyLLMStreamError(tc.in); got != tc.want {
+				t.Errorf("classifyLLMStreamError(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStreamLLMToSSE_HappyPath is the end-to-end glue test for the
+// LLM→SSE bridge. It wires a fake SambaNova upstream that emits three
+// content deltas and verifies the JSON-wrapped wire format the
+// browser EventSource is going to consume:
+//
+//	data: {"delta":"Hello, "}
+//	data: {"delta":"world"}
+//	data: {"delta":"!"}
+//
+// (each followed by the terminal blank line). It also asserts the
+// returned LLMStreamResult carries the joined text and the final-chunk
+// usage block, since the handler downstream needs both for the `done`
+// event payload.
+func TestStreamLLMToSSE_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		writeSSEChunk(t, w, `{"choices":[{"index":0,"delta":{"content":"Hello, "},"finish_reason":null}]}`)
+		writeSSEChunk(t, w, `{"choices":[{"index":0,"delta":{"content":"world"},"finish_reason":null}]}`)
+		writeSSEChunk(t, w, `{"choices":[{"index":0,"delta":{"content":"!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":3,"total_tokens":4}}`)
+	}))
+	defer srv.Close()
+
+	app, _ := newLLMTestApp(t, 5*time.Second, 1*time.Second, 0)
+	rec := httptest.NewRecorder()
+	fl, ok := http.ResponseWriter(rec).(http.Flusher)
+	if !ok {
+		t.Fatal("httptest.ResponseRecorder does not implement http.Flusher")
+	}
+
+	res, err := app.streamLLMToSSE(context.Background(), rec, fl, srv.URL, nil, `{}`)
+	if err != nil {
+		t.Fatalf("streamLLMToSSE: %v", err)
+	}
+
+	if got, want := res.Text, "Hello, world!"; got != want {
+		t.Errorf("res.Text = %q, want %q", got, want)
+	}
+	if res.Usage == nil || res.Usage.TotalTokens != 4 {
+		t.Errorf("res.Usage = %+v, want TotalTokens=4", res.Usage)
+	}
+
+	// Decode each SSE event into its delta and assert order.
+	deltas := readSSEDeltas(t, rec.Body.String())
+	want := []string{"Hello, ", "world", "!"}
+	if len(deltas) != len(want) {
+		t.Fatalf("emitted %d deltas, want %d. body=%q", len(deltas), len(want), rec.Body.String())
+	}
+	for i, d := range deltas {
+		if d != want[i] {
+			t.Errorf("delta[%d] = %q, want %q", i, d, want[i])
+		}
+	}
+}
+
+// TestStreamLLMToSSE_UpstreamError exercises the failure mode where
+// SambaNova returns 503 with retries=0 (so no replay). streamLLMToSSE
+// must surface the error to its caller (the handler will then frame
+// it as an SSE error event); it must NOT itself emit a partial event,
+// because at the moment of failure no delta has been written yet and
+// inserting a synthetic "" delta would corrupt the client's view.
+func TestStreamLLMToSSE_UpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	app, _ := newLLMTestApp(t, 2*time.Second, 1*time.Second, 0)
+	rec := httptest.NewRecorder()
+	fl, _ := http.ResponseWriter(rec).(http.Flusher)
+
+	_, err := app.streamLLMToSSE(context.Background(), rec, fl, srv.URL, nil, `{}`)
+	if err == nil {
+		t.Fatal("expected error from streamLLMToSSE on 503 upstream, got nil")
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("expected no SSE body on upstream error, got %q", rec.Body.String())
+	}
+}
+
+// readSSEDeltas extracts the {"delta": "..."} payloads from an SSE
+// response body in arrival order. Tolerates the named-event lines and
+// blank separators per the SSE spec; a parse failure on any data line
+// fails the test loudly because that means the wire format drifted.
+func readSSEDeltas(t *testing.T, body string) []string {
+	t.Helper()
+	var deltas []string
+	sc := bufio.NewScanner(strings.NewReader(body))
+	for sc.Scan() {
+		line := sc.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		raw := strings.TrimPrefix(line, "data: ")
+		var parsed struct {
+			Delta string `json:"delta"`
+		}
+		if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+			// Non-delta JSON (the named events) — skip rather than
+			// fail. The test only asserts on delta payloads.
+			continue
+		}
+		deltas = append(deltas, parsed.Delta)
+	}
+	if err := sc.Err(); err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("scanner: %v", err)
+	}
+	return deltas
+}


### PR DESCRIPTION
## Summary

This delivers the inbound counterpart to the SambaNova streaming client landed in #54. `GET /v1/investments/analysis/stream` is now an SSE endpoint that forwards each LLM content delta to the browser as it arrives, instead of holding the request open for the 10–30s the model spends emitting tokens.

The handler runs the same DB pre-checks as the synchronous `/analysis` endpoint (goals exist, portfolio non-empty) and only switches into `text/event-stream` once those 4xx-eligible validations pass — so client-side error handling for "no goals set" stays a normal JSON envelope rather than a malformed SSE frame. Once streaming starts:

- per-chunk deltas go out as anonymous `data: {"delta": "..."}` events on the default `onmessage` channel,
- the joined text is parsed with the existing `parseLLMResponse`,
- the analyzed portfolio is persisted to the same table `/analysis/summary` reads from (best-effort: a persist failure logs but does not abort the stream — the user already has the result),
- a final `event: done` event carries the structured analyzed portfolio plus `finish_reason` and `usage`.

Mid-stream failures emit a single `event: error` rather than an HTTP 5xx, because the response status is already on the wire and unchangeable by then.

I also factored the chat-completions prompt template into `renderInvestmentPortfolioPrompt` so the streaming and synchronous paths share one source of truth — drift between the two would silently produce different analyses for the same user depending on which endpoint they hit.

### Wire format

```text
data: {"delta": "Based on the asset allocation..."}
data: {"delta": " your portfolio shows..."}

event: done
data: {"finish_reason":"stop","usage":{...},"analyzed":{...}}
```

```text
event: error
data: {"error":"upstream stalled"}
```

All events are JSON-wrapped (even per-token deltas) so the client always parses with a single `JSON.parse(event.data)` regardless of which event name fires. Forward-compatible: new fields can be added without breaking parsing.

### Information-leakage rules on the error path

- **No raw upstream errors hit the wire.** `classifyLLMStreamError` collapses transport/dial/TLS errors to a fixed phrase (`internal stream error`) and only surfaces messages we author ourselves (`upstream stalled`, `upstream timed out`, `request canceled`, `llm: non-2xx response: <code>`). Hostnames, retry counts, socket-level diagnostics stay in the structured server logs.
- **No partial deltas after a failure.** `streamLLMToSSE` returns the underlying error to the handler rather than emitting a synthetic empty delta. The handler writes a single `event: error` and the connection ends. Clients can therefore treat any received delta as authoritative.

### Why mounted on the regular `/v1` router

The endpoint sits inside the regular `/v1` router (not the dedicated long-lived `sseRoutes` server) because each call is bounded by `-llm-total-budget` (default 90s) — it behaves much more like a slow HTTP request than a persistent push channel. Going through the normal middleware chain means it inherits per-IP rate limiting (you do not want a user spamming expensive LLM calls), bearer-token auth, X-Request-ID correlation, and the one-line-per-request log entry, all of which are correct here.

### Two side tasks bundled in

- **`TODO.md` item 8** (concurrency for AI portfolio analysis) is struck through with a one-paragraph note. The P3 worker pool plus singleflight registry already brought the cache-cold portfolio analysis from ~25–30s to ~3–5s on Premium Alpha Vantage tiers, and PR #54's streaming client frees the inbound HTTP request from being pinned for the LLM tail. Anyone reading TODO.md should not be misled into reopening it.
- **`.vscode/settings.json` and `sqlc.yaml` decision: keep both as-is.** Both files have been untouched since the initial commits ~2 years ago. That is because the underlying contracts have not changed: `.vscode/settings.json` carries one Makefile-Tools setting (`makefile.configureOnOpen: false`) which is still valid for any contributor with that extension and would re-introduce a configure-popup if removed; `sqlc.yaml` v2 still correctly points at the live `internal/sql/{schema,queries}` and `internal/database` layout. Neither needs an update — stable config does not mean stale config. If we want to add Go-extension defaults to `.vscode/settings.json` (e.g. `go.lintTool: golangci-lint` to align with CI), that is a separate, tiny enhancement PR rather than scope for the SSE feature.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` passes (full suite)
- [x] `go test ./cmd/api -count=1 -race` passes (race detector)
- [x] `golangci-lint run --timeout 5m ./cmd/api/...` reports `0 issues`
- [x] New SSE-specific tests added (9): default + named event framing, multi-line data splitting per spec, flush count, write-error propagation, JSON payload round-trip, error-classifier table, end-to-end `streamLLMToSSE` happy path against an httptest SambaNova, and the upstream-503 no-partial-output case
- [x] Manual smoke (planned post-merge): hit `/v1/investments/analysis/stream` from an authenticated browser session and confirm deltas render incrementally