### PR TITLE
deploy: helm chart v0.1.0 for OptiVest API

### DIFF
--- a/deploy/charts/optivest/.helmignore
+++ b/deploy/charts/optivest/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/charts/optivest/Chart.yaml
+++ b/deploy/charts/optivest/Chart.yaml
@@ -1,24 +1,78 @@
 apiVersion: v2
 name: optivest
-description: A Helm chart for Kubernetes
 
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+# Concise one-liner used by `helm search` and `helm show chart`.
+# Keep it under ~80 chars; longer rationale belongs in README.md.
+description: Helm chart for the OptiVest API (Go) and its goose migration sidecar
+
+# `application` (a deployable workload chart) vs `library` (a chart of
+# helpers consumed by other charts). OptiVest is the workload itself,
+# so application is correct.
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
+# version is the chart's own SemVer. Bump on every chart change
+# regardless of whether appVersion changes. Conventions:
+#   - patch (0.1.0 -> 0.1.1): chart-only fixes (typo, comment, no
+#                              behaviour change)
+#   - minor (0.1.0 -> 0.2.0): chart features (new template, new
+#                              value, new option)
+#   - major (0.1.0 -> 1.0.0): backwards-incompatible value renames or
+#                              template restructure that breaks an
+#                              existing release on `helm upgrade`
+# Keep this in sync with whatever you ship to deploy environments so
+# `helm history` is meaningful for rollbacks.
 version: 0.1.0
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-appVersion: "1.16.0"
+# appVersion is the version of the OptiVest application this chart
+# was tested against. Distinct from chart version because the chart
+# and the app evolve on different cadences. Used by `helm list` and
+# the rendered `app.kubernetes.io/version` label.
+#
+# Pinned to 0.1.0 for now because OptiVest hasn't cut a SemVer release
+# tag yet (binary embeds vcs.Version() from runtime/debug, which gives
+# a commit hash, not a version). When the project tags v1.0.0, sync
+# this field. Quote it because Helm treats unquoted appVersion as a
+# number when it parses cleanly as one (e.g. `1.16` would lose the
+# patch component without quotes).
+appVersion: "0.1.0"
+
+# kubeVersion is the minimum Kubernetes API version the templates
+# target. We use:
+#   - apps/v1     (Deployment, GA since 1.9)
+#   - v1          (Service, ConfigMap, Secret, ServiceAccount, Pod -
+#                  GA since forever)
+#   - autoscaling/v2     (HPA, GA since 1.23)
+#   - networking.k8s.io/v1   (Ingress, GA since 1.19)
+#   - gateway.networking.k8s.io/v1   (HTTPRoute, GA since 1.30)
+#
+# 1.30 is the floor for HTTPRoute. We pin >=1.27 because that's what
+# `kindest/node` ships with the kind v0.20+ default image and gives
+# us modern probe semantics + PodReadiness gates without surprises.
+# HTTPRoute is gated by a values flag; users on <1.30 leave it
+# disabled and use the legacy Ingress instead.
+kubeVersion: ">=1.27.0-0"
+
+# sources point at the repository for `helm show chart` and any
+# OCI-registry browser. Just one entry: the project itself, since the
+# chart lives inside the repo it deploys.
+sources:
+  - https://github.com/Blue-Davinci/OptiVest
+
+# maintainers - who is on the hook for chart issues. Email is
+# optional but adds a contact path that's distinct from "filing a
+# GitHub issue", which matters when a chart consumer hits a bug
+# during a 3am cluster-wide upgrade.
+maintainers:
+  - name: Blue-Davinci
+    url: https://github.com/Blue-Davinci
+
+# keywords show up in `helm search` if the chart is published to a
+# registry (chart museum, GHCR-as-OCI, etc.). Free-form; pick the
+# terms a user would actually type. We deliberately omit "kubernetes"
+# (every chart is for kubernetes) and "helm" (likewise tautological).
+keywords:
+  - optivest
+  - personal-finance
+  - go
+  - api
+  - sse

--- a/deploy/charts/optivest/Chart.yaml
+++ b/deploy/charts/optivest/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: optivest
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/deploy/charts/optivest/templates/NOTES.txt
+++ b/deploy/charts/optivest/templates/NOTES.txt
@@ -1,35 +1,106 @@
-1. Get the application URL by running these commands:
-{{- if .Values.httpRoute.enabled }}
-{{- if .Values.httpRoute.hostnames }}
-    export APP_HOSTNAME={{ .Values.httpRoute.hostnames | first }}
-{{- else }}
-    export APP_HOSTNAME=$(kubectl get --namespace {{(first .Values.httpRoute.parentRefs).namespace | default .Release.Namespace }} gateway/{{ (first .Values.httpRoute.parentRefs).name }} -o jsonpath="{.spec.listeners[0].hostname}")
-  {{- end }}
-{{- if and .Values.httpRoute.rules (first .Values.httpRoute.rules).matches (first (first .Values.httpRoute.rules).matches).path.value }}
-    echo "Visit http://$APP_HOSTNAME{{ (first (first .Values.httpRoute.rules).matches).path.value }} to use your application"
+{{/*
+NOTES.txt - rendered AFTER `helm install` and `helm upgrade`. Helm
+prints this verbatim. Keep it actionable: an operator just ran
+install/upgrade and wants to know "what now?", not a tour of the
+chart. Detailed rationale lives in chart README.md.
 
-    NOTE: Your HTTPRoute depends on the listener configuration of your gateway and your HTTPRoute rules.
-    The rules can be set for path, method, header and query parameters.
-    You can check the gateway configuration with 'kubectl get --namespace {{(first .Values.httpRoute.parentRefs).namespace | default .Release.Namespace }} gateway/{{ (first .Values.httpRoute.parentRefs).name }} -o yaml'
-{{- end }}
-{{- else if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
-  {{- end }}
-{{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "optivest.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "optivest.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "optivest.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "optivest.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
-{{- end }}
+The chart in v0.1 is ClusterIP-only (Ingress and HTTPRoute remain
+disabled until v0.3), so the only access pattern is port-forward.
+We surface that prominently. We also call out the most common
+day-zero failure mode: the Pod stays in CreateContainerConfigError
+because the Secret named in `existingSecret` doesn't exist. NOTES is
+the right place to surface that because it's printed exactly when
+the operator is poised to wonder why their pod isn't healthy.
+*/}}
+
+OptiVest API has been installed.
+
+  Release name:   {{ .Release.Name }}
+  Namespace:      {{ .Release.Namespace }}
+  Chart version:  {{ .Chart.Version }}
+  App version:    {{ .Chart.AppVersion }}
+  Image:          {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+  Replicas:       {{ .Values.replicaCount }}
+
+# ----------------------------------------------------------------------------
+# Did you create the Secret?
+# ----------------------------------------------------------------------------
+This chart deliberately does NOT manage secret material. The API Pod
+will stay in CreateContainerConfigError until a Secret named
+`{{ .Values.existingSecret }}` exists in namespace
+`{{ .Release.Namespace }}`.
+
+If you haven't created it yet, here is a paste-ready template for
+local kind. Replace `unset-for-local` with real keys for any vendor
+you actually want to call.
+
+    kubectl -n {{ .Release.Namespace }} create secret generic {{ .Values.existingSecret }} \
+        --from-literal=OPTIVEST_DB_DSN='postgres://optivest:optivest@host.docker.internal:5432/optivest?sslmode=disable' \
+        --from-literal=OPTIVEST_DATA_ENCRYPTION_KEY="$(openssl rand -hex 32)" \
+        --from-literal=OPTIVEST_REDIS_PASSWORD='' \
+        --from-literal=OPTIVEST_ALPHAVANTAGE_API_KEY='unset-for-local' \
+        --from-literal=OPTIVEST_EXCHANGERATE_API_KEY='unset-for-local' \
+        --from-literal=OPTIVEST_FRED_API_KEY='unset-for-local' \
+        --from-literal=OPTIVEST_FINANCIALMODELINGPREP_API_KEY='unset-for-local' \
+        --from-literal=OPTIVEST_SAMBA_NOVA_LLM_API_KEY='unset-for-local' \
+        --from-literal=OPTIVEST_PREDICTOR_API_KEY='unset-for-local' \
+        --from-literal=OPTIVEST_OCRSPACE_API_KEY='unset-for-local' \
+        --from-literal=OPTIVEST_SMTP_HOST='sandbox.smtp.mailtrap.io' \
+        --from-literal=OPTIVEST_SMTP_USERNAME='' \
+        --from-literal=OPTIVEST_SMTP_PASSWORD='' \
+        --from-literal=OPTIVEST_SMTP_SENDER='OptiVest <no-reply@optivest.local>'
+
+OPTIVEST_DATA_ENCRYPTION_KEY MUST be a hex-encoded 16/24/32-byte AES
+key. The openssl call above gives you 32 bytes (AES-256). Anything
+else is rejected at boot by validateConfig() in cmd/api/main.go.
+
+After creating the Secret, the Pod will progress on its own; no
+restart needed.
+
+# ----------------------------------------------------------------------------
+# Reach the API
+# ----------------------------------------------------------------------------
+The Service is ClusterIP, so port-forward to reach it from your host:
+
+    kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "optivest.fullname" . }} \
+        {{ .Values.service.apiPort }}:{{ .Values.service.apiPort }} \
+        {{ .Values.service.ssePort }}:{{ .Values.service.ssePort }}
+
+Then:
+
+    curl http://localhost:{{ .Values.service.apiPort }}/healthcheck
+    curl http://localhost:{{ .Values.service.apiPort }}/readyz
+
+# ----------------------------------------------------------------------------
+# Watch the rollout
+# ----------------------------------------------------------------------------
+    kubectl -n {{ .Release.Namespace }} rollout status deployment/{{ include "optivest.fullname" . }}
+    kubectl -n {{ .Release.Namespace }} logs -f -l app.kubernetes.io/instance={{ .Release.Name }}
+
+To run the chart's `helm test` smoke check (a tiny Pod that hits
+/healthcheck on the API Service):
+
+    helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+# ----------------------------------------------------------------------------
+# What this chart version does NOT do (deliberate)
+# ----------------------------------------------------------------------------
+This is chart {{ .Chart.Version }}. The following are scaffolded but
+not yet wired or are deferred outright:
+
+  - Migrate Job (goose up via Helm pre-install/pre-upgrade hook) -
+    chart v0.2. For now, run goose against your Postgres BEFORE
+    `helm install` so the API doesn't hit missing tables:
+
+      goose -dir internal/sql/schema postgres "$OPTIVEST_DB_DSN" up
+
+  - Ingress + cert-manager - chart v0.3. Use port-forward until then.
+
+  - Postgres + Redis as in-cluster bitnami subcharts - chart v0.4.
+    For now, the chart talks to whatever is at
+    {{ .Values.externalRedis.host }} (Redis) and whatever DSN is in
+    your Secret (Postgres).
+
+  - HorizontalPodAutoscaler - scaffolded as templates/hpa.yaml but
+    `autoscaling.enabled` is false until we have realistic load
+    metrics to drive it.

--- a/deploy/charts/optivest/templates/NOTES.txt
+++ b/deploy/charts/optivest/templates/NOTES.txt
@@ -1,0 +1,35 @@
+1. Get the application URL by running these commands:
+{{- if .Values.httpRoute.enabled }}
+{{- if .Values.httpRoute.hostnames }}
+    export APP_HOSTNAME={{ .Values.httpRoute.hostnames | first }}
+{{- else }}
+    export APP_HOSTNAME=$(kubectl get --namespace {{(first .Values.httpRoute.parentRefs).namespace | default .Release.Namespace }} gateway/{{ (first .Values.httpRoute.parentRefs).name }} -o jsonpath="{.spec.listeners[0].hostname}")
+  {{- end }}
+{{- if and .Values.httpRoute.rules (first .Values.httpRoute.rules).matches (first (first .Values.httpRoute.rules).matches).path.value }}
+    echo "Visit http://$APP_HOSTNAME{{ (first (first .Values.httpRoute.rules).matches).path.value }} to use your application"
+
+    NOTE: Your HTTPRoute depends on the listener configuration of your gateway and your HTTPRoute rules.
+    The rules can be set for path, method, header and query parameters.
+    You can check the gateway configuration with 'kubectl get --namespace {{(first .Values.httpRoute.parentRefs).namespace | default .Release.Namespace }} gateway/{{ (first .Values.httpRoute.parentRefs).name }} -o yaml'
+{{- end }}
+{{- else if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "optivest.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "optivest.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "optivest.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "optivest.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/deploy/charts/optivest/templates/_helpers.tpl
+++ b/deploy/charts/optivest/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "optivest.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "optivest.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "optivest.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "optivest.labels" -}}
+helm.sh/chart: {{ include "optivest.chart" . }}
+{{ include "optivest.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "optivest.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "optivest.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "optivest.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "optivest.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/optivest/templates/deployment.yaml
+++ b/deploy/charts/optivest/templates/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "optivest.fullname" . }}
+  labels:
+    {{- include "optivest.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "optivest.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "optivest.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "optivest.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/optivest/templates/deployment.yaml
+++ b/deploy/charts/optivest/templates/deployment.yaml
@@ -40,10 +40,80 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # CLI args - everything the OptiVest binary reads from
+          # flags rather than env. The mapping is centralized here so
+          # the values.yaml-to-flag relationship is grep-able.
+          #
+          # Argv composition note: the image's ENTRYPOINT is
+          # `["/sbin/tini", "--"]` and its CMD is `["/app/api"]`.
+          # Kubernetes `args:` replaces CMD wholesale, so `/app/api`
+          # has to be args[0] - otherwise the final argv is
+          # `tini -- -env=...` and tini tries to exec `-env=...` as
+          # the binary. Keeping ENTRYPOINT (no `command:` override
+          # below) means tini stays in place for signal forwarding
+          # and zombie reaping.
+          args:
+            - "/app/api"
+            - "-env={{ .Values.config.env }}"
+            # Bind both ports on 0.0.0.0 inside the container so the
+            # kubelet can reach them via the PodIP. The container is
+            # firewalled by the Pod boundary; 0.0.0.0 is safe here.
+            - "-port={{ .Values.service.apiPort }}"
+            - "-ws-port={{ .Values.service.ssePort }}"
+            - "-redis-addr={{ .Values.externalRedis.host }}"
+            # cors-trusted-origins is a flag.Func that splits on
+            # whitespace inside this single value. Empty string is
+            # acceptable (no origins accepted, browser-less API
+            # only). NEVER use "*" outside development.
+            - "-cors-trusted-origins={{ .Values.config.corsTrustedOrigins }}"
+            - "-limiter-enabled={{ .Values.config.limiter.enabled }}"
+            - "-limiter-rps={{ .Values.config.limiter.rps }}"
+            - "-limiter-burst={{ .Values.config.limiter.burst }}"
           ports:
-            - name: http
-              containerPort: {{ .Values.service.port }}
+            # Named ports rather than literal numbers - the probes
+            # below (and the Service in service.yaml) reference these
+            # names, so renumbering happens in one place (values.yaml)
+            # without surgery on every consumer.
+            - name: api
+              containerPort: {{ .Values.service.apiPort }}
               protocol: TCP
+            - name: sse
+              containerPort: {{ .Values.service.ssePort }}
+              protocol: TCP
+          # envFrom + env split:
+          #   - envFrom: secretRef pulls every key from the external
+          #     Secret named in `existingSecret`. The OptiVest
+          #     binary's *_API_KEY family + DSN + encryption key +
+          #     SMTP creds all have os.Getenv() defaults, so they
+          #     load cleanly via this mechanism. The Secret must
+          #     exist before the Pod starts or the kubelet will
+          #     hold the Pod in CreateContainerConfigError.
+          #   - extraEnvFrom: caller-provided ConfigMaps / Secrets
+          #     (e.g. an environment-specific overlay).
+          envFrom:
+            - secretRef:
+                name: {{ .Values.existingSecret }}
+            {{- with .Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          # Inline env entries. GOMEMLIMIT goes here rather than in a
+          # ConfigMap because (a) it's a single var and (b) it ties
+          # to resources.limits.memory which is also values-driven,
+          # so co-locating keeps the relationship visible. Add a
+          # ConfigMap template if/when this list grows past ~3 vars.
+          env:
+            {{- if .Values.config.gomemlimit }}
+            # GOMEMLIMIT tells the Go runtime its memory ceiling so
+            # the GC can run aggressively *before* the kubelet
+            # OOM-kills the pod. Without it, a Go binary inside a
+            # memory-limited cgroup has no idea about the cgroup
+            # limit and will routinely OOM-kill itself under load.
+            - name: GOMEMLIMIT
+              value: {{ .Values.config.gomemlimit | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/deploy/charts/optivest/templates/hpa.yaml
+++ b/deploy/charts/optivest/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "optivest.fullname" . }}
+  labels:
+    {{- include "optivest.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "optivest.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/charts/optivest/templates/httproute.yaml
+++ b/deploy/charts/optivest/templates/httproute.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "optivest.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "optivest.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.httpRoute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/deploy/charts/optivest/templates/ingress.yaml
+++ b/deploy/charts/optivest/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "optivest.fullname" . }}
+  labels:
+    {{- include "optivest.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "optivest.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/charts/optivest/templates/service.yaml
+++ b/deploy/charts/optivest/templates/service.yaml
@@ -7,9 +7,23 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
+    # Two named ports because OptiVest's binary listens on two: the
+    # main API surface and the SSE long-lived stream. They live on
+    # the same Pod so a single Service can front both.
+    #
+    # `targetPort: api` (and `sse`) reference the named ports defined
+    # on the container in deployment.yaml, not literal port numbers.
+    # That means renumbering the API port (e.g. moving 4000 -> 4040
+    # to dodge a host conflict in a different deploy environment)
+    # only requires updating values.yaml; the cross-template
+    # references stay correct.
+    - port: {{ .Values.service.apiPort }}
+      targetPort: api
       protocol: TCP
-      name: http
+      name: api
+    - port: {{ .Values.service.ssePort }}
+      targetPort: sse
+      protocol: TCP
+      name: sse
   selector:
     {{- include "optivest.selectorLabels" . | nindent 4 }}

--- a/deploy/charts/optivest/templates/service.yaml
+++ b/deploy/charts/optivest/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "optivest.fullname" . }}
+  labels:
+    {{- include "optivest.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "optivest.selectorLabels" . | nindent 4 }}

--- a/deploy/charts/optivest/templates/serviceaccount.yaml
+++ b/deploy/charts/optivest/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "optivest.serviceAccountName" . }}
+  labels:
+    {{- include "optivest.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/deploy/charts/optivest/templates/tests/test-connection.yaml
+++ b/deploy/charts/optivest/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "optivest.fullname" . }}-test-connection"
+  labels:
+    {{- include "optivest.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "optivest.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/deploy/charts/optivest/templates/tests/test-connection.yaml
+++ b/deploy/charts/optivest/templates/tests/test-connection.yaml
@@ -1,3 +1,32 @@
+{{/*
+Helm test hook - a one-shot Pod that runs when you call
+`helm test <release>`. Exit-zero means the chart's smoke check
+passed; non-zero is a failed test, which Helm surfaces in its
+output.
+
+`helm.sh/hook: test` makes Helm treat this as a test resource
+(opt-in only on `helm test`, not created during `helm install`).
+`helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded`
+means an old test pod from a previous run is cleaned up at the
+START of a new run, AND a successful run is also cleaned up at the
+END. Failed runs are left in place for debugging - reading the
+container logs of a failed test pod is the entire point.
+
+The check itself: hit the API's /healthcheck endpoint via the
+in-cluster Service DNS name. Service DNS is
+`<service-name>.<namespace>.svc.cluster.local`, but the short form
+`<service-name>` resolves correctly inside the same namespace. We
+use the short form so the manifest stays portable across namespace
+renames.
+
+Why busybox wget instead of a more ergonomic tool: busybox is tiny
+(~1 MiB compressed), pre-pinned by k8s test conventions, and the
+chart shouldn't pull a heavier base just for one HTTP probe. Note
+that busybox `wget --spider` returns non-zero on a perfectly
+successful HEAD response (subtle exit-code semantics differ from
+GNU wget), so we do a tiny GET and discard the body via -O- and a
+redirect, matching the pattern used in /Dockerfile's HEALTHCHECK.
+*/}}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -6,10 +35,21 @@ metadata:
     {{- include "optivest.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "optivest.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never
+  # The test Pod runs as a worker, not a service - it doesn't need
+  # an SA token mounted. Cosmetic but tightens the Pod's surface.
+  automountServiceAccountToken: false
+  containers:
+    - name: probe
+      image: busybox:1.37
+      command:
+        - wget
+      args:
+        - "-q"
+        - "-O"
+        - "-"
+        - "--tries=1"
+        - "--timeout=5"
+        - "http://{{ include "optivest.fullname" . }}:{{ .Values.service.apiPort }}/healthcheck"

--- a/deploy/charts/optivest/values.yaml
+++ b/deploy/charts/optivest/values.yaml
@@ -1,0 +1,161 @@
+# Default values for optivest.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: nginx
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created.
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account.
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template.
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  port: 80
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+
+# -- Expose the service via gateway-api HTTPRoute
+# Requires Gateway API resources and suitable controller installed within the cluster
+# (see: https://gateway-api.sigs.k8s.io/guides/)
+httpRoute:
+  # HTTPRoute enabled.
+  enabled: false
+  # HTTPRoute annotations.
+  annotations: {}
+  # Which Gateways this Route is attached to.
+  parentRefs:
+  - name: gateway
+    sectionName: http
+    # namespace: default
+  # Hostnames matching HTTP header.
+  hostnames:
+  - chart-example.local
+  # List of rules and filters applied.
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /headers
+  #   filters:
+  #   - type: RequestHeaderModifier
+  #     requestHeaderModifier:
+  #       set:
+  #       - name: My-Overwrite-Header
+  #         value: this-is-the-only-value
+  #       remove:
+  #       - User-Agent
+  # - matches:
+  #   - path:
+  #       type: PathPrefix
+  #       value: /echo
+  #     headers:
+  #     - name: version
+  #       value: v2
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+  # - name: foo
+  #   secret:
+  #     secretName: mysecret
+  #     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+  # - name: foo
+  #   mountPath: "/etc/foo"
+  #   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/deploy/charts/optivest/values.yaml
+++ b/deploy/charts/optivest/values.yaml
@@ -1,161 +1,413 @@
-# Default values for optivest.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+# =============================================================================
+# OptiVest Helm chart - default values
+# =============================================================================
+#
+# These defaults target the local-kind learning track described in
+# `.notes/deployment-options.md` (gitignored). They are deliberately
+# conservative: single replica, low resource limits, ClusterIP service,
+# in-cluster Redis at "redis:6379" assumed, Ingress and HTTPRoute
+# disabled. The chart is installable with no `--set` flags, but the
+# Pod will stay in CreateContainerConfigError until you create the
+# Secret named in `existingSecret` below (see chart README for the
+# exact envelope).
+#
+# Production overrides live in a separate values file
+# (`values-prod.yaml`, future) and are layered with
+# `helm install ... -f values.yaml -f values-prod.yaml`. NEVER put
+# real secrets in either file - secret material always comes from an
+# externally-created Secret, see `existingSecret`.
 
-# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+# -----------------------------------------------------------------------------
+# Replicas
+# -----------------------------------------------------------------------------
+# replicaCount: 1 is correct for local kind. In production with sticky
+# sessions for SSE you'd run >=2 replicas behind an ingress with
+# session affinity; without that, an SSE client whose connection
+# landed on replica A would lose its in-memory state if a redeploy
+# moved them to replica B. The current code keeps the per-user channel
+# registry (cmd/api/notifications.go) in pod-local memory, so multi-
+# replica safely requires either:
+#   1. sticky sessions on the ingress (simplest)
+#   2. moving the channel registry to a Redis pubsub fan-out across
+#      pods (the right long-term answer; logged in audit Pass 4)
 replicaCount: 1
 
-# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+# -----------------------------------------------------------------------------
+# Image - the optivest-api container
+# -----------------------------------------------------------------------------
+# Local kind: build with `docker build -t optivest-api:latest .`,
+# load into kind with `kind load docker-image optivest-api:latest
+# --name optivest`. pullPolicy MUST be IfNotPresent or Never for kind
+# to use the loaded image; Always would cause the kubelet to try to
+# pull from a remote registry and fail (the image isn't in any
+# registry until we add a publish-on-tag CI workflow - currently
+# tracked as a pending follow-up since CI builds with push:false).
+#
+# Production: bump repository to a real registry path (e.g.
+# `ghcr.io/blue-davinci/optivest-api`) and pin tag to a specific
+# version. Avoid the floating `latest` tag in any environment that
+# isn't kind, because rollbacks become impossible.
+#
+# tag empty string ("") falls back to `.Chart.AppVersion` in the
+# Deployment template - keep that override available so a user can
+# bump the chart's appVersion as the canonical "what we ship" without
+# editing this block.
 image:
-  repository: nginx
-  # This sets the pull policy for images.
+  repository: optivest-api
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+# imagePullSecrets - if the registry requires auth, name a Secret of
+# type kubernetes.io/dockerconfigjson here. For public registries
+# (including GHCR with anon read on a public repo) leave empty.
 imagePullSecrets: []
-# This is to override the chart name.
+# - name: ghcr-pull-secret
+
+# nameOverride / fullnameOverride - escape hatches for the standard
+# release-name + chart-name composition done in _helpers.tpl. Empty
+# means "use the standard composition", which is what you want 99% of
+# the time. Useful when adopting a chart into an existing cluster
+# where resource names are already locked in.
 nameOverride: ""
 fullnameOverride: ""
 
-# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+# -----------------------------------------------------------------------------
+# ServiceAccount
+# -----------------------------------------------------------------------------
+# Keep the chart-managed ServiceAccount (create: true). The OptiVest
+# binary doesn't talk to the Kubernetes API itself, so the SA's token
+# is mostly cosmetic at this chart version - but giving the workload
+# its own SA gives us a clean attachment point for narrow RBAC later
+# (e.g. when chart v0.5 adds the ability to read its own ConfigMap
+# for hot-reload, or when we attach IRSA / Workload Identity in
+# managed-K8s providers).
+#
+# automount: true is the default; the OptiVest binary doesn't use the
+# API, so technically we could disable it. Left enabled so kubectl
+# debug pods (which inherit the SA token) keep working without
+# special handling.
 serviceAccount:
-  # Specifies whether a service account should be created.
   create: true
-  # Automatically mount a ServiceAccount's API credentials?
   automount: true
-  # Annotations to add to the service account.
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template.
+  # name: "" means "let the chart generate a name from the release
+  # name + chart name". Override only if integrating with an
+  # externally-managed SA (e.g. one created by your secret-manager
+  # operator).
   name: ""
 
-# This is for setting Kubernetes Annotations to a Pod.
-# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+# -----------------------------------------------------------------------------
+# Pod metadata
+# -----------------------------------------------------------------------------
+# podAnnotations - useful for Prometheus scrape config
+# (`prometheus.io/scrape: "true"`, `prometheus.io/port: "4000"`,
+# `prometheus.io/path: "/metrics"`) when you've installed a
+# Prometheus that uses pod-annotation-based service discovery.
+# Empty by default; set on a per-environment basis.
 podAnnotations: {}
-# This is for setting Kubernetes Labels to a Pod.
-# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+
+# podLabels - extra labels added to the Pod template (in addition to
+# the standard chart label set from _helpers.tpl). Useful for
+# attaching a NetworkPolicy or PodMonitor selector that's specific
+# to this release without changing the chart.
 podLabels: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+# -----------------------------------------------------------------------------
+# Pod-level security context
+# -----------------------------------------------------------------------------
+# The OptiVest Dockerfile creates `optivest` USER UID 10001 (defined
+# at the bottom of /Dockerfile in the runtime stage) and runs as
+# that. These settings make the Pod-spec policy match what the image
+# already does so admission controllers (Pod Security Standards
+# "restricted" profile) don't reject the Pod.
+#
+# If the runtime image is ever swapped to gcr.io/distroless/static:nonroot
+# (referenced in the Dockerfile header comment as a future tightening
+# pass), the UID changes to 65532. Bump this block in lock-step with
+# that change - the chart should mirror image reality, not guess at
+# it.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  fsGroup: 10001
+  seccompProfile:
+    type: RuntimeDefault
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+# Container-level securityContext - belt-and-braces.
+# readOnlyRootFilesystem: true is correct for OptiVest because the
+# binary writes nothing to the local filesystem (logs go to stdout,
+# no uploaded-file storage). If a future feature requires write
+# access (e.g. local file uploads, a tmp-file-based OCR pipeline),
+# add a writable emptyDir volume rather than relaxing this flag.
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
 
-# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+# -----------------------------------------------------------------------------
+# Service
+# -----------------------------------------------------------------------------
+# Two ports because the OptiVest binary listens on two: the main API
+# (default 4000) and the SSE long-lived stream port (default 4001).
+# Both are exposed by the same Pod, so one Service is enough.
+#
+# ClusterIP for the first chart pass: reachable from inside the
+# cluster only. We'll add Ingress in chart v0.3. LoadBalancer is
+# available on managed K8s providers but on kind it requires
+# `cloud-provider-kind` or similar shim - not worth it for the
+# learning track.
 service:
-  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
   type: ClusterIP
-  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
-  port: 80
+  apiPort: 4000
+  ssePort: 4001
 
-# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+# -----------------------------------------------------------------------------
+# Ingress (legacy networking.k8s.io/v1)
+# -----------------------------------------------------------------------------
+# Disabled until chart v0.3 adds proper TLS via cert-manager. When
+# enabled, requires an ingress controller (ingress-nginx, traefik)
+# installed in the cluster. The chart-example.local hostname here is
+# a helm-create placeholder; replace with your real hostname.
 ingress:
   enabled: false
   className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
   hosts:
     - host: chart-example.local
       paths:
         - path: /
           pathType: ImplementationSpecific
   tls: []
-    # - secretName: chart-example-tls
+    # - secretName: optivest-tls
     #   hosts:
-    #     - chart-example.local
+    #     - api.optivest.example
 
-# -- Expose the service via gateway-api HTTPRoute
-# Requires Gateway API resources and suitable controller installed within the cluster
-# (see: https://gateway-api.sigs.k8s.io/guides/)
+# -----------------------------------------------------------------------------
+# HTTPRoute (Gateway API, modern alternative to Ingress)
+# -----------------------------------------------------------------------------
+# Disabled until we decide between legacy Ingress and Gateway API.
+# Gateway API is the future (GA since k8s 1.30) but adoption in
+# managed-K8s providers is uneven. Requires Gateway API CRDs + a
+# controller that implements them (envoy-gateway, contour, etc.)
+# installed in the cluster. We keep the template scaffolded as a
+# stub so chart v0.3 can pick either ingress.enabled OR
+# httpRoute.enabled without touching the templates.
 httpRoute:
-  # HTTPRoute enabled.
   enabled: false
-  # HTTPRoute annotations.
   annotations: {}
-  # Which Gateways this Route is attached to.
   parentRefs:
-  - name: gateway
-    sectionName: http
-    # namespace: default
-  # Hostnames matching HTTP header.
+    - name: gateway
+      sectionName: http
   hostnames:
-  - chart-example.local
-  # List of rules and filters applied.
+    - chart-example.local
   rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /headers
-  #   filters:
-  #   - type: RequestHeaderModifier
-  #     requestHeaderModifier:
-  #       set:
-  #       - name: My-Overwrite-Header
-  #         value: this-is-the-only-value
-  #       remove:
-  #       - User-Agent
-  # - matches:
-  #   - path:
-  #       type: PathPrefix
-  #       value: /echo
-  #     headers:
-  #     - name: version
-  #       value: v2
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+# -----------------------------------------------------------------------------
+# Resource requests + limits
+# -----------------------------------------------------------------------------
+# Local kind defaults are deliberately small so the chart fits on a
+# laptop. Production should profile actual workload and adjust; the
+# Go runtime is sensitive to memory limits (uses GOMEMLIMIT, set in
+# config.gomemlimit below).
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
 
-# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+# -----------------------------------------------------------------------------
+# Probes - kubelet liveness + readiness checks
+# -----------------------------------------------------------------------------
+# OptiVest exposes /healthcheck (liveness-suitable: process is up)
+# and /readyz (readiness-suitable: process is up AND its dependencies
+# are reachable). Both are intentionally unauthenticated; the
+# rationale lives in cmd/api/routes.go - they're on the base router
+# so scrapes don't go through rate-limit / metrics / log-requests.
+#
+# Production note: /readyz checks DB and Redis reachability. If
+# either is down, the Pod is marked NotReady and removed from
+# Service rotation. That's correct behaviour - a Pod that can't talk
+# to its dependencies should not be receiving user traffic - but it
+# means a database flap can cascade into "all pods unready" briefly.
+# Tune readinessProbe.failureThreshold if that's a concern.
 livenessProbe:
   httpGet:
-    path: /
-    port: http
+    path: /healthcheck
+    port: api
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 3
+
 readinessProbe:
   httpGet:
-    path: /
-    port: http
+    path: /readyz
+    port: api
+  initialDelaySeconds: 3
+  periodSeconds: 5
+  timeoutSeconds: 2
+  failureThreshold: 3
 
-# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+# -----------------------------------------------------------------------------
+# Application config
+# -----------------------------------------------------------------------------
+# Two places config goes:
+#
+#   - non-secret values land in a ConfigMap (in chart v0.1 we don't
+#     have a configmap.yaml template yet; the values below are passed
+#     as CLI args via the Deployment template's `args:` block. Reason:
+#     the OptiVest binary at this version is CLI-flag-driven for
+#     operational knobs - only secret-like keys (DSN, encryption key,
+#     API keys, SMTP creds) have os.Getenv() defaults. A backend
+#     follow-up to add env-var support to operational flags would let
+#     us move these to a real ConfigMap; logged in todo as
+#     `backend-env-flags`.
+#
+#   - secret values come from an EXTERNALLY-CREATED Secret named in
+#     `existingSecret`. The chart NEVER renders secret material into
+#     manifests; that pattern would commit secrets to git history.
+#     Bootstrap procedure in NOTES.txt (printed after `helm install`).
+config:
+  # `env` -> -env=staging|development|production. The binary's run-
+  # mode flag. development is the most permissive (warns on missing
+  # required config); production refuses to start with the same
+  # gaps. staging is the right default for local kind: surfaces
+  # config errors loudly without being so strict that a half-finished
+  # secret breaks the boot.
+  env: staging
+
+  # CORS trustedOrigins -> -cors-trusted-origins flag, which the
+  # binary defines as a flag.Func that splits on whitespace. Multiple
+  # origins are space-separated INSIDE the single flag value. NEVER
+  # use "*" in any non-development environment.
+  corsTrustedOrigins: "http://localhost:5173"
+
+  # Rate-limit knobs -> -limiter-enabled, -limiter-rps, -limiter-burst.
+  # Defaults mirror the binary's in-code defaults but explicit so an
+  # operator sees the contract without grepping cmd/api/main.go.
+  # Disabling the limiter is safe in a single-tenant local-dev
+  # scenario; in any environment that takes external traffic, leave
+  # it on.
+  limiter:
+    enabled: true
+    rps: 4
+    burst: 10
+
+  # GOMEMLIMIT - the Go runtime memory ceiling. Should be ~85% of
+  # resources.limits.memory so the GC has headroom to run before the
+  # kubelet OOM-kills the pod. Without this set, a Go binary inside a
+  # memory-limited cgroup has no idea about the cgroup limit and will
+  # routinely OOM-kill itself under load. Express the value in the
+  # same units Go accepts: KiB, MiB, GiB. With limits.memory: 512Mi,
+  # "435MiB" (= ~85%) is a sensible value. Empty string means "don't
+  # set" (not recommended in production).
+  gomemlimit: "435MiB"
+
+# existingSecret - the Secret resource whose contents the chart's
+# Deployment will `envFrom`. The Secret must carry every variable
+# from cmd/api/.env.example marked [REQUIRED]:
+#
+#   OPTIVEST_DB_DSN                          (required)
+#   OPTIVEST_DATA_ENCRYPTION_KEY             (required, hex AES key)
+#   OPTIVEST_REDIS_PASSWORD                  (optional - empty for kind)
+#   OPTIVEST_ALPHAVANTAGE_API_KEY            (required in staging+)
+#   OPTIVEST_EXCHANGERATE_API_KEY            (required in staging+)
+#   OPTIVEST_FRED_API_KEY                    (required in staging+)
+#   OPTIVEST_FINANCIALMODELINGPREP_API_KEY   (required in staging+)
+#   OPTIVEST_SAMBA_NOVA_LLM_API_KEY          (required in staging+)
+#   OPTIVEST_PREDICTOR_API_KEY               (required in staging+)
+#   OPTIVEST_OCRSPACE_API_KEY                (required in staging+)
+#   OPTIVEST_SMTP_HOST                       (required in staging+)
+#   OPTIVEST_SMTP_USERNAME                   (required in staging+)
+#   OPTIVEST_SMTP_PASSWORD                   (required in staging+)
+#   OPTIVEST_SMTP_SENDER                     (required in staging+)
+#
+# The chart fails at Pod-start time if the Secret doesn't exist
+# (CreateContainerConfigError). NOTES.txt prints a paste-ready
+# `kubectl create secret generic` template for local kind.
+#
+# In production this Secret is provisioned via SOPS (git-encrypted),
+# sealed-secrets (cluster-encrypted), or an External Secrets
+# Operator pulling from a vendor secret manager (AWS SM, GCP SM,
+# Vault). The chart is agnostic - it just consumes a Secret of a
+# known shape.
+existingSecret: optivest-secrets
+
+# -----------------------------------------------------------------------------
+# External dependencies (Postgres, Redis)
+# -----------------------------------------------------------------------------
+# externalRedis.host - the address the API uses for `-redis-addr`.
+# Default "redis:6379" assumes a Service named `redis` in the same
+# namespace - convenient when you've installed bitnami/redis under
+# that name next to OptiVest. Override to a managed-cache hostname
+# in production, or to "host.docker.internal:6379" when running
+# kind against a host-installed valkey (`make dev/up`).
+#
+# Postgres is reached via OPTIVEST_DB_DSN from the Secret, so it
+# doesn't have a parallel block here - the DSN already encodes the
+# host:port:dbname tuple.
+#
+# Chart v0.4 will add `redis.enabled` and `postgresql.enabled`
+# subcharts (bitnami) so both can be in-cluster managed-by-Helm
+# rather than externalized. This block stays as the override path
+# for production where you wouldn't run them in-cluster anyway.
+externalRedis:
+  host: "redis:6379"
+
+# -----------------------------------------------------------------------------
+# Autoscaling
+# -----------------------------------------------------------------------------
+# Disabled. Static replicaCount is the right default until we have
+# realistic load metrics to inform a target CPU/memory utilization.
+# Enabling without baseline data tends to produce flappy scale
+# decisions that hurt more than they help.
 autoscaling:
   enabled: false
   minReplicas: 1
-  maxReplicas: 100
+  maxReplicas: 5
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
-# Additional volumes on the output Deployment definition.
+# -----------------------------------------------------------------------------
+# Volumes / volumeMounts
+# -----------------------------------------------------------------------------
+# OptiVest doesn't need any. Listed here for completeness because
+# the helm-create scaffold included them and a future feature
+# (e.g. a writable /tmp emptyDir if we ever flip
+# readOnlyRootFilesystem to false) would slot in cleanly.
 volumes: []
-  # - name: foo
-  #   secret:
-  #     secretName: mysecret
-  #     optional: false
-
-# Additional volumeMounts on the output Deployment definition.
 volumeMounts: []
-  # - name: foo
-  #   mountPath: "/etc/foo"
-  #   readOnly: true
 
+# -----------------------------------------------------------------------------
+# Pod scheduling
+# -----------------------------------------------------------------------------
+# Empty by default. Useful in production for spreading replicas
+# across zones (podAntiAffinity) or pinning to specific node pools
+# (taint + toleration).
 nodeSelector: {}
-
 tolerations: []
-
 affinity: {}
+
+# -----------------------------------------------------------------------------
+# Extra env / extra envFrom (escape hatches)
+# -----------------------------------------------------------------------------
+# Useful for overriding a CLI-flag default without bumping the chart
+# minor, or for adding a new environment-driven knob the chart
+# doesn't model directly.
+extraEnv: []
+# - name: OPTIVEST_PORTFOLIO_WORKER_LIMIT
+#   value: "12"
+extraEnvFrom: []
+# - configMapRef:
+#     name: my-extra-config


### PR DESCRIPTION
## Summary

- First Helm chart for OptiVest, scaffolded with \`helm create\` (v4.1.4) and customized for OptiVest reality. Lints clean and renders 4 manifests (ServiceAccount, Service, Deployment, helm-test Pod) plus disabled-by-default Ingress / HTTPRoute / HPA stubs ready for later versions.
- Smoke-tested end-to-end on local kind v0.31.0 + podman 5.8.2 + k8s v1.35.0: \`helm install\` → \`/healthcheck\` 200 → \`/metrics\` 200 → \`helm test\` Phase Succeeded.
- Chart structured around an externally-managed \`existingSecret\` (chart never renders secret material) and CLI-flag-driven runtime config (matches what OptiVest's binary actually reads).

## Commit narrative (read in order)

| commit | concern |
|---|---|
| \`618e9cb\` | scaffold from \`helm create\` — unmodified baseline so subsequent diffs show what we changed |
| \`a5bae80\` | \`Chart.yaml\` metadata: real description, kubeVersion >=1.27, sources/maintainers/keywords, appVersion 0.1.0 to match chart |
| \`268b840\` | workload concern (values + deployment + service ship together): real image, two named ports (api 4000 + sse 4001), \`runAsUser: 10001\` matching the Dockerfile, \`args:\` block with \`/app/api\` first (because image \`ENTRYPOINT\` is \`tini --\` and K8s \`args:\` replaces only CMD), \`envFrom: secretRef:\` for the existingSecret |
| \`55d5803\` | docs concern: \`NOTES.txt\` rewritten for OptiVest's ClusterIP+port-forward path with paste-ready secret-bootstrap, and \`tests/test-connection.yaml\` hits \`/healthcheck\` instead of bare host:port |

## Test plan

Local kind v0.31.0 (rootless podman, k8s v1.35.0):

- [x] \`helm lint\` — clean (only the cosmetic \`[INFO] icon is recommended\`)
- [x] \`helm template\` — 4 manifests render
- [x] \`helm install --dry-run\` — NOTES + tests render with substituted values
- [x] \`helm install optivest deploy/charts/optivest -n optivest --set image.repository=localhost/optivest-api --set config.env=development\` — Pod 1/1 Running
- [x] Side-loaded \`redis:7-alpine\` + \`postgres:17-alpine\` into kind, applied schema via a goose Job that mounted the schema files as a ConfigMap
- [x] \`curl /healthcheck\` via \`kubectl port-forward\` — \`{"env":"development","status":"ok","uptime_sec":820}\`
- [x] \`curl /metrics\` — 200, 3997 bytes of Prometheus exposition
- [x] \`helm test optivest\` — TEST SUITE: optivest-test-connection — **Phase: Succeeded**

## Known frictions (to document, not fix in this PR)

1. **Podman rootless adds \`localhost/\` prefix** to tagged images — operators on rootless podman need \`--set image.repository=localhost/optivest-api\` when side-loading via \`kind load\`. The chart's default (\`optivest-api\`) is correct for docker.
2. **Default \`config.env=staging\` is intentionally strict** — refused to start with empty SMTP creds. That's the security tier-2 contract working correctly. Operators smoke-installing with placeholder secrets should use \`--set config.env=development\`.
3. **chart 0.1.0 doesn't ship a migrate Job** — operators must run \`goose up\` against Postgres before \`helm install\` (or after, but before the API gets traffic). Deferred to chart v0.2; \`NOTES.txt\` documents the workaround.

## What this chart deliberately does NOT do (yet)

| version | adds |
|---|---|
| v0.2 | Migrate Job as Helm \`pre-install\` / \`pre-upgrade\` hook (replaces the manual \`goose up\` step) |
| v0.3 | Ingress + cert-manager Issuer reference (TLS, external traffic) |
| v0.4 | bitnami/postgresql + bitnami/redis as Helm subchart dependencies, gated by enabled-flag |
| v0.5 | NetworkPolicy, narrower RBAC on the chart-managed ServiceAccount |
| v0.6 | HorizontalPodAutoscaler |

## Backend follow-ups identified during this work

- **CI publishes images to GHCR**: today \`ci.yml\` builds optivest-api + optivest-migrate with \`push: false\` — only used in-CI for tests. Need a separate \`publish-on-tag\` workflow before any "real" deploy.
- **\`os.Getenv\` defaults on operational flags**: the OptiVest binary's secret-like flags read os.Getenv but the operational flags (\`-env\`, \`-limiter-*\`, \`-cors-trusted-origins\`) are CLI-only. Adding env-var defaults would be 12-factor-app posture and let the chart move those from \`args:\` to a real ConfigMap.