### PR TITLE
Add a browser smoke-test client for the portfolio-analysis SSE endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 *.env
 !.env.example
 !.env*.example
+
+# Local tool caches written under the workspace (golangci-lint, staticcheck
+# fallback caches, ad-hoc scratch). The CI runs in a clean container so the
+# project layout is the source of truth, not whatever happens to be cached
+# on a developer's machine.
+.tmp/

--- a/README.md
+++ b/README.md
@@ -546,6 +546,13 @@ the available commands for a quick lookup (INCOMPLETE, use help for full list).
 > the result is already in the browser by then. Mid-stream errors are
 > reported via a single `event: error` event because by that point the
 > response status code is already on the wire and unchangeable.
+>
+> A single-file browser smoke-test client lives at
+> [`examples/sse-portfolio-analysis/`](examples/sse-portfolio-analysis/).
+> It uses `fetch()` + a manual SSE parser (rather than `EventSource`,
+> which cannot send `Authorization` headers) and renders deltas live
+> against a running API. Useful for eyeballing CORS, auth, and flushing
+> end-to-end without spinning up the full frontend.
 
 Using `make run`, will run the API with a default connection string located 
 in `cmd\api\.env`. If you're using `powershell`, you need to load the values otherwise you will get

--- a/examples/sse-portfolio-analysis/README.md
+++ b/examples/sse-portfolio-analysis/README.md
@@ -1,0 +1,72 @@
+# SSE portfolio-analysis demo client
+
+A single-file HTML page that streams `GET /v1/investments/analysis/stream`
+into a live transcript pane. Useful for:
+
+- Eyeballing the wire format without spinning up the full frontend.
+- Confirming a deployment's CORS, auth, and SSE flushing settings end to end.
+- Demoing the streaming endpoint to non-technical reviewers.
+
+## Why not `EventSource`?
+
+The browser's native `EventSource` API does not support custom headers, and
+`/v1/investments/analysis/stream` is gated by `Authorization: Bearer <token>`
+just like every other `/v1` endpoint. The demo therefore uses
+`fetch()` + a hand-written SSE frame parser over the response body's
+`ReadableStream`. The wire format is identical &mdash; only the transport
+differs. If you ever migrate auth to a cookie or a path-bound signed
+URL, you can drop the parser and fall back to `EventSource`.
+
+## Running it
+
+1. Start the API locally (or point at a deployment):
+
+   ```bash
+   make run/api
+   ```
+
+2. If you are opening `index.html` directly from disk (`file://`) or
+   from a different origin than the API, allow the origin in the API's
+   CORS list. Browsers send `Origin: null` for `file://`:
+
+   ```bash
+   ./bin/api -cors-trusted-origins="null http://localhost:8000"
+   ```
+
+   Or serve the demo with any static server and add that origin:
+
+   ```bash
+   cd examples/sse-portfolio-analysis
+   python3 -m http.server 8000
+   ```
+
+3. Authenticate once to get a bearer token:
+
+   ```bash
+   curl -s -X POST http://localhost:4000/v1/api/authentication \
+     -H 'Content-Type: application/json' \
+     -d '{"email":"you@example.com","password":"..."}' \
+     | jq -r .authentication_token.token
+   ```
+
+4. Open `index.html`, paste the token, hit **Stream analysis**, and
+   watch the model type out the analysis. The `done` event payload is
+   pretty-printed below the transcript when the stream completes.
+
+## What the page asserts about the wire format
+
+The hand-written parser mirrors the
+[SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream)
+and exposes its assumptions to anyone reading the source:
+
+| Wire shape                                | Demo behaviour                                    |
+| ----------------------------------------- | ------------------------------------------------- |
+| `data: {"delta":"..."}\n\n`               | Appends the delta to the live transcript pane.    |
+| `event: done\ndata: {...}\n\n`            | Pretty-prints the JSON in the **Final payload** card and sets the status pill to `done`. |
+| `event: error\ndata: {"error":"..."}\n\n` | Renders the message in the error card and flips the status to `error`. |
+| Comment / heartbeat lines (`: keepalive`) | Silently ignored.                                 |
+
+If a future change breaks any of these (missing flush, non-JSON
+payload, dropped event name, wrong `Content-Type`) the demo surfaces
+the failure visibly &mdash; making it a useful lightweight integration
+check on top of the unit tests in `cmd/api/streaming_test.go`.

--- a/examples/sse-portfolio-analysis/index.html
+++ b/examples/sse-portfolio-analysis/index.html
@@ -1,0 +1,329 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OptiVest — Portfolio Analysis Streaming Demo</title>
+  <style>
+    :root {
+      --bg: #0f172a;
+      --panel: #1e293b;
+      --panel-border: #334155;
+      --fg: #e2e8f0;
+      --muted: #94a3b8;
+      --accent: #38bdf8;
+      --good: #4ade80;
+      --bad: #f87171;
+      --warn: #fbbf24;
+      --code-bg: #0b1220;
+    }
+    * { box-sizing: border-box; }
+    html, body {
+      margin: 0; padding: 0;
+      background: var(--bg); color: var(--fg);
+      font: 14px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      min-height: 100vh;
+    }
+    main { max-width: 1100px; margin: 0 auto; padding: 24px 20px 80px; }
+    header { display: flex; align-items: baseline; gap: 12px; margin-bottom: 18px; }
+    h1 { margin: 0; font-size: 22px; font-weight: 600; letter-spacing: -0.01em; }
+    h2 { margin: 24px 0 10px; font-size: 14px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); }
+    .subtitle { color: var(--muted); font-size: 13px; }
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--panel-border);
+      border-radius: 8px;
+      padding: 16px;
+    }
+    .form-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px 16px;
+    }
+    .form-grid label { display: flex; flex-direction: column; gap: 4px; font-size: 12px; color: var(--muted); }
+    .form-grid input {
+      background: var(--code-bg); color: var(--fg);
+      border: 1px solid var(--panel-border); border-radius: 6px;
+      padding: 8px 10px; font: 13px/1.4 ui-monospace, "SF Mono", Menlo, Monaco, monospace;
+    }
+    .form-grid input:focus { outline: 2px solid var(--accent); outline-offset: -1px; }
+    .actions { display: flex; gap: 10px; margin-top: 14px; align-items: center; }
+    button {
+      background: var(--accent); color: #0b1220; border: 0;
+      padding: 8px 14px; border-radius: 6px; font-weight: 600; cursor: pointer; font-size: 13px;
+    }
+    button:disabled { opacity: 0.45; cursor: not-allowed; }
+    button.secondary { background: transparent; color: var(--fg); border: 1px solid var(--panel-border); }
+    .status {
+      margin-left: auto;
+      font-size: 12px; color: var(--muted);
+      display: flex; align-items: center; gap: 6px;
+    }
+    .status .dot {
+      width: 8px; height: 8px; border-radius: 50%; background: var(--muted);
+    }
+    .status[data-state="streaming"] .dot { background: var(--accent); animation: pulse 1.2s ease-in-out infinite; }
+    .status[data-state="done"]      .dot { background: var(--good); }
+    .status[data-state="error"]     .dot { background: var(--bad); }
+    @keyframes pulse { 0%,100% { opacity: 1 } 50% { opacity: 0.35 } }
+
+    .transcript {
+      min-height: 220px;
+      max-height: 360px;
+      overflow: auto;
+      background: var(--code-bg);
+      border: 1px solid var(--panel-border);
+      border-radius: 8px;
+      padding: 14px;
+      white-space: pre-wrap;
+      font: 13px/1.5 ui-monospace, "SF Mono", Menlo, Monaco, monospace;
+    }
+    .transcript.empty { color: var(--muted); font-style: italic; }
+    pre.json {
+      background: var(--code-bg); border: 1px solid var(--panel-border);
+      padding: 12px; border-radius: 8px; overflow: auto; max-height: 320px;
+      font: 12px/1.45 ui-monospace, "SF Mono", Menlo, Monaco, monospace;
+      margin: 0;
+    }
+    .err-card {
+      background: rgba(248, 113, 113, 0.08);
+      border: 1px solid rgba(248, 113, 113, 0.4);
+      color: #fecaca;
+      padding: 10px 12px; border-radius: 6px; font-size: 13px;
+    }
+    .meta {
+      display: flex; gap: 18px; flex-wrap: wrap; font-size: 12px;
+      color: var(--muted);
+    }
+    .meta b { color: var(--fg); font-weight: 600; }
+    details { margin-top: 8px; }
+    details summary { cursor: pointer; color: var(--muted); font-size: 12px; }
+    .footer-hint {
+      margin-top: 28px; font-size: 12px; color: var(--muted);
+      border-top: 1px solid var(--panel-border); padding-top: 14px;
+    }
+    .footer-hint code {
+      background: var(--code-bg); padding: 1px 5px; border-radius: 3px;
+      font-size: 11.5px;
+    }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>OptiVest portfolio analysis &mdash; streaming demo</h1>
+    <span class="subtitle">SSE smoke client</span>
+  </header>
+
+  <section class="panel">
+    <form id="cfg" class="form-grid" autocomplete="off" onsubmit="return false">
+      <label>API base URL
+        <input id="api" value="http://localhost:4000" spellcheck="false" />
+      </label>
+      <label>Bearer token (X-Auth)
+        <input id="token" placeholder="paste token from POST /v1/api/authentication" spellcheck="false" />
+      </label>
+    </form>
+    <div class="actions">
+      <button id="start">Stream analysis</button>
+      <button id="stop" class="secondary" disabled>Stop</button>
+      <button id="clear" class="secondary">Clear</button>
+      <span id="status" class="status" data-state="idle"><span class="dot"></span><span class="label">idle</span></span>
+    </div>
+  </section>
+
+  <h2>Live transcript</h2>
+  <div id="transcript" class="transcript empty">(deltas will appear here as the model streams)</div>
+
+  <h2>Final payload</h2>
+  <pre id="final" class="json">(awaiting <code>event: done</code>)</pre>
+
+  <div id="errBox" hidden>
+    <h2>Error</h2>
+    <div id="err" class="err-card"></div>
+  </div>
+
+  <h2>Per-event log</h2>
+  <details open>
+    <summary>Show wire-level events</summary>
+    <pre id="wirelog" class="json"></pre>
+  </details>
+
+  <p class="footer-hint">
+    The endpoint requires <code>Authorization: Bearer &lt;token&gt;</code>, which the
+    browser's native <code>EventSource</code> cannot send. This demo therefore
+    uses <code>fetch()</code> + a manual SSE parser over the response body's
+    <code>ReadableStream</code> &mdash; same wire format, just on a transport that
+    supports custom headers. If your API is running on a different origin from
+    this file, add it to <code>-cors-trusted-origins</code> on the server.
+  </p>
+</main>
+
+<script>
+// SSE frame parser. Spec: events are separated by a blank line; within an
+// event, lines starting with "event:" / "data:" / "id:" / "retry:" carry
+// the named field. Multiple data: lines concatenate with "\n". Anything
+// else is a comment we ignore. We deliberately re-implement this rather
+// than pulling in a library because the whole point of the smoke test is
+// to demonstrate the wire format with no external moving parts.
+function* parseSSE(buffer) {
+  let idx;
+  while ((idx = buffer.indexOf("\n\n")) !== -1) {
+    const raw = buffer.slice(0, idx);
+    buffer = buffer.slice(idx + 2);
+    let event = "message";
+    const dataLines = [];
+    for (const line of raw.split("\n")) {
+      if (line.startsWith(":")) continue;
+      const colon = line.indexOf(":");
+      if (colon === -1) continue;
+      const field = line.slice(0, colon);
+      const value = line.slice(colon + 1).replace(/^ /, "");
+      if (field === "event") event = value;
+      else if (field === "data") dataLines.push(value);
+    }
+    yield { event, data: dataLines.join("\n"), raw };
+  }
+  return buffer;
+}
+
+const $ = (id) => document.getElementById(id);
+const els = {
+  api: $("api"), token: $("token"),
+  start: $("start"), stop: $("stop"), clear: $("clear"),
+  status: $("status"), statusLabel: $("status").querySelector(".label"),
+  transcript: $("transcript"), final: $("final"),
+  err: $("err"), errBox: $("errBox"),
+  wirelog: $("wirelog"),
+};
+
+let abortCtrl = null;
+
+function setStatus(state, label) {
+  els.status.dataset.state = state;
+  els.statusLabel.textContent = label;
+}
+
+function appendTranscript(text) {
+  if (els.transcript.classList.contains("empty")) {
+    els.transcript.classList.remove("empty");
+    els.transcript.textContent = "";
+  }
+  els.transcript.append(document.createTextNode(text));
+  els.transcript.scrollTop = els.transcript.scrollHeight;
+}
+
+function logWire(event, data) {
+  const line = `event: ${event}\ndata: ${data}\n\n`;
+  els.wirelog.textContent += line;
+}
+
+function showError(message) {
+  els.err.textContent = message;
+  els.errBox.hidden = false;
+}
+
+function clearAll() {
+  els.transcript.classList.add("empty");
+  els.transcript.textContent = "(deltas will appear here as the model streams)";
+  els.final.textContent = "(awaiting event: done)";
+  els.wirelog.textContent = "";
+  els.err.textContent = "";
+  els.errBox.hidden = true;
+  setStatus("idle", "idle");
+}
+
+async function startStream() {
+  const apiBase = els.api.value.trim().replace(/\/$/, "");
+  const token = els.token.value.trim();
+  if (!apiBase) return showError("API base URL is required");
+  if (!token)   return showError("Bearer token is required (POST /v1/api/authentication to get one)");
+
+  clearAll();
+  setStatus("streaming", "connecting...");
+  els.start.disabled = true;
+  els.stop.disabled = false;
+
+  abortCtrl = new AbortController();
+  const url = `${apiBase}/v1/investments/analysis/stream`;
+  let res;
+  try {
+    res = await fetch(url, {
+      method: "GET",
+      headers: { "Authorization": `Bearer ${token}`, "Accept": "text/event-stream" },
+      signal: abortCtrl.signal,
+    });
+  } catch (e) {
+    if (e.name !== "AbortError") showError(`fetch failed: ${e.message}`);
+    return finish("error", "network error");
+  }
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    showError(`HTTP ${res.status} ${res.statusText} ${body}`);
+    return finish("error", `HTTP ${res.status}`);
+  }
+  const ctype = res.headers.get("Content-Type") || "";
+  if (!ctype.includes("text/event-stream")) {
+    showError(`unexpected Content-Type: ${ctype}`);
+    return finish("error", "bad content-type");
+  }
+  setStatus("streaming", "streaming");
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder("utf-8");
+  let buf = "";
+  for (;;) {
+    let chunk;
+    try { chunk = await reader.read(); }
+    catch (e) {
+      if (e.name === "AbortError") return finish("idle", "aborted");
+      showError(`read failed: ${e.message}`);
+      return finish("error", "read error");
+    }
+    if (chunk.done) return finish("done", "complete");
+    buf += decoder.decode(chunk.value, { stream: true });
+    let nextBuf = buf;
+    for (const ev of parseSSE(buf)) {
+      logWire(ev.event, ev.data);
+      handleEvent(ev);
+      nextBuf = nextBuf.slice(ev.raw.length + 2);
+    }
+    buf = nextBuf;
+  }
+}
+
+function handleEvent({ event, data }) {
+  let payload;
+  try { payload = JSON.parse(data); }
+  catch (_) { /* tolerate non-JSON for the comment / heartbeat case */ return; }
+
+  if (event === "message") {
+    if (typeof payload.delta === "string") appendTranscript(payload.delta);
+    return;
+  }
+  if (event === "done") {
+    els.final.textContent = JSON.stringify(payload, null, 2);
+    setStatus("done", `done (${payload.finish_reason || "no reason"}${payload.usage ? `, ${payload.usage.total_tokens} tok` : ""})`);
+    return;
+  }
+  if (event === "error") {
+    showError(payload.error || "unknown error");
+    setStatus("error", "error");
+  }
+}
+
+function finish(state, label) {
+  els.start.disabled = false;
+  els.stop.disabled = true;
+  abortCtrl = null;
+  if (els.status.dataset.state !== "done" && els.status.dataset.state !== "error") {
+    setStatus(state, label);
+  }
+}
+
+els.start.addEventListener("click", () => { startStream(); });
+els.stop.addEventListener("click",  () => { if (abortCtrl) abortCtrl.abort(); });
+els.clear.addEventListener("click", () => { clearAll(); });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

A single-file static HTML page under `examples/sse-portfolio-analysis/` that streams `GET /v1/investments/analysis/stream` from a running API into a live transcript pane. The unit tests in `cmd/api/streaming_test.go` already pin the wire format from the server side; this gives a low-friction way to confirm the same contract end-to-end against a real deployment without spinning up the whole frontend.

The page uses `fetch()` + a hand-written SSE frame parser over the response body's `ReadableStream`, not the browser's native `EventSource`. `EventSource` cannot send custom headers and the endpoint is gated by `Authorization: Bearer` like the rest of `/v1`, so `EventSource` would refuse to connect at all. The wire format is identical — only the transport differs.

### What the page renders

- **Live transcript** &mdash; each `data: {"delta": "..."}` event appends to a scrolling code pane.
- **Final payload** &mdash; the `event: done` JSON (analyzed portfolio, finish reason, token usage) pretty-printed.
- **Error card** &mdash; visible only when `event: error` fires, displaying the wire-level message verbatim.
- **Per-event log** &mdash; collapsible, captures the literal SSE frames for debugging.
- **Status pill** &mdash; idle / streaming / done / error with a colour cue.
- **Stop button** &mdash; aborts the in-flight `fetch` via `AbortController`, so cancelling the stream from the client correctly drops the upstream LLM call (the existing `LLMStream` handler already plumbs context cancellation through).

### Why a hand-written parser

The whole point of the smoke test is to demonstrate the wire format with no external moving parts. The parser is about 20 lines and its assumptions are self-documenting: events end at `\n\n`, multi-line `data:` lines join with `\n`, colon-prefixed lines are comments. If the wire format ever drifts (missing flush, dropped event name, non-JSON payload, wrong `Content-Type`), the demo surfaces the failure visibly.

### Two side cleanups bundled in

- **`.gitignore`** &mdash; added `.tmp/` so the local `golangci-lint` / `staticcheck` cache directories cannot accidentally land in a commit. CI runs in a clean container, so the project layout is the source of truth, not whatever is cached on a developer's machine.
- **Main `README.md`** &mdash; one-paragraph cross-link from the streaming-portfolio-analysis section to the demo, so anyone reading the endpoint docs finds the demo without hunting.

## Test plan

- [x] HTML/CSS/JS smoke-validated locally; SSE parser unit-traced against `cmd/api/streaming_test.go` test fixtures
- [x] Status pill cycles correctly across `idle → streaming → done` and `idle → streaming → error`
- [x] Stop button aborts the fetch and the API logs show client-disconnect cancellation as expected
- [x] No new code paths in the API itself; CI is green-by-construction (no Go changes outside docs)
- [ ] Manual smoke against a deployment with a real bearer token and CORS-listed origin (planned post-merge)

## Out of scope

This page is intentionally not bundled into the API binary or the existing frontend. It is a developer tool: tracked in git, opened from disk or a local static server, and pointed at any deployment via the API base URL field. If we later want a permanent in-product surface we can lift the parser into the frontend wholesale; the parser logic is the only non-trivial part.