### PR TITLE
Bump CI actions to the Node 24 runtime ahead of the June 2026 cutover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,12 @@ jobs:
           cache: true
 
       - name: golangci-lint
-        # v7 is the first action major that supports golangci-lint v2's
-        # new config schema. Older v6 errors with `invalid version
-        # string` at runtime even if the binary itself is fine.
-        uses: golangci/golangci-lint-action@v7
+        # v9 is the first action major to ship the Node.js 24 runtime,
+        # closing the Sept 2025 deprecation of Node 20 on GitHub-hosted
+        # runners. v8 already required golangci-lint v2.1.0+ (we run
+        # v2.12.2, see GOLANGCI_LINT_VERSION above), and v9 changes only
+        # the runtime — no config-schema or input changes from v7.
+        uses: golangci/golangci-lint-action@v9
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=5m
@@ -135,7 +137,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage profile
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-profile
           path: coverage.out
@@ -226,7 +228,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build ${{ matrix.image }}
         uses: docker/build-push-action@v7
@@ -249,7 +251,7 @@ jobs:
           echo "| ${{ matrix.image }} | \`$size\` |" >> /tmp/sizes-${{ matrix.image }}.md
 
       - name: Upload image tarball
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: image-${{ matrix.image }}
           path: /tmp/${{ matrix.image }}.tar
@@ -350,7 +352,7 @@ jobs:
           upload-release-assets: false
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sbom-${{ matrix.image }}
           path: sbom-${{ matrix.image }}.spdx.json
@@ -372,7 +374,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Seed env files
         # Both credentials below are generated freshly with openssl on


### PR DESCRIPTION
## Summary

GitHub [announced the deprecation of Node.js 20 on hosted runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) in September 2025. Forced cutover is June 2 2026 and removal completes September 16 2026, so this moves CI off Node 20-based actions before warnings turn into hard failures.

### What changed

| Action                               | Before | After | Why                                                                                                                                                                                  |
| ------------------------------------ | ------ | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `actions/upload-artifact`            | `v4`   | `v7`  | v6 was the first major to default to Node 24, v7 added optional direct-upload (`archive: false`, unused here). Pairs cleanly with the `download-artifact@v8` already on the receivers. |
| `docker/setup-buildx-action`         | `v3`   | `v4`  | v4 is the Node 24 runtime release. No input changes.                                                                                                                                 |
| `golangci/golangci-lint-action`      | `v7`   | `v9`  | v8 raised the floor to `golangci-lint v2.1.0+` (we already run `v2.12.2` via `GOLANGCI_LINT_VERSION`); v9 is the Node 24 runtime bump. No config-schema, input-name, or cache changes from v7. |

The matching `actions/download-artifact` is already at `v8` from a prior Dependabot PR (#51), so the `docker-build → {image-scan, sbom, e2e}` artefact handoff is now version-aligned end to end.

### What did not change

| Action                            | Pinned at      | Status                                                                                                                                                  |
| --------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `actions/checkout`                | `v6`           | Already Node 24.                                                                                                                                        |
| `actions/setup-go`                | `v6`           | Already Node 24.                                                                                                                                        |
| `actions/download-artifact`       | `v8`           | Already Node 24 (#51).                                                                                                                                  |
| `docker/build-push-action`        | `v7`           | Already Node 24.                                                                                                                                        |
| `aquasecurity/trivy-action`       | `v0.36.0`      | Currently the latest release; pinned exactly because we audit the bundled trivy binary version.                                                          |
| `hadolint/hadolint-action`        | `v3.3.0`       | Currently the latest release; pinned exactly because we audit the bundled hadolint binary version. **Still Node 20 upstream** — tracked via Dependabot. |
| `anchore/sbom-action`             | `v0.24.0`      | Currently the latest; pinned exactly for SBOM provenance.                                                                                               |
| `gitleaks/gitleaks-action`        | `v2`           | Currently the latest major (`v2.3.9`). **Still Node 20 upstream** — tracked via Dependabot.                                                              |
| `github/codeql-action`            | `v3`           | Maintained by GitHub Security; runtime tracked by them.                                                                                                  |

The two remaining Node 20 actions (`hadolint`, `gitleaks`) have no Node 24 release published yet. Until upstream cuts one, the runner uses its compatibility shim and the deprecation banner stays on those two steps only — no fix possible from this side.

### Pinning style stays the same

`actions/*` and `docker/*` stay on major-tag floats so Dependabot rides patch and minor updates without one PR per bump. The binary-bundling actions (`trivy`, `hadolint`, `sbom`) stay pinned to the exact release whose bundled binary we have audited; that pinning is intentional and unchanged.

## Test plan

- [x] `golangci-lint run --timeout 5m ./cmd/api/...` clean locally with the same `v2.12.2` binary `golangci-lint-action@v9` will install
- [x] `actions/upload-artifact@v7` artefact format is read-compatible with `actions/download-artifact@v8` (the existing pair on the receiving jobs)
- [x] No workflow input changed in the bumped actions; only the runtime
- [ ] CI green on this PR (the only real proof the bumps work end-to-end)