### PR TITLE
Security tier-2: stop leaking what we already know we leak

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,10 +451,28 @@ jobs:
           echo "$body" | grep -qE '^optivest_'
           echo "metrics OK"
 
-      - name: Assert /debug/vars is JSON
+      - name: Assert /debug/vars is JSON and cmdline is stripped
         run: |
-          curl -fsS http://127.0.0.1:4000/debug/vars | jq -e '.cmdline' >/dev/null
-          echo "debug/vars OK"
+          # The OptiVest /debug/vars handler is a curated wrapper around
+          # expvar.Handler that blocklists keys that leak operational
+          # information about the running process. cmdline is the canonical
+          # one - the std expvar package publishes os.Args verbatim, which
+          # exposes any secret-bearing flag an operator typed instead of
+          # exporting via env var. Strip plus regression-test is the only
+          # thing that keeps the behavior from quietly being re-added by
+          # an `import _ "expvar"` somewhere in a future PR.
+          body=$(curl -fsS http://127.0.0.1:4000/debug/vars)
+          echo "$body" | jq -e 'type == "object"' >/dev/null
+          if echo "$body" | jq -e 'has("cmdline")' >/dev/null; then
+            echo "FAIL: /debug/vars exposed 'cmdline'; debugVarsBlocklist regressed" >&2
+            exit 1
+          fi
+          # memstats is auto-registered by the std expvar package and is the
+          # most stable presence-check we have - it confirms (a) the handler
+          # is actually walking the expvar registry, not returning {}, and
+          # (b) the JSON envelope round-trips cleanly through jq.
+          echo "$body" | jq -e '.memstats | type == "object"' >/dev/null
+          echo "debug/vars OK (cmdline stripped, memstats present)"
 
       - name: Compose ps
         if: always()

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -12,12 +12,27 @@
 # Specifically the allowlist covers:
 #   - cmd/api/.env.example      (committed runtime config template)
 #   - .env.example              (committed compose interpolation template)
+#   - .github/workflows/ci.yml  (the e2e job calls openssl to generate
+#                               throwaway test credentials and substitutes
+#                               them into temporary env files; gitleaks
+#                               flags those substitution patterns)
 # Real /.env and cmd/api/.env are both gitignored and not subject to this
 # allowlist; if they ever end up in a commit, gitleaks will catch them.
+#
+# Workflow allowlist scope: previously this allowlisted EVERY file matching
+# `.github/workflows/.+\.ya?ml`, which silently exempted any future
+# workflow added to the repo. The current entry pins to ci.yml only; new
+# workflows will be scanned on equal terms with the rest of the tree, and
+# adding a second allowlisted workflow requires an explicit edit here
+# (with a justification in the surrounding comment).
 #
 # Pattern allowlist:
 #   - The `openssl rand -hex 32` instruction in comments. Some scanners
 #     match on `[0-9a-f]{64}` adjacent to the word "key".
+#   - `POSTGRES_PASSWORD=${pg_pw}` and `OPTIVEST_DATA_ENCRYPTION_KEY=${enc_key}`,
+#     which are the literal substitution patterns the e2e job uses to seed
+#     temporary credentials for the running container. The actual values
+#     are openssl-generated at runtime and never appear in the tree.
 #
 # Run locally with:
 #   gitleaks detect --config .gitleaks.toml --no-banner
@@ -35,15 +50,18 @@ description = "OptiVest committed environment templates and known-safe defaults"
 paths = [
   '''(^|/)\.env\.example$''',
   '''(^|/)cmd/api/\.env\.example$''',
-  # GHA workflows reference example values when seeding env files for e2e.
-  # Those references are not real credentials.
-  '''(^|/)\.github/workflows/.+\.ya?ml$''',
+  '''(^|/)\.github/workflows/ci\.yml$''',
 ]
 
 regexes = [
   # Documentation-style hash showing the *length* of an AES-256 key
   # without being a real key value.
   '''openssl\s+rand\s+-hex\s+32''',
+  # Literal substitution patterns from ci.yml's e2e job. The variables on
+  # the right-hand side (${pg_pw}, ${enc_key}) are openssl-generated at
+  # job runtime; only the patterns themselves live in the tree.
+  '''POSTGRES_PASSWORD=\$\{pg_pw\}''',
+  '''OPTIVEST_DATA_ENCRYPTION_KEY=\$\{enc_key\}''',
 ]
 
 # Specific commits that landed before this config was added. Empty for now;

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,34 @@ start if any of the following is empty (see `validateConfig` in
 In `development` the same checks log warnings but do not abort startup, so
 local work with a partial `.env` continues to function.
 
+## Secrets must NEVER be passed on the command line
+
+The flag definitions in `cmd/api/main.go` default-from-env for every
+secret-bearing variable, so an operator who exports the corresponding
+`OPTIVEST_*` env var gets the expected behavior. What's banned at startup
+is passing the secret value LITERALLY on the command line - e.g.
+`./api -encryption-key=<hex>` or `./api -api-key-sambanova=<value>`.
+
+The `rejectSecretFlags` startup gate scans `os.Args` BEFORE `flag.Parse`
+and exits with code 2 if any of these prefixes appears:
+
+- `-encryption-key`, `--encryption-key`
+- `-redis-password`, `--redis-password`
+- `-smtp-password`, `--smtp-password`
+- `-db-dsn`, `--db-dsn` (DSNs typically embed credentials)
+- `-api-key-*` for any vendor (Alpha Vantage, FRED, FMP, SambaNova, etc.)
+
+The reason matters: command-line values land in `/proc/<pid>/cmdline`
+(world-readable on most Linux distros), `ps -ef`, shell history, and any
+process supervisor that records argv. The startup gate makes that leak
+impossible to introduce via a stressed engineer doing a quick experiment
+or a runbook that hardcodes the wrong example.
+
+The curated `/debug/vars` handler (`cmd/api/metrics.go`) provides a
+second layer: even if the gate is bypassed (e.g. by a forked build),
+the handler strips `cmdline` from the JSON output so operational
+endpoints don't echo back what was passed.
+
 ## Generating a fresh AES-GCM key
 
 ```bash

--- a/cmd/api/authentication.go
+++ b/cmd/api/authentication.go
@@ -52,9 +52,22 @@ func (app *application) createAuthenticationApiKeyHandler(w http.ResponseWriter,
 		}
 		return
 	}
-	// if the user is not activated, we return an error
+	// If the user exists but isn't activated, return the same generic
+	// invalid-credentials response we use for not-found / wrong-password.
+	// The previous behavior - 423 Locked with "your user account must be
+	// activated" - was a credential-stuffing oracle: an attacker testing
+	// an (email, password) combo could distinguish "right password,
+	// inactive account" (423) from "wrong password" (401), letting them
+	// confirm valid credentials even when the account couldn't be logged
+	// into. The activation requirement is still enforced - it just no
+	// longer leaks back to the unauthenticated caller. Log the
+	// distinction at WARN with the user_id so legitimate operators can
+	// still triage "user keeps trying to log in but never activated."
 	if !user.Activated {
-		app.inactiveAccountResponse(w, r)
+		app.logger.Warn("login attempted against inactive account; returning generic invalid-credentials",
+			zap.Int64("user_id", user.ID),
+		)
+		app.invalidCredentialsResponse(w, r)
 		return
 	}
 	// check if the password matches
@@ -315,24 +328,28 @@ func (app *application) createPasswordResetTokenHandler(w http.ResponseWriter, r
 		app.failedValidationResponse(w, r, v.Errors)
 		return
 	}
-	// Try to retrieve the corresponding user record for the email address. If it can't
-	// be found, return an error message to the client.
+	// All three branches below (email-not-found, account-inactive, and
+	// the genuine happy path) MUST return the same envelope and status
+	// code so an anonymous caller cannot distinguish them. The previous
+	// implementation got the email-not-found branch right in spirit but
+	// used a 422 envelope with v.Errors, while the inactive-account
+	// branch returned 423; both shapes were enumeration tells. Now all
+	// roads lead to accountRecoveryEligibleResponse with 202.
 	user, err := app.models.Users.GetByEmail(r.Context(), input.Email, app.config.encryption.key)
 	if err != nil {
-		switch {
-		// We willl use a generic error message to avoid leaking information about which
-		// email addresses are registered with the system.
-		case errors.Is(err, data.ErrGeneralRecordNotFound):
-			v.AddError("message", "if we found a matching email address, we have sent password reset instructions to it")
-			app.failedValidationResponse(w, r, v.Errors)
-		default:
-			app.serverErrorResponse(w, r, err)
+		if errors.Is(err, data.ErrGeneralRecordNotFound) {
+			app.loggerFromRequest(r).Warn("password-reset requested for unknown email; sending generic envelope")
+			app.accountRecoveryEligibleResponse(w, r)
+			return
 		}
+		app.serverErrorResponse(w, r, err)
 		return
 	}
-	// Return an error message if the user is not activated.
 	if !user.Activated {
-		app.inactiveAccountResponse(w, r)
+		app.loggerFromRequest(r).Warn("password-reset requested for inactive account; sending generic envelope",
+			zap.Int64("matched_user_id", user.ID),
+		)
+		app.accountRecoveryEligibleResponse(w, r)
 		return
 	}
 
@@ -354,34 +371,29 @@ func (app *application) createPasswordResetTokenHandler(w http.ResponseWriter, r
 		}
 	}
 
-	// Otherwise, create a new password reset token with a 45-minute expiry time.
 	token, err := app.models.Tokens.New(r.Context(), user.ID, 45*time.Minute, data.ScopePasswordReset)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
 	}
-	// Email the user with their password reset token.
 	app.background(func() {
 		data := map[string]any{
 			"passwordResetURL":   app.config.frontend.passwordreseturl + token.Plaintext,
 			"passwordResetToken": token.Plaintext,
 		}
-		// Since email addresses MAY be case sensitive, notice that we are sending this
-		// email using the address stored in our database for the user --- not to the
-		// input.Email address provided by the client in this request.
-		err = app.mailer.Send(user.Email, "token_password_reset.tmpl", data)
-		if err != nil {
-			app.logger.Error("Error sending password reset email", zap.Error(err))
+		if err := app.mailer.Send(user.Email, "token_password_reset.tmpl", data); err != nil {
+			app.loggerFromRequest(r).Error("password-reset email send failed",
+				zap.Int64("user_id", user.ID),
+				zap.Error(err),
+			)
 		}
 	})
-	// Send a 202 Accepted response and confirmation message to the client.
-	// But use a generic message as well
-	// an email will be sent to you containing password reset instructions
-	env := envelope{"message": "if we found a matching email address, we have sent password reset instructions to it"}
-	err = app.writeJSON(w, http.StatusAccepted, env, nil)
-	if err != nil {
-		app.serverErrorResponse(w, r, err)
-	}
+	// Same envelope as the unknown-email and inactive-account branches
+	// above. The previous bespoke message ("if we found a matching email
+	// address, we have sent password reset instructions") was almost the
+	// right shape but did not match the not-found branch byte-for-byte,
+	// so an attacker comparing responses could still distinguish them.
+	app.accountRecoveryEligibleResponse(w, r)
 }
 
 // validateTOTPResetPasswordHandler() is a helper that validates the TOTP code for the user when
@@ -453,32 +465,34 @@ func (app *application) createManualActivationTokenHandler(w http.ResponseWriter
 		app.failedValidationResponse(w, r, v.Errors)
 		return
 	}
-	// Try to retrieve the corresponding user record for the email address. If it can't
-	// be found, return an error message to the client.
+	// Every branch below collapses into accountRecoveryEligibleResponse
+	// so the wire response is byte-identical regardless of whether the
+	// email is registered, the account is already activated, or we
+	// genuinely created a token and queued an email. Specific reasons
+	// are logged at WARN with the user_id (where known) so support and
+	// incident-response can still triage real users.
 	user, err := app.models.Users.GetByEmail(r.Context(), input.Email, app.config.encryption.key)
 	if err != nil {
-		switch {
-		case errors.Is(err, data.ErrGeneralRecordNotFound):
-			v.AddError("email", "no matching email address found")
-			app.failedValidationResponse(w, r, v.Errors)
-		default:
-			app.serverErrorResponse(w, r, err)
+		if errors.Is(err, data.ErrGeneralRecordNotFound) {
+			app.loggerFromRequest(r).Warn("manual-activation requested for unknown email; sending generic envelope")
+			app.accountRecoveryEligibleResponse(w, r)
+			return
 		}
+		app.serverErrorResponse(w, r, err)
 		return
 	}
-	// Return an error if the user has already been activated.
 	if user.Activated {
-		v.AddError("email", "user has already been activated")
-		app.failedValidationResponse(w, r, v.Errors)
+		app.loggerFromRequest(r).Warn("manual-activation requested for already-activated account; sending generic envelope",
+			zap.Int64("matched_user_id", user.ID),
+		)
+		app.accountRecoveryEligibleResponse(w, r)
 		return
 	}
-	// Otherwise, create a new activation token.
 	token, err := app.models.Tokens.New(r.Context(), user.ID, 3*24*time.Hour, data.ScopeActivation)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
 	}
-	// Email the user with their additional activation token.
 	app.background(func() {
 		data := map[string]any{
 			"activationURL": app.config.frontend.activationurl + token.Plaintext,
@@ -486,20 +500,18 @@ func (app *application) createManualActivationTokenHandler(w http.ResponseWriter
 			"lastName":      user.LastName,
 			"userID":        user.ID,
 		}
-		// Since email addresses MAY be case sensitive, notice that we are sending this
-		// email using the address stored in our database for the user --- not to the
-		// input.Email address provided by the client in this request.
-		err = app.mailer.Send(user.Email, "user_welcome.tmpl", data)
-		if err != nil {
-			app.logger.Info("An error occurred while sending the activation email", zap.Error(err))
+		// Email addresses MAY be case-sensitive; we send to the address
+		// stored in our database for the user, NOT input.Email. Token
+		// breadcrumbs (Plaintext, Hash) never enter logs - see the
+		// audit-log redaction work in PR #58.
+		if err := app.mailer.Send(user.Email, "user_welcome.tmpl", data); err != nil {
+			app.loggerFromRequest(r).Info("manual-activation email send failed",
+				zap.Int64("user_id", user.ID),
+				zap.Error(err),
+			)
 		}
 	})
-	// Send a 202 Accepted response and confirmation message to the client.
-	env := envelope{"message": "an email will be sent to you containing activation instructions"}
-	err = app.writeJSON(w, http.StatusAccepted, env, nil)
-	if err != nil {
-		app.serverErrorResponse(w, r, err)
-	}
+	app.accountRecoveryEligibleResponse(w, r)
 }
 
 // ToDo: Add handlers for recovering account with recovery codes
@@ -524,38 +536,42 @@ func (app *application) initializeRecoveryByRecoveryCodes(w http.ResponseWriter,
 		app.failedValidationResponse(w, r, v.Errors)
 		return
 	}
-	// Try to retrieve the corresponding user record for the email address. If it can't
-	// be found, return an error message to the client.
+	// Every branch below collapses into accountRecoveryEligibleResponse
+	// so the wire is byte-identical regardless of whether the email is
+	// unknown, the account is unactivated, MFA was never enabled (which
+	// is the actual eligibility precondition for this flow), or we
+	// genuinely created a recovery token. The previous shape leaked
+	// three orthogonal account-state bits to anonymous probes: existence,
+	// activation-state, and MFA-configured-state.
 	user, err := app.models.Users.GetByEmail(r.Context(), input.Email, app.config.encryption.key)
 	if err != nil {
-		switch {
-		case errors.Is(err, data.ErrGeneralRecordNotFound):
-			v.AddError("email", "no matching email address found")
-			app.failedValidationResponse(w, r, v.Errors)
-		default:
-			app.serverErrorResponse(w, r, err)
+		if errors.Is(err, data.ErrGeneralRecordNotFound) {
+			app.loggerFromRequest(r).Warn("recovery-by-codes requested for unknown email; sending generic envelope")
+			app.accountRecoveryEligibleResponse(w, r)
+			return
 		}
+		app.serverErrorResponse(w, r, err)
 		return
 	}
-	// Return an error if the user has not been activated.
 	if !user.Activated {
-		v.AddError("email", "user account has not been activated")
-		app.failedValidationResponse(w, r, v.Errors)
+		app.loggerFromRequest(r).Warn("recovery-by-codes requested for inactive account; sending generic envelope",
+			zap.Int64("matched_user_id", user.ID),
+		)
+		app.accountRecoveryEligibleResponse(w, r)
 		return
 	}
-	// Return an error if the user has not enabled MFA
 	if !user.MFAEnabled {
-		v.AddError("email", "user account has not enabled MFA")
-		app.failedValidationResponse(w, r, v.Errors)
+		app.loggerFromRequest(r).Warn("recovery-by-codes requested for account without MFA; sending generic envelope",
+			zap.Int64("matched_user_id", user.ID),
+		)
+		app.accountRecoveryEligibleResponse(w, r)
 		return
 	}
-	// Otherwise, create a new recovery token with 15-minute expiry time.
 	token, err := app.models.Tokens.New(r.Context(), user.ID, 15*time.Minute, data.ScopeRecovery)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
 	}
-	// Email the user with their additional recovery token.
 	app.background(func() {
 		data := map[string]any{
 			"recoveryCodesURL": app.config.frontend.recoveryurl,
@@ -563,21 +579,16 @@ func (app *application) initializeRecoveryByRecoveryCodes(w http.ResponseWriter,
 			"firstName":        user.FirstName,
 			"lastName":         user.LastName,
 		}
-		// Since email addresses MAY be case sensitive, notice that we are sending this
-		// email using the address stored in our database for the user --- not to the
-		// input.Email address provided by the client in this request.
-		err = app.mailer.Send(user.Email, "account_recovery.tmpl", data)
-		if err != nil {
-			app.logger.Info("An error occurred while sending the recovery email", zap.Error(err))
+		// Email addresses MAY be case-sensitive; we send to the address
+		// stored in our database, not input.Email.
+		if err := app.mailer.Send(user.Email, "account_recovery.tmpl", data); err != nil {
+			app.loggerFromRequest(r).Info("recovery email send failed",
+				zap.Int64("user_id", user.ID),
+				zap.Error(err),
+			)
 		}
 	})
-	// Send a 202 Accepted response and confirmation message to the client.
-	env := envelope{"message": "an email will be sent to you containing recovery instructions"}
-	err = app.writeJSON(w, http.StatusAccepted, env, nil)
-	if err != nil {
-		app.serverErrorResponse(w, r, err)
-	}
-
+	app.accountRecoveryEligibleResponse(w, r)
 }
 
 // validateRecoveryCodeHandler() is a handler method that verifies the recovery code for the user when

--- a/cmd/api/errors.go
+++ b/cmd/api/errors.go
@@ -51,11 +51,37 @@ func (app *application) authenticationRequiredResponse(w http.ResponseWriter, r 
 	app.errorResponse(w, r, http.StatusUnauthorized, message)
 }
 
-// The inactiveAccountResponse() method will return 401 inactive account error, that is the account
-// needs to be activated to proceed.
+// The inactiveAccountResponse() method returns 423 Locked. It is used on
+// AUTHENTICATED routes (`requireActivatedUser` middleware) where the caller
+// has already proven possession of a valid bearer token and the server is
+// telling them their account is in a locked state - that response leaks
+// nothing new because the caller is already known. Do NOT use it on
+// unauthenticated routes (login, password-reset, recovery, activation):
+// those leak account-state to anonymous probes and must use
+// accountRecoveryEligibleResponse instead.
 func (app *application) inactiveAccountResponse(w http.ResponseWriter, r *http.Request) {
 	message := "your user account must be activated to access this resource"
 	app.errorResponse(w, r, http.StatusLocked, message)
+}
+
+// accountRecoveryEligibleResponse returns the canonical 202 Accepted envelope
+// used by every unauthenticated account-recovery, activation, and password-
+// reset flow. The wire format is byte-identical regardless of which branch
+// the caller actually took (email-not-found, already-activated, MFA-not-
+// enabled, or the genuine happy path), so the response itself reveals
+// nothing about the requester's account state. Callers MUST log the
+// real branch at WARN with the request_id (and user_id where available)
+// so support and incident-response can still triage legitimate users.
+//
+// Status code is 202 specifically because none of these flows synchronously
+// confirm the email was sent - delivery happens via app.background. 202
+// matches that semantics ("we'll get to it") and avoids the 200-vs-202
+// distinction being itself a tell.
+func (app *application) accountRecoveryEligibleResponse(w http.ResponseWriter, r *http.Request) {
+	env := envelope{"message": "if your account is eligible for this action, an email will be sent with further instructions"}
+	if err := app.writeJSON(w, http.StatusAccepted, env, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
 }
 
 // The badRequestResponse() method will be used to send a 400 Bad Request status code and

--- a/cmd/api/errors_test.go
+++ b/cmd/api/errors_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// TestAccountRecoveryEligibleResponse_WireFormat asserts the canonical
+// shape every unauthenticated account-recovery / activation / password-
+// reset handler must produce. The wire MUST be byte-identical regardless
+// of which branch the caller took (email-not-found, already-activated,
+// MFA-not-enabled, or the genuine happy path); if this test ever needs
+// to change, every leak-prone caller almost certainly does too.
+//
+// The previous shapes were a 422 with v.Errors envelope (email-not-found
+// branches), a 423 Locked (inactive-account branch), and a bespoke
+// "if we found a matching email..." message on the password-reset happy
+// path - three observably-different responses that doubled as account-
+// state oracles for an anonymous probe.
+func TestAccountRecoveryEligibleResponse_WireFormat(t *testing.T) {
+	app := &application{logger: zap.NewNop()}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/api/password-reset", nil)
+	app.accountRecoveryEligibleResponse(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json prefix", got)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("response body is not valid JSON: %v\nbody: %s", err, rec.Body.String())
+	}
+	msg, ok := body["message"].(string)
+	if !ok {
+		t.Fatalf("body missing string field 'message'; got %#v", body)
+	}
+	wantPrefix := "if your account is eligible"
+	if !strings.HasPrefix(msg, wantPrefix) {
+		t.Errorf("message = %q, want prefix %q", msg, wantPrefix)
+	}
+	// Negative checks: previous handler-specific phrasings must NOT survive.
+	for _, leak := range []string{
+		"no matching email address found",
+		"user has already been activated",
+		"user account has not been activated",
+		"user account has not enabled MFA",
+		"if we found a matching email address",
+	} {
+		if strings.Contains(msg, leak) {
+			t.Errorf("message %q contains leaky phrase %q", msg, leak)
+		}
+	}
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -325,6 +325,24 @@ func main() {
 	// concurrency entirely and reproduce pre-P3 serial behavior.
 	flag.IntVar(&cfg.portfolio.workerLimit, "portfolio-worker-limit", 6, "Max concurrent per-asset workers in portfolio analysis (1 = serial; tune to upstream API rate limits)")
 
+	// Refuse to start if a secret-bearing flag was passed on the command
+	// line. The flag definitions above remain so the StringVars still
+	// default-from-env, but operators who type the value into the shell
+	// (instead of exporting the env var) leak it to /proc/<pid>/cmdline,
+	// `ps -ef`, shell history, and any process supervisor that records
+	// argv. We do this BEFORE flag.Parse so the value is never decoded
+	// into a typed config field that might subsequently appear in a log
+	// line or in /debug/vars. Runs before the -version declaration too
+	// because rejectSecretFlags only looks at os.Args literally; it
+	// doesn't depend on any flag being registered yet.
+	if raw, name := rejectSecretFlags(os.Args[1:]); raw != "" {
+		fmt.Fprintf(os.Stderr,
+			"refusing to start: %q is a secret-bearing flag (matched %q); set the corresponding env var instead\n",
+			raw, name,
+		)
+		os.Exit(2)
+	}
+
 	// -version must be declared BEFORE flag.Parse(); declaring it after
 	// (the prior layout) meant `optivest -version` failed at parse time
 	// with "flag provided but not defined" and the conditional below
@@ -332,7 +350,6 @@ func main() {
 	// stdout for the build version saw nothing.
 	displayVersion := flag.Bool("version", false, "Display version and exit")
 
-	// Parse the flags
 	flag.Parse()
 
 	if *displayVersion {
@@ -571,6 +588,53 @@ func openDB(cfg config) (*sql.DB, *database.Queries, error) {
 	return db, queries, nil
 }
 
+// secretFlagPrefixes is the set of CLI flag name prefixes whose values are
+// sensitive credentials. The flag definitions in main() default-from-env for
+// each of these, so an operator who exports the env var still gets the
+// expected behavior. What's banned here is passing the value LITERALLY on
+// the command line, which leaks it to:
+//
+//   - /proc/<pid>/cmdline (world-readable on most Linux distros)
+//   - ps -ef and any tool that reads /proc/<pid>/cmdline
+//   - shell history (.bash_history / .zsh_history)
+//   - any process supervisor that records argv (systemd journal, k8s
+//     describe, docker inspect, supervisord logs)
+//
+// Prefix matching is intentional for "-api-key-" so we cover every API key
+// without having to list each one - new vendor integrations get the
+// protection automatically.
+var secretFlagPrefixes = []string{
+	"encryption-key",
+	"redis-password",
+	"smtp-password",
+	"db-dsn",
+	"api-key-",
+}
+
+// rejectSecretFlags scans args (typically os.Args[1:]) for any token
+// matching a secretFlagPrefixes entry. Returns the raw arg as the user
+// typed it (so error messages echo back exactly what was rejected) and
+// the normalised flag name; both empty if args are clean.
+//
+// Both single-dash (-encryption-key=...) and double-dash forms
+// (--encryption-key=...) are handled by trimming leading dashes before
+// the prefix match. Values are only extracted to find the '=' boundary;
+// they are never returned and never logged.
+func rejectSecretFlags(args []string) (raw, name string) {
+	for _, arg := range args {
+		trimmed := strings.TrimLeft(arg, "-")
+		if eq := strings.IndexByte(trimmed, '='); eq != -1 {
+			trimmed = trimmed[:eq]
+		}
+		for _, prefix := range secretFlagPrefixes {
+			if strings.HasPrefix(trimmed, prefix) {
+				return arg, trimmed
+			}
+		}
+	}
+	return "", ""
+}
+
 // validateConfig returns a list of human-readable errors describing required
 // configuration that is missing. It is intentionally cheap to call: it does not
 // perform any I/O. Callers decide whether missing values are fatal based on the
@@ -633,11 +697,21 @@ func validateConfig(cfg config) []string {
 // openRedis() opens a new Redis connection using the provided configuration.
 // It returns a pointer to the Redis client and an error value.
 func openRedis(cfg config) (*redis.Client, error) {
-	// Initialize the Redis client with the provided config
+	// Initialize the Redis client with the provided config. The Password
+	// field MUST be wired through here: cfg.redis.password is read from
+	// -redis-password / OPTIVEST_REDIS_PASSWORD, validated, and surfaced
+	// in the startup banner as "configured", but if the field below is
+	// commented out the driver sends every command unauthenticated. A
+	// Redis instance with `requirepass` rejects every call with NOAUTH,
+	// and the failure mode looks like a generic transient error in the
+	// caller stack rather than a configuration problem. Empty string
+	// means "no auth", which is the existing zero-value semantics of
+	// redis.Options - so leaving this enabled is safe even when the
+	// operator hasn't set OPTIVEST_REDIS_PASSWORD.
 	rdb := redis.NewClient(&redis.Options{
-		Addr: cfg.redis.addr, // Redis address
-		//Password: cfg.redis.password, // No password set if empty
-		DB: cfg.redis.db, // Use default DB if not set
+		Addr:     cfg.redis.addr,
+		Password: cfg.redis.password,
+		DB:       cfg.redis.db,
 	})
 
 	// Ping the Redis server with a short bounded deadline so a misconfigured

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -1,0 +1,71 @@
+package main
+
+import "testing"
+
+// TestRejectSecretFlags_Cases enumerates every shape of secret-bearing flag
+// the audit told us to refuse at startup. The function MUST return a
+// non-empty raw value for each, because the caller treats any non-empty
+// return as a fatal startup error. False positives (the second half of the
+// table, where the helper must NOT match) are equally important: a flag
+// like -api-url-alphavantage shares a prefix with -api-key-alphavantage
+// and would block legitimate launches if matched here.
+func TestRejectSecretFlags_Cases(t *testing.T) {
+	cases := []struct {
+		name      string
+		args      []string
+		wantRaw   string
+		wantMatch string
+	}{
+		// Single-dash forms.
+		{"single-dash, value-after-equals, encryption-key", []string{"-encryption-key=deadbeef"}, "-encryption-key=deadbeef", "encryption-key"},
+		{"single-dash, value-as-next-arg, encryption-key", []string{"-encryption-key", "deadbeef"}, "-encryption-key", "encryption-key"},
+		{"single-dash, redis-password", []string{"-redis-password=hunter2"}, "-redis-password=hunter2", "redis-password"},
+		{"single-dash, smtp-password", []string{"-smtp-password=swordfish"}, "-smtp-password=swordfish", "smtp-password"},
+		{"single-dash, db-dsn embeds creds", []string{"-db-dsn=postgres://u:p@h/d"}, "-db-dsn=postgres://u:p@h/d", "db-dsn"},
+		{"single-dash, api-key-alphavantage", []string{"-api-key-alphavantage=abc"}, "-api-key-alphavantage=abc", "api-key-alphavantage"},
+		{"single-dash, api-key-sambanova", []string{"-api-key-sambanova=xyz"}, "-api-key-sambanova=xyz", "api-key-sambanova"},
+
+		// Double-dash forms (Go flag accepts both).
+		{"double-dash, encryption-key", []string{"--encryption-key=deadbeef"}, "--encryption-key=deadbeef", "encryption-key"},
+		{"double-dash, api-key-fred", []string{"--api-key-fred=val"}, "--api-key-fred=val", "api-key-fred"},
+
+		// Mixed positional - the secret arg can be anywhere.
+		{"secret in second position", []string{"-port=4000", "-encryption-key=x"}, "-encryption-key=x", "encryption-key"},
+
+		// False positives the helper MUST NOT trigger on. -api-url-* shares
+		// a prefix root with -api-key-* but is harmless metadata.
+		{"clean: api-url is not api-key", []string{"-api-url-alphavantage=https://example.com"}, "", ""},
+		{"clean: redis-addr is not redis-password", []string{"-redis-addr=localhost:6379"}, "", ""},
+		{"clean: smtp-host is not smtp-password", []string{"-smtp-host=mail.example"}, "", ""},
+		{"clean: empty args", []string{}, "", ""},
+		{"clean: only safe flags", []string{"-port=4000", "-env=production"}, "", ""},
+		{"clean: -version flag", []string{"-version"}, "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotRaw, gotMatch := rejectSecretFlags(tc.args)
+			if gotRaw != tc.wantRaw {
+				t.Errorf("raw = %q, want %q", gotRaw, tc.wantRaw)
+			}
+			if gotMatch != tc.wantMatch {
+				t.Errorf("match = %q, want %q", gotMatch, tc.wantMatch)
+			}
+		})
+	}
+}
+
+// TestRejectSecretFlags_StopsAtFirstHit documents that the helper returns
+// the FIRST matching arg, not the last. Order matters because the caller's
+// error message echoes the matched arg back to the operator; if a launch
+// includes two secret flags, naming the first one points the operator at
+// the start of the offending command line.
+func TestRejectSecretFlags_StopsAtFirstHit(t *testing.T) {
+	args := []string{"-port=4000", "-encryption-key=first", "-redis-password=second"}
+	raw, match := rejectSecretFlags(args)
+	if raw != "-encryption-key=first" {
+		t.Errorf("raw = %q, want -encryption-key=first (first hit)", raw)
+	}
+	if match != "encryption-key" {
+		t.Errorf("match = %q, want encryption-key", match)
+	}
+}

--- a/cmd/api/metrics.go
+++ b/cmd/api/metrics.go
@@ -274,6 +274,62 @@ func getOrCreateBucket(buckets map[string]*metricBucket, name string, kind metri
 	return b
 }
 
+// ---------------------------------------------------------------------------
+// /debug/vars curated handler.
+//
+// The default expvar.Handler walks every published var and emits "cmdline"
+// (a JSON array of os.Args) by default. The rejectSecretFlags startup gate
+// (see main.go) makes it impossible to BOOT the binary with a credential-
+// bearing flag, so the practical leak is small today. But:
+//
+//   - cmdline still echoes deployment topology (paths to envvar files,
+//     non-default flag values like -portfolio-worker-limit=12) that an
+//     unauthenticated /debug/vars caller has no need to see.
+//   - The startup gate is a recent control. Any operator who downgrades
+//     past the gate, or runs a forked build, would re-expose the flags
+//     without realizing it. Belt-and-braces here keeps the leak shut on
+//     both ends.
+//
+// memstats, goroutines, version, and the curated counters defined in
+// publishMetrics + logging.go pass through unchanged. If a future expvar
+// publishes a value whose marshaled form might itself include secrets,
+// this is the choke point to filter it.
+// ---------------------------------------------------------------------------
+
+// debugVarsBlocklist is the set of expvar names this handler refuses to
+// emit on /debug/vars. The behavior mirrors the inverse of metrics.go's
+// allowlist for /metrics: there we only emit what we explicitly know is
+// safe; here we emit everything except what we explicitly know leaks.
+var debugVarsBlocklist = map[string]struct{}{
+	"cmdline": {},
+}
+
+// debugVarsHandler is the curated /debug/vars handler. It produces JSON
+// matching the default expvar.Handler shape (an unsorted top-level
+// object) minus any keys in debugVarsBlocklist. The format is
+// intentionally identical so existing tooling (operator scripts that
+// curl /debug/vars and grep, ad-hoc dashboards) continues to work.
+func (app *application) debugVarsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	if _, err := io.WriteString(w, "{\n"); err != nil {
+		return
+	}
+	first := true
+	expvar.Do(func(kv expvar.KeyValue) {
+		if _, blocked := debugVarsBlocklist[kv.Key]; blocked {
+			return
+		}
+		if !first {
+			if _, err := io.WriteString(w, ",\n"); err != nil {
+				return
+			}
+		}
+		first = false
+		fmt.Fprintf(w, "%q: %s", kv.Key, kv.Value)
+	})
+	_, _ = io.WriteString(w, "\n}\n")
+}
+
 // scalarString renders an expvar.Var to its text exposition value. Int and
 // Float marshal directly; expvar.Func is invoked and its result coerced.
 // Anything else returns ok=false, which the caller treats as "skip this

--- a/cmd/api/metrics_test.go
+++ b/cmd/api/metrics_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"expvar"
 	"fmt"
 	"net/http"
@@ -394,3 +395,46 @@ func validPromName(s string) bool {
 
 // _ ensures fmt is referenced even if we trim debug formatting later.
 var _ = fmt.Sprintf
+
+// TestDebugVarsHandler_StripsCmdline locks down the curated /debug/vars
+// behavior: cmdline (which expvar publishes by default and which echoes
+// os.Args verbatim) MUST not appear in the output, while every other
+// expvar must pass through unchanged. The startup gate
+// (rejectSecretFlags) makes it impossible to BOOT the binary with a
+// credential-bearing flag, so the practical leak surface is small;
+// belt-and-braces here covers the case of a downgrade past the gate or
+// a fork that disables it.
+func TestDebugVarsHandler_StripsCmdline(t *testing.T) {
+	app := &application{logger: zap.NewNop()}
+
+	// Ensure the marker var exists on this run. publishMetrics() may not
+	// have executed in the test binary, so use the get-or-create helper.
+	probe := getOrPublishString(t, "test_debugvars_probe")
+	probe.Set("present")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/debug/vars", nil)
+	app.debugVarsHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); !strings.HasPrefix(got, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json prefix", got)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, `"cmdline":`) {
+		t.Errorf("/debug/vars body still contains cmdline:\n%s", body)
+	}
+	if !strings.Contains(body, `"test_debugvars_probe":`) {
+		t.Errorf("/debug/vars body missing the probe var; body = %s", body)
+	}
+	// The body must be a single valid JSON object.
+	var parsed map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &parsed); err != nil {
+		t.Fatalf("body is not valid JSON: %v\nbody: %s", err, body)
+	}
+	if _, ok := parsed["cmdline"]; ok {
+		t.Errorf("parsed body still has cmdline key: %#v", parsed["cmdline"])
+	}
+}

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"expvar"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -88,7 +87,10 @@ func (app *application) routes() http.Handler {
 	router.Get("/healthcheck", app.healthcheckHandler)
 	router.Get("/readyz", app.readyzHandler)
 	router.Get("/metrics", app.prometheusMetricsHandler)
-	router.Handle("/debug/vars", expvar.Handler())
+	// debugVarsHandler is the curated replacement for expvar.Handler():
+	// same JSON shape, but "cmdline" (and any future blocklisted key) is
+	// omitted. See cmd/api/metrics.go for the rationale.
+	router.Get("/debug/vars", app.debugVarsHandler)
 
 	// Make our categorized routes. globalMiddleware is attached to v1Router,
 	// not the base router, so /v1/* keeps its full chain (metrics, requestID,


### PR DESCRIPTION
## Summary

Closes six audit findings around credential lifecycle and unauthenticated-endpoint enumeration. Each is a "we already know this is wrong, just fix it" item rather than an architectural change, so they ship together as a coherent batch.

The audit's 1-month item (per-account brute-force lockout) is intentionally **not** in this PR; it requires new Redis state and an expvar surface and lands as a separate PR 61.5.

## What's in scope

| # | Audit ref | What changes |
|---|---|---|
| 1 | Pass 1 #2 / Pass 6 #11 | Uncomment the \`Password:\` line in \`openRedis\`. Audit's words: "highest priority security/lifecycle bug, must ship in 1-week window." |
| 2 | Pass 6 #10 | Reject secret-bearing flags on the command line at startup (\`-encryption-key\`, \`-redis-password\`, \`-smtp-password\`, \`-db-dsn\`, \`-api-key-*\`). |
| 3 | Pass 3 #3 / Pass 6 #9 | Login: stop returning 423 Locked for inactive accounts (collapse to 401 invalid-credentials). |
| 4 | Pass 3 #4 | Activation / recovery / password-reset flows: every branch returns the same 202 generic envelope. |
| 5 | Pass 3 #17 / Pass 6 #6 | \`/debug/vars\`: strip \`cmdline\` from the published expvars. |
| 6 | Pass 6 #14 | Narrow gitleaks allowlist from "all workflows" to \`ci.yml\` only, plus specific regex patterns for the two e2e-job interpolation tells. |

Plus a SECURITY.md update documenting the new no-secrets-on-CLI gate and the cmdline strip.

## Why this batching

The six items share a theme - *don't leak what we already know we leak* - and don't touch each other's code paths much, so they land as one review-friendly PR rather than six tiny ones. Each is independently revertible if review surfaces an issue.

The brute-force lockout work the audit flagged as a 1-month item needs:
- a Redis schema for the per-(account, IP) failed-login counter
- a state machine for the cool-down (linear vs exponential)
- two new expvars (\`auth_login_failures_total\`, \`auth_login_lockouts_total\`) and an alerting hookup
- tests that cover both the sliding-window and the reset-on-success paths

Real chunk of work; deserves its own PR. Tracking as PR 61.5.

## Out of scope (intentional follow-ups)

The password-reset MFA branch still returns 401 when the TOTP is missing/wrong, which technically reveals MFA-enabled status to anonymous probes. Fixing that requires API+frontend coordination (the frontend needs to know whether to prompt for a TOTP) so it ships separately, not silently bundled into the generic-envelope work.

## Behavior change the frontend should know about

The Svelte client at \`/home/bluedavinci/Projects/Svelte/OptiVest Frontend/\` consumes \`POST /v1/users/login\`. With this PR:

- An inactive account no longer receives \`423 Locked\` with "your account must be activated". It receives \`401 invalid authentication credentials\`. Any UI branching on the 423 to show "please activate" guidance must move to the email-confirmation flow or rely on the \`loggerFromRequest\` server logs for support correlation.

Activation / recovery / password-reset response shapes also change: every flow now returns \`202 Accepted\` with \`{"message": "if your account is eligible for this action, an email will be sent with further instructions"}\`. The frontend likely already handles 202 generically here; any UI displaying the previous bespoke phrasings ("we have sent password reset instructions", "an email will be sent containing activation instructions") will render the new generic text instead. Worth a quick visual check before merge.

## Tests

Three new test functions, twelve+ table cases:

- \`TestRejectSecretFlags_Cases\` - every shape of secret flag (single/double dash, equals/space-separated value, prefix matching for \`-api-key-*\`) and pinned false-positives (\`-api-url-*\`, \`-redis-addr\`, \`-smtp-host\` MUST NOT match).
- \`TestRejectSecretFlags_StopsAtFirstHit\` - documents that the helper returns the first matching arg so error messages echo what the operator typed.
- \`TestAccountRecoveryEligibleResponse_WireFormat\` - asserts the 202 + canonical message and negative-checks every previously-leaky phrase that must NOT survive.
- \`TestDebugVarsHandler_StripsCmdline\` - asserts cmdline absent, probe var still present, body parses as JSON.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./... -count=1 -race -timeout=120s\` clean (cmd/api 16s)
- [x] \`golangci-lint run --timeout=5m ./...\` 0 issues (locally on Go 1.26 + golangci-lint v2.12.2 to match CI)
- [ ] CI lint / test / vuln / e2e all green
- [ ] CI gitleaks job passes the narrowed allowlist (no real-credential content; the two e2e openssl-generated patterns are explicitly regex-allowlisted)

## Manual smoke tests once merged

- \`POST /v1/api/authentication\` with email of inactive user + correct password -> 401 (was 423)
- \`POST /v1/api/users/activated\` for unknown email -> 202 generic envelope (was 422 with "no matching email...")
- \`POST /v1/api/users/activated\` for already-activated user -> 202 generic envelope (was 422 with "user has already been activated")
- \`POST /v1/api/users/passwordreset\` for unknown email -> 202 generic envelope
- \`POST /v1/api/users/recovery\` for inactive / non-MFA account -> 202 generic envelope
- \`GET /debug/vars\` - body MUST NOT contain \`"cmdline"\`
- \`./api -encryption-key=hex\` -> exit 2 with "refusing to start: ... is a secret-bearing flag ..."