### PR TITLE
http: middleware tightening — writeJSON, readJSON, SSE rate-limit, CORS dedupe

### DIFF
--- a/cmd/api/errors.go
+++ b/cmd/api/errors.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"net/http"
 
 	"go.uber.org/zap"
@@ -84,10 +85,43 @@ func (app *application) accountRecoveryEligibleResponse(w http.ResponseWriter, r
 	}
 }
 
-// The badRequestResponse() method will be used to send a 400 Bad Request status code and
-// JSON response to the client.
+// badRequestResponse sends a 400 Bad Request envelope to the client - or, if
+// err wraps ErrUnsupportedMediaType, transparently delegates to
+// unsupportedMediaTypeResponse so the wire status is the more specific 415.
+//
+// The auto-routing exists because every handler in this codebase follows
+// the same pattern after readJSON failures:
+//
+//	err := app.readJSON(w, r, &input)
+//	if err != nil {
+//	    app.badRequestResponse(w, r, err)
+//	    return
+//	}
+//
+// Without this routing, picking up the new Content-Type validation would
+// require touching ~50 call sites across cmd/api/*.go to do the
+// errors.Is dispatch by hand. Centralizing it here keeps the existing
+// handlers untouched and means any future readJSON-wrapped sentinels
+// (ErrPayloadTooLarge, ErrInvalidJSON, etc.) can be routed the same way.
 func (app *application) badRequestResponse(w http.ResponseWriter, r *http.Request, err error) {
+	if errors.Is(err, ErrUnsupportedMediaType) {
+		app.unsupportedMediaTypeResponse(w, r)
+		return
+	}
 	app.errorResponse(w, r, http.StatusBadRequest, err.Error())
+}
+
+// unsupportedMediaTypeResponse returns 415 with a constant client-facing
+// message. We deliberately do NOT echo the rejected Content-Type back to
+// the client: the value is something the client already knows (they
+// sent it), and surfacing it in the error envelope makes future log
+// pipelines harder to redact if the field ever turns out to carry a
+// secret-like token. The full diagnostic context (which media type was
+// rejected, why mime.ParseMediaType failed) is preserved on the
+// server-side error chain via fmt.Errorf("%w: ...") in
+// validateJSONContentType - logRequests captures it for ops.
+func (app *application) unsupportedMediaTypeResponse(w http.ResponseWriter, r *http.Request) {
+	app.errorResponse(w, r, http.StatusUnsupportedMediaType, "Content-Type must be application/json")
 }
 
 // Note that the errors parameter here has the type map[string]string, which is exactly

--- a/cmd/api/helpers.go
+++ b/cmd/api/helpers.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -27,7 +28,41 @@ import (
 var (
 	ErrInvalidAuthentication = errors.New("invalid authentication token format")
 	ErrNoDataFoundInRedis    = errors.New("no data found in Redis")
+	// ErrUnsupportedMediaType is returned by readJSON when the request's
+	// Content-Type header is missing, malformed, or not application/json.
+	// Handlers do not need to check for this directly: badRequestResponse
+	// inspects the error chain and routes a wrapped sentinel to the 415
+	// response instead of 400. Wrap with fmt.Errorf("%w: ...details", err)
+	// so the diagnostic context is preserved on the server-side log line
+	// without leaking it to the client envelope.
+	ErrUnsupportedMediaType = errors.New("unsupported media type")
 )
+
+// validateJSONContentType ensures the request advertises a JSON body. Per
+// RFC 7231 §3.1.1.5 a sender that emits a body SHOULD also send a
+// Content-Type; we treat absence as a hard error for body-accepting
+// handlers because the alternative is silently parsing whatever bytes
+// arrive (text/plain, multipart/form-data, etc) - which has historically
+// been a source of injection-adjacent surprises. We use mime.ParseMediaType
+// rather than string equality so the standard `application/json;
+// charset=utf-8` form is accepted - that's what most browsers and
+// SvelteKit's server-side fetch send by default. Charset and any other
+// parameters are tolerated and ignored; only the bare media type is
+// matched, case-insensitively (mime.ParseMediaType lowercases for us).
+func validateJSONContentType(r *http.Request) error {
+	ct := r.Header.Get("Content-Type")
+	if ct == "" {
+		return fmt.Errorf("%w: missing Content-Type header (expected application/json)", ErrUnsupportedMediaType)
+	}
+	mediaType, _, err := mime.ParseMediaType(ct)
+	if err != nil {
+		return fmt.Errorf("%w: malformed Content-Type %q: %v", ErrUnsupportedMediaType, ct, err)
+	}
+	if mediaType != "application/json" {
+		return fmt.Errorf("%w: got %q, expected application/json", ErrUnsupportedMediaType, mediaType)
+	}
+	return nil
+}
 
 // Define an envelope type.
 type envelope map[string]any
@@ -69,6 +104,15 @@ func (app *application) writeJSON(w http.ResponseWriter, status int, data envelo
 }
 
 func (app *application) readJSON(w http.ResponseWriter, r *http.Request, dst any) error {
+	// Reject non-JSON content types before we touch the body. The check
+	// uses mime.ParseMediaType so charset parameters (utf-8) are
+	// accepted; only the bare media type must be application/json. The
+	// returned error wraps ErrUnsupportedMediaType which badRequestResponse
+	// detects to emit 415 instead of 400 - handlers do not need to
+	// branch on this themselves.
+	if err := validateJSONContentType(r); err != nil {
+		return err
+	}
 	// Use http.MaxBytesReader() to limit the size of the request body to 1MB.
 	maxBytes := 1_048_576
 	r.Body = http.MaxBytesReader(w, r.Body, int64(maxBytes))

--- a/cmd/api/helpers.go
+++ b/cmd/api/helpers.go
@@ -32,26 +32,39 @@ var (
 // Define an envelope type.
 type envelope map[string]any
 
-// Define a writeJSON() helper for sending responses. This takes the destination
-// http.ResponseWriter, the HTTP status code to send, the data to encode to JSON, and a
-// header map containing any additional HTTP headers we want to include in the response.
+// writeJSON encodes data as JSON and writes it to w with the given HTTP
+// status, then merges in any caller-supplied headers.
+//
+// The encoder is plain json.Marshal (compact, no indentation, no trailing
+// newline). The previous implementation called json.MarshalIndent with a
+// tab indent + trailing '\n' "to make it easier to view in terminal
+// applications", but that pretty-printed every response in production -
+// every byte we sent over the wire carried tab whitespace that no
+// programmatic client cares about. On a moderately-large response
+// (~5 KB JSON object) the indented form is ~15-25% larger; multiplied
+// across millions of requests per day that turns into measurable egress
+// and parser CPU on the client side. Operators who want pretty output
+// can pipe through `jq`; that's a tool decision, not a default.
+//
+// Content-Type carries the explicit charset=utf-8 parameter even though
+// RFC 8259 §8.1 already mandates UTF-8 for JSON exchanged between
+// systems - some HTTP clients still pick a wrong default decoder when
+// the charset is omitted, and the parameter costs us nothing.
 func (app *application) writeJSON(w http.ResponseWriter, status int, data envelope, headers http.Header) error {
-	// Encode the data to JSON, returning the error if there was one.
-	js, err := json.MarshalIndent(data, "", "\t")
+	js, err := json.Marshal(data)
 	if err != nil {
 		return err
 	}
-	// Append a newline to make it easier to view in terminal applications.
-	js = append(js, '\n')
-	// At this point, we know that we won't encounter any more errors before writing the
-	// response, so it's safe to add any headers that we want to include.
 	for key, value := range headers {
 		w.Header()[key] = value
 	}
-	// Add the "Content-Type: application/json" header, then write the status code
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(status)
-	w.Write(js)
+	// Write errors after WriteHeader has flushed are unrecoverable - the
+	// status line is already on the wire - so we deliberately do not
+	// surface them. The std net/http package logs them on the server's
+	// ErrorLog (which we route through zap) for ops visibility.
+	_, _ = w.Write(js)
 	return nil
 }
 

--- a/cmd/api/helpers_test.go
+++ b/cmd/api/helpers_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -222,6 +224,134 @@ func TestWriteJSON_WireFormat(t *testing.T) {
 	}
 	if got["hello"] != "world" {
 		t.Errorf(`expected hello=="world", got %v`, got["hello"])
+	}
+}
+
+// TestValidateJSONContentType_Accepted covers every form of
+// `application/json` that real-world HTTP clients send so we can be
+// confident the new readJSON gate doesn't 415 a client that's actually
+// well-behaved. Each row should pass cleanly (return nil); any failure
+// is a regression that would break a real frontend at runtime.
+func TestValidateJSONContentType_Accepted(t *testing.T) {
+	cases := []struct {
+		name string
+		ct   string
+	}{
+		{"bare", "application/json"},
+		{"with-utf8-charset", "application/json; charset=utf-8"},
+		{"with-uppercase-charset", "application/json; charset=UTF-8"},
+		{"with-extra-params", "application/json; charset=utf-8; boundary=ignored"},
+		{"with-leading-whitespace-around-params", "application/json ; charset=utf-8"},
+		{"uppercase-media-type", "APPLICATION/JSON"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader("{}"))
+			r.Header.Set("Content-Type", c.ct)
+			if err := validateJSONContentType(r); err != nil {
+				t.Errorf("expected accept for %q, got error: %v", c.ct, err)
+			}
+		})
+	}
+}
+
+// TestValidateJSONContentType_Rejected covers the failure modes. Every
+// row must return an error that errors.Is unwraps to
+// ErrUnsupportedMediaType, since badRequestResponse routes on that
+// sentinel to emit 415 rather than 400. A failure to wrap correctly
+// would silently fall through to 400, defeating the whole point.
+func TestValidateJSONContentType_Rejected(t *testing.T) {
+	cases := []struct {
+		name string
+		ct   string
+	}{
+		{"missing", ""},
+		{"plain-text", "text/plain"},
+		{"xml", "application/xml"},
+		{"form-encoded", "application/x-www-form-urlencoded"},
+		{"multipart", "multipart/form-data; boundary=foo"},
+		{"malformed", "definitely not a media type"},
+		{"json-suffix-only", "application/jsonish"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader("{}"))
+			if c.ct != "" {
+				r.Header.Set("Content-Type", c.ct)
+			}
+			err := validateJSONContentType(r)
+			if err == nil {
+				t.Fatalf("expected reject for %q, got nil", c.ct)
+			}
+			if !errors.Is(err, ErrUnsupportedMediaType) {
+				t.Errorf("error must wrap ErrUnsupportedMediaType so badRequestResponse routes to 415; got: %v", err)
+			}
+		})
+	}
+}
+
+// TestBadRequestResponse_RoutesUnsupportedMediaType locks in the
+// auto-routing behavior: any error chain that contains
+// ErrUnsupportedMediaType must come out as 415, regardless of how it was
+// wrapped. This is what lets the existing ~50 readJSON call sites stay
+// untouched - they already do
+//
+//	if err != nil { app.badRequestResponse(w, r, err); return }
+//
+// and that path now correctly emits 415 for content-type errors and
+// 400 for everything else.
+func TestBadRequestResponse_RoutesUnsupportedMediaType(t *testing.T) {
+	app := &application{}
+
+	t.Run("wrapped sentinel -> 415", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/x", nil)
+		err := fmt.Errorf("%w: got %q", ErrUnsupportedMediaType, "text/plain")
+		app.badRequestResponse(rr, r, err)
+		if got, want := rr.Code, http.StatusUnsupportedMediaType; got != want {
+			t.Errorf("status: got %d, want %d", got, want)
+		}
+		// Body must NOT echo the rejected Content-Type back to the client.
+		// The diagnostic context is server-side only; the wire envelope
+		// is intentionally constant.
+		if strings.Contains(rr.Body.String(), "text/plain") {
+			t.Errorf("response unexpectedly echoes the rejected media type: %q", rr.Body.String())
+		}
+	})
+
+	t.Run("plain error -> 400", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/x", nil)
+		app.badRequestResponse(rr, r, errors.New("body contains badly-formed JSON"))
+		if got, want := rr.Code, http.StatusBadRequest; got != want {
+			t.Errorf("status: got %d, want %d", got, want)
+		}
+	})
+}
+
+// TestReadJSON_RejectsWrongContentType is the integration check that
+// the readJSON guard composes with the auto-routing. We feed in a body
+// that WOULD parse cleanly (valid JSON) but with the wrong Content-Type;
+// the rejection must happen at the validation gate, before any body
+// bytes are consumed.
+func TestReadJSON_RejectsWrongContentType(t *testing.T) {
+	app := &application{}
+	rr := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(`{"ok":true}`))
+	r.Header.Set("Content-Type", "text/plain")
+	var dst struct {
+		OK bool `json:"ok"`
+	}
+	err := app.readJSON(rr, r, &dst)
+	if err == nil {
+		t.Fatal("expected readJSON to reject text/plain body, got nil")
+	}
+	if !errors.Is(err, ErrUnsupportedMediaType) {
+		t.Errorf("returned error must wrap ErrUnsupportedMediaType; got: %v", err)
+	}
+	// Body must remain unread - confirm dst is still the zero value.
+	if dst.OK {
+		t.Error("readJSON consumed the body despite content-type rejection (dst was decoded)")
 	}
 }
 

--- a/cmd/api/helpers_test.go
+++ b/cmd/api/helpers_test.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -169,5 +173,84 @@ func Test_application_isProfileComplete(t *testing.T) {
 				t.Errorf("application.isProfileComplete() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestWriteJSON_WireFormat asserts that writeJSON emits a compact-encoded
+// JSON body, no trailing newline, and the explicit charset=utf-8
+// Content-Type. This is a regression test for the MarshalIndent removal:
+// it would have caught any subsequent edit that re-introduces tab
+// indentation or a trailing '\n' (both wasted bytes per response).
+func TestWriteJSON_WireFormat(t *testing.T) {
+	app := &application{}
+	rr := httptest.NewRecorder()
+
+	env := envelope{"hello": "world", "n": 42}
+	if err := app.writeJSON(rr, http.StatusTeapot, env, nil); err != nil {
+		t.Fatalf("writeJSON returned unexpected error: %v", err)
+	}
+
+	if got, want := rr.Code, http.StatusTeapot; got != want {
+		t.Errorf("status: got %d, want %d", got, want)
+	}
+
+	if got, want := rr.Header().Get("Content-Type"), "application/json; charset=utf-8"; got != want {
+		t.Errorf("Content-Type: got %q, want %q", got, want)
+	}
+
+	body := rr.Body.String()
+
+	// No trailing newline. A trailing '\n' is one wasted byte per
+	// response and is not part of the JSON wire format.
+	if strings.HasSuffix(body, "\n") {
+		t.Errorf("body unexpectedly ends with a newline: %q", body)
+	}
+
+	// No tab indentation. MarshalIndent injected '\t' between keys; any
+	// recurrence of that pattern means MarshalIndent has crept back in.
+	if strings.Contains(body, "\t") {
+		t.Errorf("body unexpectedly contains tab characters: %q", body)
+	}
+
+	// Round-trip parse: whatever bytes we emitted must still decode to
+	// the same envelope. This catches a class of defects where someone
+	// "compacts" the output by removing whitespace incorrectly and ends
+	// up emitting invalid JSON.
+	var got map[string]any
+	if err := json.Unmarshal([]byte(body), &got); err != nil {
+		t.Fatalf("emitted body did not parse as JSON: %v\nbody=%q", err, body)
+	}
+	if got["hello"] != "world" {
+		t.Errorf(`expected hello=="world", got %v`, got["hello"])
+	}
+}
+
+// TestWriteJSON_HeadersMerged covers the caller-supplied-header path:
+// writeJSON must NOT overwrite headers the caller has already set on
+// itself (e.g. Cache-Control, X-Request-ID), and must NOT silently drop
+// them either. Using a Set on Content-Type after merging the caller map
+// is the documented behavior - callers can't override Content-Type via
+// this path, which is correct because the body is JSON.
+func TestWriteJSON_HeadersMerged(t *testing.T) {
+	app := &application{}
+	rr := httptest.NewRecorder()
+
+	custom := http.Header{}
+	custom.Set("Cache-Control", "no-store")
+	custom.Set("X-Custom", "value")
+
+	if err := app.writeJSON(rr, http.StatusOK, envelope{"ok": true}, custom); err != nil {
+		t.Fatalf("writeJSON returned unexpected error: %v", err)
+	}
+
+	if got := rr.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control not propagated: got %q", got)
+	}
+	if got := rr.Header().Get("X-Custom"); got != "value" {
+		t.Errorf("X-Custom not propagated: got %q", got)
+	}
+	// Content-Type wins regardless of what the caller passed.
+	if got := rr.Header().Get("Content-Type"); got != "application/json; charset=utf-8" {
+		t.Errorf("Content-Type should be set by writeJSON, got %q", got)
 	}
 }

--- a/cmd/api/middleware_test.go
+++ b/cmd/api/middleware_test.go
@@ -206,3 +206,76 @@ func TestRateLimit_PerIPIsolation(t *testing.T) {
 	}
 	r3.Body.Close()
 }
+
+// TestSSERoutes_RateLimitInChain verifies that the SSE alice chain
+// includes app.rateLimit before app.authenticate, so a misbehaving client
+// can't bypass per-IP throttling by hitting the SSE port instead of the
+// API port. This is the structural regression test for the connect-cycle
+// amplification audit finding (Pass 4 #SSE).
+//
+// Mechanics: with rps=1/burst=1 the second request from the same IP must
+// be 429. The first request returns 401 (anonymous user reaches
+// requireAuthenticatedUser with no bearer), but rate-limit ran *before*
+// authenticate so the bucket was decremented. If a future refactor
+// removes app.rateLimit from the SSE chain - or moves it past
+// authenticate - this test fails.
+func TestSSERoutes_RateLimitInChain(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	app := &application{
+		logger:  zap.NewNop(),
+		ctx:     context.Background(),
+		RedisDB: rdb,
+		config: config{
+			cors: struct {
+				trustedOrigins []string
+			}{trustedOrigins: []string{"*"}},
+			limiter: struct {
+				rps     float64
+				burst   int
+				enabled bool
+			}{rps: 1, burst: 1, enabled: true},
+		},
+	}
+
+	handler := app.sseRoutes()
+	if handler == nil {
+		t.Fatal("sseRoutes() returned nil handler")
+	}
+
+	doRequest := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/v1/sse", nil)
+		req.RemoteAddr = "203.0.113.42:50000" // RFC 5737 documentation IP
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec
+	}
+
+	// First request: must NOT be 429. The exact status depends on what
+	// happens after rate-limit - probably 401 from requireAuthenticatedUser
+	// since we send no bearer token - but not 429 because the bucket has
+	// budget. We assert "anything except 429" rather than a specific code
+	// to keep the test robust to unrelated chain changes.
+	r1 := doRequest()
+	if r1.Code == http.StatusTooManyRequests {
+		t.Fatalf("first request unexpectedly 429; rate-limit consumed budget too eagerly. body=%s", r1.Body.String())
+	}
+
+	// Second request from the same IP: with burst=1 the bucket is empty,
+	// so rate-limit must fire and emit 429. If rate-limit is missing from
+	// the chain, this would instead be 401 again (or whatever the post-
+	// rate-limit middlewares decide).
+	r2 := doRequest()
+	if r2.Code != http.StatusTooManyRequests {
+		t.Errorf("second SSE request from exhausted IP: got %d, want 429 (rate-limit missing from SSE chain?)", r2.Code)
+	}
+
+	// Sanity: 429 responses should carry Retry-After per the rate-limit
+	// middleware contract. If this header is missing, the chain wired
+	// in something OTHER than our app.rateLimit (e.g. a generic 429
+	// from chi).
+	if r2.Code == http.StatusTooManyRequests && r2.Header().Get("Retry-After") == "" {
+		t.Error("429 response missing Retry-After header; either rate-limit ran wrong or a different 429 source intercepted")
+	}
+}

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -18,12 +18,41 @@ func (app *application) sseRoutes() http.Handler {
 		AllowCredentials: false,
 		MaxAge:           300, // Maximum value not ignored bycls any of major browsers
 	}))
-	// SSE middleware chain. Deliberately omits logRequests: SSE
-	// connections are long-lived (minutes to hours) and a single
-	// "request completed" line at disconnect time is more misleading than
-	// useful. requestID still runs so that anything the SSE handler
-	// itself logs is correlatable with the original HTTP request.
-	sseMiddleware := alice.New(app.requestID, app.recoverPanic, app.authenticate, app.requireAuthenticatedUser, app.requireActivatedUser).Then
+	// SSE middleware chain.
+	//
+	// Ordering matches the main API chain (routes() below) wherever both
+	// have the same middleware, so a request that lands on either server
+	// goes through the same sequence: requestID -> recoverPanic ->
+	// rateLimit -> authenticate -> requireAuthenticatedUser ->
+	// requireActivatedUser. The shared shape is what lets a single
+	// rateLimit middleware (per-IP, Redis-backed) cap connect-attempts
+	// across both servers - reconnect cycles on the SSE port no longer
+	// bypass throttling that the same client would hit on the API port.
+	//
+	// Deliberately omitted vs the main chain:
+	//
+	//   - metrics: SSE connections are long-lived. CaptureMetrics blocks
+	//     until the response Body finishes; for a 4-hour stream it would
+	//     bump total_processing_time_us by 14e9 microseconds and skew
+	//     dashboards. SSE has its own per-event metrics inside the
+	//     handler (publishing pipeline, see notifications.go).
+	//
+	//   - logRequests: same reason. One "request completed" line at
+	//     disconnect, hours after the actual auth happened, is more
+	//     misleading than useful. requestID still runs so anything the
+	//     SSE handler itself logs is correlatable with the original
+	//     HTTP request via X-Request-ID.
+	//
+	// rateLimit was added in this commit. The existing per-user
+	// "1 stream max" rule (enforced by AddClient closing the prior
+	// channel - see notifications.go) limited concurrent streams; it
+	// did NOT limit connect/disconnect cycles, each of which performs a
+	// Redis HGETALL + a database SELECT (loadAndSendPendingNotifications).
+	// A misbehaving client that rapidly reconnected could amplify load
+	// well past what the main-API per-IP bucket would have allowed.
+	// Slotting rateLimit BEFORE authenticate also throttles bearer-token
+	// brute-force on the SSE port specifically.
+	sseMiddleware := alice.New(app.requestID, app.recoverPanic, app.rateLimit, app.authenticate, app.requireAuthenticatedUser, app.requireActivatedUser).Then
 	// Make our categorized routes
 	v1Router := chi.NewRouter()
 	v1Router.With(sseMiddleware).Get("/sse", app.ServeSSE)

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -8,16 +8,54 @@ import (
 	"github.com/justinas/alice"
 )
 
-func (app *application) sseRoutes() http.Handler {
-	router := chi.NewRouter()
-	router.Use(cors.Handler(cors.Options{
+// corsOptions builds the cors.Options used by both http.Server instances
+// (the main API server in routes(), and the SSE server in sseRoutes()).
+// The two surfaces previously each inlined a near-identical struct
+// literal, which had two failure modes:
+//
+//   - Drift: a config change applied to one surface but not the other
+//     produced subtle CORS behavior asymmetries between /v1/* and
+//     /v1/sse that browsers would notice but server-side tests would
+//     not. The two had already drifted on a comment typo ("bycls"
+//     vs "by", since fixed).
+//
+//   - Repeated review burden: every diff that touched either struct
+//     had to consciously consider whether the same change belonged on
+//     the other one.
+//
+// The only legitimate variance between the two surfaces is the set of
+// allowed methods (SSE is GET-only; API has the full CRUD set), so
+// that's the parameter. Everything else - origins, headers, credentials,
+// max-age - is policy that must NOT differ between surfaces.
+//
+// AllowCredentials: false is intentional. The frontend authenticates
+// via "Authorization: Bearer <token>" (not cookies), and CORS does not
+// restrict the Authorization header on cross-origin requests when
+// AllowCredentials is false. Switching to AllowCredentials: true would
+// (a) require enumerating origins exactly because browsers reject the
+// wildcard with credentials, (b) cause cookies to be transmitted
+// cross-origin, which we explicitly do not want for a Bearer-token
+// scheme, and (c) silently change preflight semantics in ways the
+// frontend would have to be re-audited for.
+//
+// MaxAge 300 is the largest preflight-cache value major browsers honor
+// (Chrome caps at 7200s only with a non-default policy; Firefox caps
+// at 86400s; Safari at 300s). 300s is the safe lowest-common-ceiling
+// that all of them respect uniformly.
+func (app *application) corsOptions(allowedMethods []string) cors.Options {
+	return cors.Options{
 		AllowedOrigins:   app.config.cors.trustedOrigins,
-		AllowedMethods:   []string{"GET"},
+		AllowedMethods:   allowedMethods,
 		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
 		ExposedHeaders:   []string{"link"},
 		AllowCredentials: false,
-		MaxAge:           300, // Maximum value not ignored bycls any of major browsers
-	}))
+		MaxAge:           300,
+	}
+}
+
+func (app *application) sseRoutes() http.Handler {
+	router := chi.NewRouter()
+	router.Use(cors.Handler(app.corsOptions([]string{"GET"})))
 	// SSE middleware chain.
 	//
 	// Ordering matches the main API chain (routes() below) wherever both
@@ -64,14 +102,7 @@ func (app *application) sseRoutes() http.Handler {
 // routes() is a method that returns a http.Handler that contains all the routes for the application
 func (app *application) routes() http.Handler {
 	router := chi.NewRouter()
-	router.Use(cors.Handler(cors.Options{
-		AllowedOrigins:   app.config.cors.trustedOrigins,
-		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "PATCH"},
-		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
-		ExposedHeaders:   []string{"link"},
-		AllowCredentials: false,
-		MaxAge:           300, // Maximum value not ignored by any of major browsers
-	}))
+	router.Use(cors.Handler(app.corsOptions([]string{"GET", "POST", "PUT", "DELETE", "PATCH"})))
 	// Global middleware chain, outer to inner:
 	//   metrics      - expvar counters and httpsnoop wrapper for the whole
 	//                  pipeline. Kept outermost so every request is at

--- a/cmd/api/routes_test.go
+++ b/cmd/api/routes_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// TestCorsOptions_OnlyMethodsVary locks in the contract of the
+// corsOptions helper introduced when we deduplicated the SSE and API
+// CORS configs: the *only* legitimate point of variance between the two
+// surfaces is the AllowedMethods slice. Headers, origins source,
+// exposed headers, credentials, and max-age must be byte-identical
+// across surfaces - any drift here is a policy regression.
+//
+// If a future PR legitimately needs surface-specific headers or
+// max-age, the right path is to extend the helper signature with the
+// new parameter, not to reintroduce two struct literals. This test
+// would be the place to encode "headers may now differ between
+// surfaces" if/when that becomes a real requirement.
+func TestCorsOptions_OnlyMethodsVary(t *testing.T) {
+	app := &application{
+		config: config{
+			cors: struct {
+				trustedOrigins []string
+			}{trustedOrigins: []string{"https://app.example.com"}},
+		},
+	}
+
+	api := app.corsOptions([]string{"GET", "POST", "PUT", "DELETE", "PATCH"})
+	sse := app.corsOptions([]string{"GET"})
+
+	// AllowedMethods is the only field that may differ.
+	if reflect.DeepEqual(api.AllowedMethods, sse.AllowedMethods) {
+		t.Errorf("API and SSE somehow have identical AllowedMethods; one of them is misconfigured: api=%v sse=%v",
+			api.AllowedMethods, sse.AllowedMethods)
+	}
+
+	// Every other field must agree byte-for-byte. We compare via copies
+	// with AllowedMethods zeroed so DeepEqual catches any other drift
+	// without us enumerating each field by name.
+	apiCopy := api
+	sseCopy := sse
+	apiCopy.AllowedMethods = nil
+	sseCopy.AllowedMethods = nil
+	if !reflect.DeepEqual(apiCopy, sseCopy) {
+		t.Errorf("CORS config drifted between surfaces (other than AllowedMethods):\n  api=%+v\n  sse=%+v",
+			apiCopy, sseCopy)
+	}
+
+	// Spot-check the method sets are what we expect; if a future PR
+	// adds a method to the API surface (e.g. HEAD) it should show up in
+	// this test and force the author to confirm the change is wanted.
+	wantAPI := []string{"DELETE", "GET", "PATCH", "POST", "PUT"}
+	gotAPI := append([]string(nil), api.AllowedMethods...)
+	sort.Strings(gotAPI)
+	if !reflect.DeepEqual(gotAPI, wantAPI) {
+		t.Errorf("API AllowedMethods drift: got %v, want %v", gotAPI, wantAPI)
+	}
+	if !reflect.DeepEqual(sse.AllowedMethods, []string{"GET"}) {
+		t.Errorf("SSE AllowedMethods must remain GET-only, got %v", sse.AllowedMethods)
+	}
+
+	// AllowCredentials must be false. Setting it to true would require
+	// dropping the wildcard origin (browsers reject "*" with credentials)
+	// and would cause cross-origin cookie transmission - we authenticate
+	// via Bearer tokens, not cookies, so this is a security-relevant
+	// invariant.
+	if api.AllowCredentials || sse.AllowCredentials {
+		t.Error("AllowCredentials must remain false on both surfaces (Bearer-token scheme, no cross-origin cookies)")
+	}
+
+	// AllowedOrigins must be sourced from config (this is what makes
+	// trusted-origin changes a config push, not a code release).
+	if !reflect.DeepEqual(api.AllowedOrigins, []string{"https://app.example.com"}) {
+		t.Errorf("AllowedOrigins must mirror app.config.cors.trustedOrigins, got %v", api.AllowedOrigins)
+	}
+}


### PR DESCRIPTION
## Summary

Four discrete HTTP-layer cleanups from the audit roadmap, shipped as one PR with a single concern per commit so the review story is commit-by-commit, not one mega-diff.

| # | Concern | File:line | Wire effect |
|---|---|---|---|
| 1 | `writeJSON` used `json.MarshalIndent` unconditionally | `cmd/api/helpers.go:38–56` | Compact JSON, no trailing newline, explicit `application/json; charset=utf-8`. Bytes-on-wire only; not a contract change. |
| 2 | `readJSON` didn't validate `Content-Type` | `cmd/api/helpers.go` (`readJSON` + new `validateJSONContentType`) | New `415` for missing/wrong header. Frontend orientation-scan verified SvelteKit sends compatible headers. |
| 3 | SSE chain skipped `app.rateLimit` | `cmd/api/routes.go:11–61` | SSE clients can now receive `429` on connect when per-IP bucket is empty. |
| 4 | CORS config duplicated + had `"bycls"` typo | `cmd/api/routes.go` (new `corsOptions` helper) | None — pure refactor + typo fix. |

## Why one PR / four commits

Each concern is independent (no commit depends on another) and small enough that four separate stacked PRs would be more overhead than the changes warrant — see PR #60/#61 stack from last week which needed two separate rebases. One PR keeps CI/review/merge atomic. The commit log below is structured for commit-by-commit review.

## Commit-by-commit

### `d3f8455` — `http(helpers): writeJSON drops MarshalIndent and explicitly declares utf-8`

`json.MarshalIndent(data, "", "\t")` was emitting tab-indented + trailing-`\n` JSON on every response. The historical justification ("easier to view in terminal applications") doesn't survive contact with production: programmatic clients parse identically regardless of whitespace, so the indentation is pure egress overhead (~15–25% size increase on a representative ~5 KB response). Operators who want pretty output can pipe through `jq`.

Switch to plain `json.Marshal` (compact, no trailing newline) and tighten `Content-Type` to `application/json; charset=utf-8` — RFC 8259 §8.1 mandates UTF-8 for JSON exchanged between systems, but a small minority of HTTP clients still pick a wrong default decoder when the parameter is omitted.

Added `TestWriteJSON_WireFormat` and `TestWriteJSON_HeadersMerged` so any subsequent edit that re-introduces indentation or a trailing newline is caught immediately.

### `b4f72eb` — `http(helpers): readJSON enforces application/json Content-Type with 415 routing`

`readJSON` used to parse whatever bytes the client sent regardless of `Content-Type`. Per RFC 7231 §3.1.1.5 a sender that emits a body SHOULD declare its type, and audit Pass 4 flagged the absence as a real gap.

`readJSON` now calls a new `validateJSONContentType(r)` up front; rejection wraps `ErrUnsupportedMediaType`, which `badRequestResponse` detects via `errors.Is` and routes to a new `unsupportedMediaTypeResponse` (415). **This means zero handler changes** — the ~50 existing call sites that follow the canonical pattern

```go
err := app.readJSON(w, r, &input)
if err != nil { app.badRequestResponse(w, r, err); return }
```

automatically pick up the new 415 behavior without being touched.

`mime.ParseMediaType` is used instead of string equality so the parameter forms work — bare `application/json`, with `charset=utf-8`, with `UTF-8` (case-insensitive), and with extra params (`boundary=...`) all pass. The full accept matrix is encoded in `TestValidateJSONContentType_Accepted`.

The 415 envelope deliberately does NOT echo the rejected `Content-Type` back to the client (the client already knows it; surfacing it risks future log-redaction surprises). Diagnostic context is preserved server-side via the wrapped `fmt.Errorf` chain.

### `1a529c0` — `http(sse): splice rateLimit into the SSE middleware chain`

The SSE handler runs on a separate `http.Server` (`cmd/api/server.go`) with its own routes assembled in `sseRoutes()`. That chain was missing `app.rateLimit`:

```
requestID -> recoverPanic -> authenticate -> requireAuthenticatedUser -> requireActivatedUser -> ServeSSE
```

Audit Pass 4 framed this as "user can hold thousands of streams" — that part is actually already covered: `AddClient` (notifications.go) closes the previous channel and cancels the previous Redis listener whenever a fresh `ServeSSE` arrives for the same userID. The real gap is **connect/disconnect cycles**, each of which does `HGETALL` + `SELECT` (`loadAndSendPendingNotifications`). Without per-IP throttling on the SSE port, a misbehaving client can amplify load past what the same client would hit on the API port.

The new chain mirrors the main API chain wherever both have the same middleware:

```
requestID -> recoverPanic -> rateLimit -> authenticate -> ... -> ServeSSE
```

`rateLimit` is BEFORE `authenticate` so bearer-token brute-force on the SSE port is also throttled.

`metrics` and `logRequests` remain deliberately omitted (long-lived streams would skew per-request metrics; the rationale is now in a long comment in `routes.go`).

`TestSSERoutes_RateLimitInChain` exercises the assembled handler with miniredis at rps=1/burst=1: first request returns 401 (anonymous), second returns 429. The test also asserts `Retry-After` is present on the 429 to confirm the response came from `app.rateLimit` and not a generic chi fallback.

**Frontend impact:** browser-side handling is essentially transparent — `src/routes/(app)/+layout.svelte` lines 56–83 already implement exponential backoff on `EventSource.onerror`, with a 20s initial delay that comfortably covers any reasonable per-IP bucket refill window. **Proxy-side caveat:** `src/routes/api/sse/+server.js` doesn't forward `X-Forwarded-For`, so all SSE connects appear to come from one IP (the proxy's) on the Go side — a multi-user deployment could self-DoS. Logged as `OPEN` in `.notes/frontend-contract-debt.md` row 6 with three resolution paths in priority order.

### `4545a87` — `http(routes): factor and dedupe CORS config across API and SSE surfaces`

`cors.Options` was inlined twice with the only legitimate variance being the `AllowedMethods` slice. The two literals had already drifted on a comment typo (`"bycls"`); review burden compounded with every PR that touched either struct. New helper `corsOptions(allowedMethods []string)` enforces structural agreement on every other field with a long-form comment explaining each policy choice (notably why `AllowCredentials: false` is intentional — Bearer-token scheme, not cookies — and why `MaxAge: 300` is the lowest-common-ceiling all major browsers respect).

`TestCorsOptions_OnlyMethodsVary` locks in the contract: methods may differ; nothing else may. Uses `reflect.DeepEqual` on copies with `AllowedMethods` zeroed so any future drift on an unrelated field is caught without enumerating field names.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` — full suite passes (incl. existing rate-limit + middleware tests)
- [x] `golangci-lint run` — 0 issues
- [x] New tests in `helpers_test.go`, `middleware_test.go`, `routes_test.go`
- [ ] CI green (will verify after push)
- [ ] e2e smoke (the docker-compose stack test continues to GET `/healthz`/`/readyz`/`/metrics`/`/debug/vars`; none of those go through `readJSON`, so the new 415 path won't interfere)

## Notes for the merge queue

- **No frontend coupling required for this PR to merge** — the Content-Type tightening is verified backward-compatible, and the SSE 429 path is gracefully handled by the existing browser-side backoff.
- **The proxy-side `X-Forwarded-For` follow-up (row 6 of the debt tracker)** should land on the frontend before any multi-user deployment of this backend PR. Single-tenant or staging deployments are unaffected.
- **No merge conflicts expected with PR #63** (the `chore/makefile-dev-redis-targets` chore PR opened earlier today) — different files, different concerns.