### PR TITLE
fix(llm): JSON-string-encode profile in messages[].content

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -211,6 +211,19 @@ Lowering it past 5s is not recommended - the model's first-token
 latency is genuinely variable, and false-positive aborts manifest as
 user-visible 5xxs.
 
+### Wire-format gotcha: `content` must be a string
+
+The OpenAI chat-completions spec requires `messages[].content` to be a
+string (or an array of typed parts), not a raw JSON object. SambaNova
+historically tolerated object-shaped content; Groq, Cerebras,
+OpenRouter and the upstream OpenAI API all enforce the spec strictly
+and 400 with `messages.0.content : value must be a string`.
+`marshalAsJSONStringLiteral` in `cmd/api/ai_operations.go` exists for
+exactly this reason — it stringifies the per-user profile structure so
+the model still sees the JSON payload, but on the wire it lives inside
+a string that every spec-compliant provider accepts. Anyone rewriting
+the prompt-rendering path should preserve this invariant.
+
 ## Streaming portfolio analysis endpoint (P4.B)
 
 `GET /v1/investments/analysis/stream` is the inbound counterpart to the

--- a/cmd/api/ai_operations.go
+++ b/cmd/api/ai_operations.go
@@ -91,6 +91,35 @@ const investmentPortfolioInstructionsTemplate = `{
     }
 }`
 
+// marshalAsJSONStringLiteral serialises v to JSON and then escapes that JSON
+// as a JSON string literal (including the surrounding double-quotes). The
+// returned bytes are safe to slot directly as the VALUE side of a
+//
+//	"content": <here>
+//
+// pair in the prompt templates.
+//
+// Why the double marshal: the OpenAI chat-completions spec requires
+// `messages[].content` to be a string (or an array of typed parts), not a
+// raw JSON object. SambaNova used to silently coerce object-shaped content
+// into a stringified version of itself; Groq, Cerebras, OpenRouter, and the
+// upstream OpenAI API all enforce the spec strictly and 400 with
+//
+//	{"error":{"message":"messages.0.content : value must be a string ..."}}
+//
+// We therefore stringify the profile structure ourselves so the model still
+// sees the same JSON payload, but on the wire it lives inside a string that
+// every spec-compliant provider accepts.
+func marshalAsJSONStringLiteral(v interface{}) ([]byte, error) {
+	inner, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	// Marshalling a string yields a quoted, escaped JSON string literal,
+	// which is exactly what we need to drop into a "content": ... slot.
+	return json.Marshal(string(inner))
+}
+
 // renderInvestmentPortfolioPrompt marshals the user profile and slots it
 // (along with the configured model identifier) into the chat-completions
 // template. Returns the final JSON body string that gets POSTed to the LLM
@@ -100,13 +129,13 @@ const investmentPortfolioInstructionsTemplate = `{
 // two LLM-calling code paths in this binary should send different model
 // names at the same time.
 func (app *application) renderInvestmentPortfolioPrompt(profile UserPortfolioProfile) (string, error) {
-	profileData, err := json.Marshal(profile)
+	profileLiteral, err := marshalAsJSONStringLiteral(profile)
 	if err != nil {
 		return "", err
 	}
 	return fmt.Sprintf(
 		investmentPortfolioInstructionsTemplate,
-		string(profileData),
+		string(profileLiteral),
 		app.config.llm.model,
 	), nil
 }
@@ -224,8 +253,10 @@ func (app *application) buildOCRRecieptAnalysisLLMRequest(ctx context.Context, o
 // %[1]s for the profile JSON and %[2]s for the model identifier; see the
 // templates in this file for the canonical shape.
 func (app *application) buildLLMRequestHelper(ctx context.Context, profile interface{}, instructionsTemplate string) (*data.LLMAnalyzedPortfolio, error) {
-	// Marshal the profile data
-	profileData, err := json.Marshal(profile)
+	// Marshal the profile data, then JSON-string-encode it so it can be
+	// dropped into the template's "content": ... slot as a spec-compliant
+	// string. See marshalAsJSONStringLiteral for the rationale.
+	profileLiteral, err := marshalAsJSONStringLiteral(profile)
 	if err != nil {
 		app.loggerFromContext(ctx).Info("Error marshaling profile data")
 		return nil, err
@@ -234,7 +265,7 @@ func (app *application) buildLLMRequestHelper(ctx context.Context, profile inter
 	// Create the final LLM request
 	finalLLMRequest := fmt.Sprintf(
 		instructionsTemplate,
-		string(profileData),
+		string(profileLiteral),
 		app.config.llm.model,
 	)
 	//app.logger.Info("Final LLM Request:", zap.Any("final_llm_request", finalLLMRequest))

--- a/cmd/api/ai_operations.go
+++ b/cmd/api/ai_operations.go
@@ -91,7 +91,7 @@ const investmentPortfolioInstructionsTemplate = `{
     }
 }`
 
-// marshalAsJSONStringLiteral serialises v to JSON and then escapes that JSON
+// marshalAsJSONStringLiteral serializes v to JSON and then escapes that JSON
 // as a JSON string literal (including the surrounding double-quotes). The
 // returned bytes are safe to slot directly as the VALUE side of a
 //
@@ -115,7 +115,7 @@ func marshalAsJSONStringLiteral(v interface{}) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Marshalling a string yields a quoted, escaped JSON string literal,
+	// Marshaling a string yields a quoted, escaped JSON string literal,
 	// which is exactly what we need to drop into a "content": ... slot.
 	return json.Marshal(string(inner))
 }


### PR DESCRIPTION
## Summary

The first SSE call against Groq after PR #74 landed 400'd with:

```
messages.0.content : value must be a string OR
messages.0.content : value must be an array
```

The chat-completions prompt templates in `cmd/api/ai_operations.go` embed the per-user profile struct directly into `messages[].content` via `fmt.Sprintf`, which produces **content-as-object** on the wire:

```json
{"role":"user","content":{"user_time_horizon":"medium",...}}
```

SambaNova historically tolerated this; every other OpenAI-compatible provider (Groq, Cerebras, OpenRouter, the upstream OpenAI API) rejects it per the spec. This is latent debt from the SambaNova days that PR #74 unmasked the moment we pointed at a strict provider.

## The fix

A small helper, `marshalAsJSONStringLiteral`, that JSON-marshals the profile **twice** — once to canonical JSON, then again to escape that JSON as a JSON string literal (including the surrounding quotes). Drops cleanly into the existing `%[1]s` slot in all three templates and produces spec-compliant **content-as-string**:

```json
{"role":"user","content":"{\"user_time_horizon\":\"medium\",...}"}
```

Both render paths route through the helper:
- `renderInvestmentPortfolioPrompt` (streaming + synchronous portfolio handlers)
- `buildLLMRequestHelper` (personal-finance + OCR handlers)

No prompt template was structurally changed — same three messages, same stop tokens, same model interpolation, same stream options. The model still sees the same JSON content; it now arrives as a string envelope instead of a raw object.

## Validation — full SSE end-to-end against Groq

| Signal | Value |
|---|---|
| `GET /v1/investments/analysis/stream` status | 200 |
| Bytes delivered to client | 28,024 |
| SSE lines | 2,051 |
| Termination | `event: done` with `finish_reason: "stop"` |
| Prompt tokens | 1,210 |
| Completion tokens | 1,025 |
| Total tokens | 2,235 |
| `CreateLLMAnalysisResponse` DB row | persisted (count went 1→2) |
| Groq upstream call latency (p50 over 3 requests) | 2.7-2.9s for the full 1K-token stream |
| `analyzed` payload | fully parsed: `summary`, `metrics`, `actions`, `recommended_investment`, `overall_summary` — all five sections present and well-formed |

**Test suite:** `go build`, `go vet`, `go test -race -count=1 ./...` all green.

## SECURITY.md update

Added a "Wire-format gotcha: `content` must be a string" subsection under the existing LLM streaming budget section. The next contributor refactoring the prompt-rendering path will find the spec citation and the cross-reference to `marshalAsJSONStringLiteral` rather than rediscovering the 400.

## Test plan

- [x] `examples/sse-portfolio-analysis` curl drive produces a clean 200 + `event: done` with structured analysis payload (validated locally)
- [x] DB persistence side-effect (`CreateLLMAnalysisResponse`) fires
- [x] Groq logs show `status:200` for the chat-completions POST
- [ ] Reviewer confirms `marshalAsJSONStringLiteral` doc comment captures the rationale clearly enough that "why double-marshal?" doesn't come back as a follow-up question
- [ ] (Followup, not this PR) Add a unit test that asserts the rendered prompt body parses such that `messages[2].content` is a string — would prevent regression if the templates ever get rewritten
