### PR TITLE
chore(k8s): add make k8s/* targets + deploy/dev manifests for kind smoke

### DIFF
--- a/deploy/dev/dev-deps.yaml
+++ b/deploy/dev/dev-deps.yaml
@@ -1,0 +1,200 @@
+# =============================================================================
+# OptiVest in-cluster dev dependencies — Postgres + Redis
+# =============================================================================
+#
+# Purpose:
+#   The Helm chart at deploy/charts/optivest is API-only — it expects an
+#   external Postgres (`postgres:5432`) and Redis (`redis:6379`) reachable
+#   inside the cluster's DNS. In production those will be a managed RDS
+#   instance and a managed Redis (ElastiCache, MemoryDB, etc.) plumbed in
+#   via the existingSecret + externalRedis.host values.
+#
+#   For local kind-based smoke testing we don't have those, so we apply a
+#   minimal in-cluster pair here. These are NOT production-grade:
+#     * single replica, no HA, no PVC (data is lost on pod restart)
+#     * no TLS, plaintext password in the bootstrap Secret
+#     * resource limits sized for laptop-scale workloads only
+#
+#   Once chart v0.4 lands the bitnami/postgresql + bitnami/redis subcharts
+#   (gated behind enabled flags), this file becomes optional — the smoke
+#   path will be `helm install --set postgresql.enabled=true ...` instead.
+#
+# Apply with:
+#   make k8s/dev-deps/up
+# Tear down with:
+#   make k8s/dev-deps/down
+# =============================================================================
+
+---
+# Postgres bootstrap credentials. The OptiVest API doesn't read these
+# directly — it gets the full DSN from `OPTIVEST_DB_DSN` in the
+# `optivest-secrets` Secret (created by `make k8s/secret/create`). This
+# Secret only seeds the postgres pod itself via envFrom so the username,
+# password, and database it creates on first boot match what the DSN
+# expects.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-bootstrap
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/component: dev-dep
+    app.kubernetes.io/part-of: optivest
+type: Opaque
+stringData:
+  POSTGRES_USER: optivest
+  POSTGRES_PASSWORD: optivest
+  POSTGRES_DB: optivest
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/component: dev-dep
+    app.kubernetes.io/part-of: optivest
+spec:
+  replicas: 1
+  # RollingUpdate would briefly run two pods sharing the same PGDATA dir
+  # if we ever added a PVC; Recreate keeps the data path single-writer.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+        app.kubernetes.io/component: dev-dep
+        app.kubernetes.io/part-of: optivest
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:17-alpine
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - secretRef:
+                name: postgres-bootstrap
+          ports:
+            - name: pg
+              containerPort: 5432
+              protocol: TCP
+          # `pg_isready` is the canonical liveness/readiness probe for
+          # postgres — it does a TCP+startup-packet check without opening
+          # a real session, so it's cheap to run every few seconds.
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "optivest", "-d", "optivest"]
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            timeoutSeconds: 3
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "optivest", "-d", "optivest"]
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app.kubernetes.io/name: postgres
+    app.kubernetes.io/component: dev-dep
+    app.kubernetes.io/part-of: optivest
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: postgres
+  ports:
+    - name: pg
+      port: 5432
+      targetPort: pg
+      protocol: TCP
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: dev-dep
+    app.kubernetes.io/part-of: optivest
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/component: dev-dep
+        app.kubernetes.io/part-of: optivest
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          imagePullPolicy: IfNotPresent
+          # 256 MiB of process memory is plenty for a smoke run; the
+          # allkeys-lru policy mirrors what we'd want in a small prod
+          # cache so behaviour under pressure is consistent between
+          # environments.
+          args:
+            - "--maxmemory"
+            - "256mb"
+            - "--maxmemory-policy"
+            - "allkeys-lru"
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 1
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: dev-dep
+    app.kubernetes.io/part-of: optivest
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis
+      protocol: TCP

--- a/deploy/dev/migrate-job.yaml
+++ b/deploy/dev/migrate-job.yaml
@@ -1,0 +1,102 @@
+# =============================================================================
+# OptiVest one-shot goose migration Job — chart v0.1 era
+# =============================================================================
+#
+# This is the *manual* migrate Job for the chart v0.1 smoke flow. Chart
+# v0.2 will replace it with a templated Job rendered as a Helm
+# pre-install / pre-upgrade hook so `helm upgrade --install` runs
+# migrations transparently.
+#
+# Until then the smoke path is:
+#   1. `make k8s/dev-deps/up`     — postgres + redis
+#   2. `make k8s/migrate`         — applies this Job (after rebuilding
+#                                    the `migrations` ConfigMap from
+#                                    internal/sql/schema/*.sql)
+#   3. `make k8s/install`         — helm upgrade --install of the chart
+#
+# Why the schema lives in a ConfigMap instead of being baked into the
+# image: keeping it out of the image means a freshly-checked-out repo
+# can re-run migrations without rebuilding the migrate image after every
+# `internal/sql/schema/*.sql` edit. Production will reverse this — we'll
+# bake the schema into a versioned migrate image so the rolled-out
+# bytes are immutable.
+#
+# DSN source: the OPTIVEST_DB_DSN secret key produced by
+# `make k8s/secret/create`. We point it at the in-cluster `postgres`
+# Service from deploy/dev/dev-deps.yaml.
+# =============================================================================
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: migrate
+  labels:
+    app.kubernetes.io/name: optivest-migrate
+    app.kubernetes.io/component: migration
+    app.kubernetes.io/part-of: optivest
+spec:
+  # 3 retries is enough to ride out a postgres readiness flap during
+  # `make k8s/smoke`; beyond that the schema is genuinely broken and we
+  # want the Job to fail loudly so CI / a human can look at it.
+  backoffLimit: 3
+  # Garbage-collect completed Jobs after 5 minutes so re-running
+  # `make k8s/migrate` doesn't have to delete the previous one.
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: optivest-migrate
+        app.kubernetes.io/component: migration
+        app.kubernetes.io/part-of: optivest
+    spec:
+      restartPolicy: OnFailure
+      # The migrate image runs as UID 10001 (Dockerfile.migrate
+      # `adduser -u 10001 goose`). Mirror that here explicitly so a
+      # cluster with PodSecurity baseline restrictions doesn't reject
+      # the pod for missing a runAsNonRoot guarantee.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: goose
+          image: localhost/optivest-migrate:0.1.0
+          imagePullPolicy: IfNotPresent
+          # ENTRYPOINT ["goose"] in Dockerfile.migrate, so args are the
+          # subcommand + flags. WORKDIR is /migrations, which is also
+          # where we mount the schema ConfigMap.
+          args:
+            - "-dir=/migrations"
+            - "postgres"
+            - "$(OPTIVEST_DB_DSN)"
+            - "up"
+          env:
+            - name: OPTIVEST_DB_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: optivest-secrets
+                  key: OPTIVEST_DB_DSN
+          volumeMounts:
+            - name: schema
+              mountPath: /migrations
+              readOnly: true
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: schema
+          configMap:
+            name: migrations

--- a/makefile
+++ b/makefile
@@ -21,6 +21,20 @@ help:
 	@echo "  dev/up              - Start the host valkey service for local API runs"
 	@echo "  dev/down            - Stop the host valkey service"
 	@echo "  dev/status          - Show whether the host valkey service is running"
+	@echo "  k8s/cluster/up      - Create the local kind cluster (rootless podman)"
+	@echo "  k8s/cluster/down    - Delete the local kind cluster"
+	@echo "  k8s/cluster/status  - Show kind cluster + node info"
+	@echo "  k8s/dev-deps/up     - Apply postgres + redis dev-dep manifests"
+	@echo "  k8s/dev-deps/down   - Remove the postgres + redis dev-dep manifests"
+	@echo "  k8s/image/build     - Build optivest-api + optivest-migrate images locally"
+	@echo "  k8s/image/load      - Side-load both images into the kind cluster"
+	@echo "  k8s/secret/create   - Create/refresh the optivest-secrets Secret from cmd/api/.env"
+	@echo "  k8s/migrate         - Run goose up as a one-shot Job (chart v0.1 manual step)"
+	@echo "  k8s/install         - helm upgrade --install the chart against the kind cluster"
+	@echo "  k8s/uninstall       - helm uninstall the chart"
+	@echo "  k8s/forward         - Port-forward API:4000 + SSE:4001 to localhost"
+	@echo "  k8s/logs            - Tail the optivest API pod logs"
+	@echo "  k8s/smoke           - Full bring-up: cluster + deps + image + secret + migrate + install"
 
 .PHONY: run/api
 run/api:
@@ -179,3 +193,199 @@ dev/down:
 .PHONY: dev/status
 dev/status:
 	@systemctl status $(DEV_REDIS_UNIT) --no-pager || true
+
+# -----------------------------------------------------------------------------
+# Kubernetes / Helm — local kind cluster + chart smoke workflow.
+# -----------------------------------------------------------------------------
+# These targets wrap the smoke-test path the chart at deploy/charts/optivest
+# was developed against: a rootless-podman-backed kind cluster, side-loaded
+# images (no registry), the postgres + redis dev-deps from deploy/dev/, and
+# the chart deployed via `helm upgrade --install`.
+#
+# All variables below are overridable on the command line, e.g.
+#   make k8s/install CHART_ENV=staging IMAGE_TAG=0.2.0
+#
+# The chart appVersion lives in deploy/charts/optivest/Chart.yaml; IMAGE_TAG
+# here just has to match whatever tag the local images were built with.
+KIND_CLUSTER         ?= optivest
+K8S_NAMESPACE        ?= optivest
+KIND_PROVIDER        ?= podman
+CHART_PATH           ?= deploy/charts/optivest
+CHART_RELEASE        ?= optivest
+IMAGE_TAG            ?= 0.1.0
+DEV_DEPS_MANIFEST    ?= deploy/dev/dev-deps.yaml
+MIGRATE_JOB_MANIFEST ?= deploy/dev/migrate-job.yaml
+SCHEMA_DIR           ?= internal/sql/schema
+ENV_FILE             ?= cmd/api/.env
+# Service hostname the in-cluster postgres dev-dep listens on. Used to
+# rewrite OPTIVEST_DB_DSN when seeding the optivest-secrets Secret so the
+# DSN baked into cmd/api/.env (which points at localhost) doesn't follow
+# us into the cluster.
+K8S_DB_DSN           ?= postgres://optivest:optivest@postgres:5432/optivest?sslmode=disable
+# `helm install --set` passes config.env=$(CHART_ENV) to the chart so
+# missing optional secrets (SMTP, vendor API keys) are warnings rather
+# than fatal startup errors. Override to "staging" or "production" once
+# the optivest-secrets Secret is fully populated.
+CHART_ENV            ?= development
+# Rootless podman tags side-loaded images with a `localhost/` prefix,
+# which the chart's image.repository default ("optivest-api") does not
+# match. Override the chart value so kubelet can resolve the image.
+CHART_IMAGE_REPO     ?= localhost/optivest-api
+
+# kind respects the env var on every command (create/get/delete/load), so
+# we set it once here and reuse via $(KIND).
+KIND := KIND_EXPERIMENTAL_PROVIDER=$(KIND_PROVIDER) kind
+
+## k8s/cluster/up: create the local kind cluster (idempotent)
+.PHONY: k8s/cluster/up
+k8s/cluster/up:
+	@if $(KIND) get clusters 2>/dev/null | grep -qx '$(KIND_CLUSTER)'; then \
+		echo "kind cluster '$(KIND_CLUSTER)' already exists"; \
+	else \
+		echo "creating kind cluster '$(KIND_CLUSTER)' (rootless $(KIND_PROVIDER))..."; \
+		$(KIND) create cluster --name $(KIND_CLUSTER); \
+	fi
+
+## k8s/cluster/down: delete the local kind cluster
+.PHONY: k8s/cluster/down
+k8s/cluster/down:
+	@echo 'Deleting kind cluster $(KIND_CLUSTER)...'
+	$(KIND) delete cluster --name $(KIND_CLUSTER)
+
+## k8s/cluster/status: show kind cluster + node info
+.PHONY: k8s/cluster/status
+k8s/cluster/status:
+	@if $(KIND) get clusters 2>/dev/null | grep -qx '$(KIND_CLUSTER)'; then \
+		echo "kind cluster: $(KIND_CLUSTER)"; \
+		kubectl --context kind-$(KIND_CLUSTER) get nodes -o wide; \
+	else \
+		echo "no kind cluster '$(KIND_CLUSTER)' (run 'make k8s/cluster/up')"; \
+	fi
+
+## k8s/dev-deps/up: deploy in-cluster postgres + redis for the smoke
+.PHONY: k8s/dev-deps/up
+k8s/dev-deps/up:
+	@echo 'Ensuring namespace $(K8S_NAMESPACE)...'
+	kubectl create namespace $(K8S_NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -
+	@echo 'Applying $(DEV_DEPS_MANIFEST)...'
+	kubectl -n $(K8S_NAMESPACE) apply -f $(DEV_DEPS_MANIFEST)
+	@echo 'Waiting for postgres + redis rollouts to complete...'
+	kubectl -n $(K8S_NAMESPACE) rollout status deployment/postgres --timeout=180s
+	kubectl -n $(K8S_NAMESPACE) rollout status deployment/redis --timeout=120s
+
+## k8s/dev-deps/down: remove the in-cluster postgres + redis dev-deps
+.PHONY: k8s/dev-deps/down
+k8s/dev-deps/down:
+	kubectl -n $(K8S_NAMESPACE) delete -f $(DEV_DEPS_MANIFEST) --ignore-not-found
+
+## k8s/image/build: build optivest-api + optivest-migrate locally
+.PHONY: k8s/image/build
+k8s/image/build:
+	@echo 'Building optivest-api:$(IMAGE_TAG)...'
+	docker build -t optivest-api:$(IMAGE_TAG) -f Dockerfile .
+	@echo 'Building optivest-migrate:$(IMAGE_TAG)...'
+	docker build -t optivest-migrate:$(IMAGE_TAG) -f Dockerfile.migrate .
+
+## k8s/image/load: side-load both images into the kind cluster
+.PHONY: k8s/image/load
+k8s/image/load:
+	@echo 'Side-loading optivest-api:$(IMAGE_TAG) into kind...'
+	$(KIND) load docker-image optivest-api:$(IMAGE_TAG) --name $(KIND_CLUSTER)
+	@echo 'Side-loading optivest-migrate:$(IMAGE_TAG) into kind...'
+	$(KIND) load docker-image optivest-migrate:$(IMAGE_TAG) --name $(KIND_CLUSTER)
+
+## k8s/secret/create: create/refresh the optivest-secrets Secret from cmd/api/.env
+##
+## kubectl rejects mixing --from-env-file with --from-literal, so we
+## merge them in shell first: drop comments + blank lines + any
+## existing OPTIVEST_DB_DSN entry from the .env file (which typically
+## points at host-side localhost), append the cluster-local DSN, then
+## feed the merged result as a single --from-env-file. mktemp keeps
+## the intermediate file out of the source tree, and the trap cleans
+## it up even if kubectl errors.
+.PHONY: k8s/secret/create
+k8s/secret/create:
+	@test -f $(ENV_FILE) || { echo "$(ENV_FILE) not found - copy cmd/api/.env.example and fill values"; exit 1; }
+	kubectl create namespace $(K8S_NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -
+	@TMPENV=$$(mktemp) && trap 'rm -f $$TMPENV' EXIT INT TERM && \
+		grep -E '^[A-Za-z_][A-Za-z0-9_]*=' $(ENV_FILE) | grep -v '^OPTIVEST_DB_DSN=' > $$TMPENV && \
+		echo 'OPTIVEST_DB_DSN=$(K8S_DB_DSN)' >> $$TMPENV && \
+		kubectl -n $(K8S_NAMESPACE) create secret generic optivest-secrets \
+			--from-env-file=$$TMPENV \
+			--dry-run=client -o yaml | kubectl apply -f -
+
+## k8s/migrate: run goose up as a one-shot Job
+##
+## chart v0.1 doesn't manage migrations itself — this rebuilds the
+## `migrations` ConfigMap from $(SCHEMA_DIR) (so a freshly-edited schema
+## file shows up without rebuilding the migrate image), tears down any
+## previous Job, and applies $(MIGRATE_JOB_MANIFEST). Chart v0.2 will
+## replace this with a templated Job rendered as a Helm hook.
+.PHONY: k8s/migrate
+k8s/migrate:
+	@echo 'Refreshing migrations ConfigMap from $(SCHEMA_DIR)/...'
+	kubectl -n $(K8S_NAMESPACE) create configmap migrations \
+		--from-file=$(SCHEMA_DIR)/ \
+		--dry-run=client -o yaml | kubectl apply -f -
+	@echo 'Replacing migrate Job...'
+	kubectl -n $(K8S_NAMESPACE) delete job migrate --ignore-not-found
+	kubectl -n $(K8S_NAMESPACE) apply -f $(MIGRATE_JOB_MANIFEST)
+	@echo 'Waiting for migrate Job to complete...'
+	kubectl -n $(K8S_NAMESPACE) wait --for=condition=complete job/migrate --timeout=180s
+	@echo 'Migration logs:'
+	kubectl -n $(K8S_NAMESPACE) logs job/migrate
+
+## k8s/install: helm upgrade --install the chart against the kind cluster
+.PHONY: k8s/install
+k8s/install:
+	helm upgrade --install $(CHART_RELEASE) $(CHART_PATH) \
+		--namespace $(K8S_NAMESPACE) \
+		--create-namespace \
+		--set image.repository=$(CHART_IMAGE_REPO) \
+		--set image.tag=$(IMAGE_TAG) \
+		--set config.env=$(CHART_ENV) \
+		--wait --timeout=180s
+
+## k8s/uninstall: helm uninstall the chart
+.PHONY: k8s/uninstall
+k8s/uninstall:
+	helm uninstall $(CHART_RELEASE) --namespace $(K8S_NAMESPACE) --ignore-not-found
+
+## k8s/forward: port-forward API:4000 + SSE:4001 to localhost (Ctrl-C to stop)
+.PHONY: k8s/forward
+k8s/forward:
+	@echo 'Forwarding $(CHART_RELEASE) API->localhost:4000, SSE->localhost:4001 (Ctrl-C to stop)'
+	kubectl -n $(K8S_NAMESPACE) port-forward svc/$(CHART_RELEASE) 4000:4000 4001:4001
+
+## k8s/logs: tail the optivest API pod logs
+.PHONY: k8s/logs
+k8s/logs:
+	kubectl -n $(K8S_NAMESPACE) logs -f deployment/$(CHART_RELEASE)
+
+## k8s/smoke: full bring-up of the chart against a fresh kind cluster
+##
+## Order matters here:
+##   1. cluster up           — kubectl context exists
+##   2. dev-deps/up          — postgres + redis are reachable inside the cluster
+##   3. image/build + load   — kubelet can pull localhost/optivest-{api,migrate}
+##   4. secret/create        — DSN + env keys are available to the migrate Job
+##                              and the API pod via envFrom
+##   5. migrate              — schema is applied before the API tries to read it
+##   6. install              — chart rolls out and probes go green
+.PHONY: k8s/smoke
+k8s/smoke:
+	@$(MAKE) k8s/cluster/up
+	@$(MAKE) k8s/dev-deps/up
+	@$(MAKE) k8s/image/build
+	@$(MAKE) k8s/image/load
+	@$(MAKE) k8s/secret/create
+	@$(MAKE) k8s/migrate
+	@$(MAKE) k8s/install
+	@echo ''
+	@echo '--- smoke complete --------------------------------------------------'
+	@echo 'tail logs:           make k8s/logs'
+	@echo 'forward ports:       make k8s/forward'
+	@echo 'helm test:           helm test $(CHART_RELEASE) -n $(K8S_NAMESPACE)'
+	@echo 'tear down chart:     make k8s/uninstall'
+	@echo 'tear down deps:      make k8s/dev-deps/down'
+	@echo 'tear down cluster:   make k8s/cluster/down'


### PR DESCRIPTION
The chart at deploy/charts/optivest is API-only — it expects an external Postgres at postgres:5432, an external Redis at redis:6379, and an operator-managed optivest-secrets Secret. The previous local smoke walked through all of that with ad-hoc kubectl apply commands and heredoc'd Job specs, which was fine for one-off learning but made re-running the smoke a copy-paste exercise.

This wraps the workflow into discrete, idempotent makefile targets and moves the YAML it needs into deploy/dev/ so the makefile stays readable:

  make k8s/cluster/up      kind create (rootless podman, idempotent)
  make k8s/dev-deps/up     postgres + redis Deployments + Services
  make k8s/image/build     optivest-api + optivest-migrate locally
  make k8s/image/load      side-load both into the kind cluster
  make k8s/secret/create   optivest-secrets from cmd/api/.env, with
                           OPTIVEST_DB_DSN rewritten to the
                           in-cluster postgres Service
  make k8s/migrate         one-shot goose Job (chart v0.1 manual step;
                           chart v0.2 will replace this with a Helm hook)
  make k8s/install         helm upgrade --install with the rootless-
                           podman friendly --set overrides
  make k8s/forward         port-forward API:4000 + SSE:4001
  make k8s/logs            tail the API pod
  make k8s/smoke           full bring-up: cluster + deps + image +
                           secret + migrate + install
  make k8s/uninstall       helm uninstall
  make k8s/dev-deps/down   tear down dev-deps
  make k8s/cluster/down    delete the kind cluster

deploy/dev/dev-deps.yaml carries the Postgres + Redis pair: single replica, no PVC, no auth on Redis, plaintext bootstrap Secret for Postgres. Documented as not-production at the top of the file. Once chart v0.4 lands the bitnami subcharts this becomes optional.

deploy/dev/migrate-job.yaml is the goose Job. Schema files come from a ConfigMap built from internal/sql/schema/ in the makefile target (so a freshly-edited migration shows up without rebuilding the migrate image), and OPTIVEST_DB_DSN comes from the optivest-secrets Secret. backoffLimit=3 to ride out a postgres readiness flap on a fresh make k8s/smoke; ttlSecondsAfterFinished=300 so the Job garbage-collects itself between runs.

Notes on the makefile:

- KIND_EXPERIMENTAL_PROVIDER=podman is hoisted into a \$(KIND) variable used by every kind invocation so the rootless podman path works on Arch/CachyOS without per-call boilerplate.

- k8s/secret/create can't combine --from-env-file with --from-literal (kubectl rejects the mix), so it merges them in a temp file: drop comments + blanks + any host-side OPTIVEST_DB_DSN from cmd/api/.env, append the cluster-local DSN, then feed the merged result as a single --from-env-file. The trap rm -f cleans the tmpfile up even if kubectl errors.

- CHART_IMAGE_REPO defaults to localhost/optivest-api because rootless podman tags side-loaded images with the localhost/ prefix and the chart's image.repository default ('optivest-api') doesn't match what containerd inside the kind node sees.

- CHART_ENV defaults to 'development' so missing optional secrets (vendor API keys, SMTP creds) are warnings rather than fatal errors for a smoke run. Override to staging/production once optivest-secrets is fully populated.

- Pod readiness uses kubectl rollout status (not kubectl wait --for=condition=ready), which correctly handles the apply-then-wait race where the wait selector matches zero pods because the Deployment hasn't created any yet.

End-to-end verified on a fresh kind cluster: make k8s/smoke goes from empty cluster -> API pod Ready (readiness probe on /readyz green) -> helm test passes -> migrations applied through schema version 38.