### PR TITLE
chore(gitignore): ignore .notes/ for local-only working notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 # project layout is the source of truth, not whatever happens to be cached
 # on a developer's machine.
 .tmp/
+
+# Local-only working notes, trackers, and orientation scratch
+.notes/


### PR DESCRIPTION
## Summary

Adds a `.notes/` rule to `.gitignore` so contributors can keep local working notes, orientation scratch, and cross-repo trackers (e.g. frontend-contract-debt trackers tied to ongoing backend audits) under the repo without risking an accidental commit. The rule is **ignore-only** - `.notes/` is not expected to ever ship in git history. If a note matures into something the team should see, move it into `docs/` or a tracked markdown file.

## Why now

The next batch of backend PRs (auth contract changes, HTTP middleware tightening, dead-code sweep) will produce wire-level changes that downstream clients (frontend / mobile) have to absorb. Tracking that debt in a local file under `.notes/frontend-contract-debt.md` keeps the inventory close to the code that produced it without publishing "the frontend hasn't caught up yet" as a long-lived artifact in the public history.

## Test plan

- [x] `git check-ignore -v .notes/<file>` resolves against the new rule
- [x] No tracked files in the repo currently match `.notes/` (verified clean `git status`)
- [x] CI on this PR is purely `.gitignore` change - should be a no-op for every gate