### PR TITLE
chore(makefile): host-side dev targets for the local valkey service

### DIFF
--- a/makefile
+++ b/makefile
@@ -18,6 +18,9 @@ help:
 	@echo "  docker/migrate      - Re-run the goose up migrations against the running postgres"
 	@echo "  docker/build        - Build the api image without starting anything"
 	@echo "  docker/ps           - Show the running compose services"
+	@echo "  dev/up              - Start the host valkey service for local API runs"
+	@echo "  dev/down            - Stop the host valkey service"
+	@echo "  dev/status          - Show whether the host valkey service is running"
 
 .PHONY: run/api
 run/api:
@@ -141,3 +144,38 @@ docker/build:
 .PHONY: docker/ps
 docker/ps:
 	docker compose ps
+
+# -----------------------------------------------------------------------------
+# Host-side dev dependencies (valkey/redis on the loopback interface).
+# -----------------------------------------------------------------------------
+# These targets manage the systemd service for the locally-installed
+# valkey package so the binary in `make run/api` has a Redis-compatible
+# server to talk to without needing the full docker-compose stack up.
+#
+# The service is intentionally NOT enabled at boot — `make dev/up` starts
+# it for the current session and `make dev/down` stops it again. This
+# keeps idle hosts free of a listening Redis when you're not developing.
+#
+# If your distro packages valkey under a different unit name (e.g.
+# `redis.service` on the legacy AUR build), override DEV_REDIS_UNIT:
+#   make dev/up DEV_REDIS_UNIT=redis
+DEV_REDIS_UNIT ?= valkey
+
+## dev/up: start the host valkey service for local API runs
+.PHONY: dev/up
+dev/up:
+	@echo 'Starting $(DEV_REDIS_UNIT)...'
+	sudo systemctl start $(DEV_REDIS_UNIT)
+	@systemctl is-active --quiet $(DEV_REDIS_UNIT) && \
+		echo "$(DEV_REDIS_UNIT) running on 127.0.0.1:6379"
+
+## dev/down: stop the host valkey service
+.PHONY: dev/down
+dev/down:
+	@echo 'Stopping $(DEV_REDIS_UNIT)...'
+	sudo systemctl stop $(DEV_REDIS_UNIT)
+
+## dev/status: show whether the host valkey service is running
+.PHONY: dev/status
+dev/status:
+	@systemctl status $(DEV_REDIS_UNIT) --no-pager || true


### PR DESCRIPTION
## Summary

Adds three makefile targets that wrap the host-installed `valkey` systemd unit so the local-binary development loop (`make run/api`) doesn't require spinning up the full compose stack just to give the rate limiter and session cache somewhere to talk to:

- `make dev/up`     — `sudo systemctl start <unit>`, then verifies the service came up on `127.0.0.1:6379`
- `make dev/down`   — `sudo systemctl stop <unit>`
- `make dev/status` — `systemctl status <unit> --no-pager`, never errors out

The unit name is parameterized via `DEV_REDIS_UNIT` (default: `valkey`) so contributors on distros that still ship the unit as `redis.service` can override without editing the makefile:

```bash
make dev/up DEV_REDIS_UNIT=redis
```

The service is intentionally **not** enabled at boot here — `dev/up` starts it for the current session only. This keeps idle hosts free of a listening Redis when no one is actively developing, which matters for laptops on untrusted networks.

`make help` output now lists all three so they're discoverable.

## Why now

The next batch of audit work (PR 62 onward — HTTP/middleware tightening, observability, etc.) involves a lot of `make run/api` cycles where the full compose stack is overkill. Having these targets makes each cycle ~10 seconds instead of ~30. Compose-based development (`make docker/up`) is **unaffected** — this is strictly additive.

## Test plan

- [x] `make help` lists `dev/up`, `dev/down`, `dev/status`
- [x] `make dev/up` (locally) brings up the service and reports the listening address
- [x] `make dev/down` cleanly stops it
- [x] `make dev/status` works whether the service is up or down (the trailing `|| true` keeps it from failing CI-style)
- [x] `DEV_REDIS_UNIT=redis make dev/status` overrides the unit name as documented