### PR TITLE
Stop emitting authentication-flow values in info-level logs

### DIFF
--- a/cmd/api/authentication.go
+++ b/cmd/api/authentication.go
@@ -256,8 +256,12 @@ func (app *application) validateMFALoginAttemptHandler(w http.ResponseWriter, r 
 		app.serverErrorResponse(w, r, err)
 		return
 	}
-	app.logger.Info("MFA setup pending status decrypted token", zap.String("decryptedToken", decryptedToken), zap.String("stored token", (*mfaSession).Value))
-	app.logger.Info("Received TOTP Code", zap.String("TOTPCode", mfaToken.TOTPCode), zap.String("Received TOTPToken", mfaToken.TOTPToken))
+	// Never log MFA secrets, decrypted tokens, the user-supplied TOTP code,
+	// or the stored MFA session value — they are auth-flow primitives that
+	// would let any reader of the log replay or bypass the MFA challenge.
+	// If a future debug session needs to confirm "did the comparison run",
+	// log a boolean (decryptedToken == sessionValue) at Debug level, never
+	// the values themselves.
 
 	// check if the decrypted token matches the one in redis
 	if decryptedToken != (*mfaSession).Value {

--- a/cmd/api/users.go
+++ b/cmd/api/users.go
@@ -81,7 +81,10 @@ func (app *application) registerUserHandler(w http.ResponseWriter, r *http.Reque
 		app.serverErrorResponse(w, r, err)
 		return
 	}
-	app.logger.Info("Token Has Been generated for new user", zap.String("token", token.Plaintext), zap.Int("user id", int(user.ID)))
+	// Never log the activation token plaintext — anyone with log access could
+	// activate the account before the legitimate user clicks the email link.
+	// User ID alone is enough breadcrumb for the registration flow.
+	app.logger.Info("activation token generated for new user", zap.Int64("user_id", user.ID))
 	app.background(func() {
 		// As there are now multiple pieces of data that we want to pass to our email
 		// templates, we create a map to act as a 'holding structure' for the data. This


### PR DESCRIPTION
## Summary

Three log lines were carrying primary-credential material into whatever log retention sits in front of `app.logger`. This removes them and replaces them with breadcrumb-only entries plus a near-the-call-site comment so a future debug session does not reintroduce the same pattern.

> **Operational note:** if any historical log retention behind `app.logger` has accumulated these values, treat the affected windows as compromised. Rotate active activation tokens issued in that window, force MFA re-enrollment for any account that completed an MFA challenge in that window, and purge the relevant log indices. This PR closes the leak; it does not retroactively redact what is already on disk.

## What changed

**`cmd/api/authentication.go`** &mdash; MFA-validation path (`validateMFALoginAttemptHandler`)

- Removed the line that logged `decryptedToken` alongside the stored MFA session value.
- Removed the line that logged the user-supplied `TOTPCode` alongside the encrypted `TOTPToken`.

A reader of the log can no longer reconstruct or replay the MFA challenge from the log alone. If a future debug session needs to confirm the comparison ran, the right shape is a boolean field (`matched: true/false`) at Debug level &mdash; never the values themselves. The replacement comment captures that guidance inline.

**`cmd/api/users.go`** &mdash; registration handler (`registerUserHandler`)

- Removed the activation token plaintext from the post-token-generation log line.
- Kept the `user_id` breadcrumb (useful for registration-funnel debugging).

The mailer goroutine downstream still sends the token to the user's mailbox, which remains the only place it should appear.

## Why this ships ahead of #56 and #57

Strictly subtractive change, single-purpose, two-file diff, zero new logic, no new test coverage to write. Every hour this sits unfixed is more credential-shaped material accumulating in log retention.

## Test plan

- [x] go build ./... clean
- [x] No remaining zap.String token / TOTPCode / decryptedToken patterns in cmd/api
- [x] No test asserts on the removed log strings
- [ ] CI green on this PR

## Follow-up tracked separately

The audit that flagged this also produced a 50-item prioritised action list across 1-week / 1-month / 1-quarter buckets. The remaining 1-week items will land as 2 follow-up PRs (error-path correctness + operational hardening) once this hotfix is merged.